### PR TITLE
test(unplugin): bind one-compile cache to real envelope

### DIFF
--- a/experimental/unplugin-perf/README.md
+++ b/experimental/unplugin-perf/README.md
@@ -1,6 +1,8 @@
 # @ttsc/unplugin per-module cost reproduction
 
-This experiment drives the **real** `@ttsc/unplugin` Rollup plugin object over a synthetic project of `N` TypeScript files and measures, per simulated build:
+This experiment drives the **real** `@ttsc/unplugin` Rollup consumer over a synthetic project and a handwritten synthetic Go transform producer. The producer controls the graph and proof shapes for repeatable measurements; it is not the TypeScript-Go driver's native envelope. The release-gated semantic calibration is [`tests/test-unplugin/src/native-plugins/cache`](../../tests/test-unplugin/src/native-plugins/cache), which links an observer into the production host and asserts its real graph before measuring reuse.
+
+For `N` TypeScript files, the harness measures per simulated build:
 
 - **plugin runs** — how many times the whole project is re-transformed (native plugin spawns). A correct per-build cache transforms the project **once**.
 - **`fs.readFileSync` calls / bytes** — the content work the adapter performs while serving the `N` modules. A correct cache validates only each module's derived inputs.
@@ -25,4 +27,4 @@ Run from the repository root:
 pnpm --dir experimental/unplugin-perf start
 ```
 
-Requires a built `ttsc` package (`packages/ttsc/lib`) and a Go toolchain on PATH (the synthetic transform plugin is a tiny Go sidecar).
+Requires a built `ttsc` package (`packages/ttsc/lib`) and a Go toolchain on PATH. The synthetic transform producer is a tiny Go sidecar.

--- a/experimental/unplugin-perf/src/index.ts
+++ b/experimental/unplugin-perf/src/index.ts
@@ -734,6 +734,11 @@ function createProject(options: MeasureOptions): string {
  * back as the transform output (identity), appends one byte to `PLUGIN_RUN_LOG`
  * per invocation so the harness can count whole-project re-transforms, and
  * optionally emits one out-of-walk output key to trigger the cache-miss bug.
+ *
+ * This producer is a synthetic protocol double. It deliberately controls the
+ * graph shape and proof density used by each measurement scenario; the normal
+ * test-unplugin native envelope gate calibrates those claims against the real
+ * TypeScript-Go driver and JSON decoder.
  */
 function writeGoPlugin(project: string): void {
   const dir = path.join(project, "go-plugin");

--- a/packages/unplugin/src/core/index.ts
+++ b/packages/unplugin/src/core/index.ts
@@ -55,6 +55,12 @@ const unpluginFactory: UnpluginFactory<
   let aliases: unknown;
   let viteCommand: string | undefined;
   let viteWatching = true;
+  // A restart can start the replacement plugin container before closing the
+  // old one, and Vite calls buildEnd even for a container that never started.
+  // Track the stable per-container PluginContext identity so that unstarted
+  // old containers cannot dispose a replacement's freshly initialized cache.
+  const viteBuildOwners = new WeakSet<object>();
+  let viteBuildLifecycles = 0;
 
   return {
     name,
@@ -89,13 +95,24 @@ const unpluginFactory: UnpluginFactory<
         missingInputs.attach(server);
       },
       // Vite calls buildEnd when the dev server (or build) closes; drop every
-      // poller so a stopped server leaks no watch state.
+      // poller and, once the last overlapping container has closed, every
+      // generation-owned filesystem tracker as well.
       buildEnd() {
         missingInputs.dispose();
+        if (viteBuildOwners.delete(this)) {
+          viteBuildLifecycles -= 1;
+        }
+        if (viteBuildLifecycles === 0) {
+          resetTtscTransformCache(transformCache);
+        }
       },
     },
 
     buildStart() {
+      if (viteCommand !== undefined && !viteBuildOwners.has(this as object)) {
+        viteBuildOwners.add(this as object);
+        viteBuildLifecycles += 1;
+      }
       // Persistent validation exists for a session that spans edits it can
       // observe, and a dev server told to open no watcher is not one:
       // `server.watch: null` leaves Vite with no change channel at all, so no

--- a/tests/test-unplugin/src/features/adapters/test_vite_build_end_disposes_the_last_overlapping_cache_owner.ts
+++ b/tests/test-unplugin/src/features/adapters/test_vite_build_end_disposes_the_last_overlapping_cache_owner.ts
@@ -1,0 +1,18 @@
+import { assertViteBuildEndDisposesTheLastOverlappingCacheOwner } from "../../internal/adapter-vite-lifecycle";
+
+/**
+ * Verifies Vite buildEnd disposes cache trackers without breaking restarts.
+ *
+ * Vite can end a container that never started, and a restart creates the
+ * replacement container before the old started container ends. Cache disposal
+ * must ignore the non-owner, retain a live replacement, and clear the cache
+ * when the final owner closes.
+ *
+ * 1. End an unstarted neighbour and prove the current cache remains live.
+ * 2. Start a replacement, end the old owner, and prove replacement reuse.
+ * 3. End the final owner and prove a later delivery starts a new generation.
+ */
+export const test_vite_build_end_disposes_the_last_overlapping_cache_owner =
+  async () => {
+    await assertViteBuildEndDisposesTheLastOverlappingCacheOwner();
+  };

--- a/tests/test-unplugin/src/index.ts
+++ b/tests/test-unplugin/src/index.ts
@@ -1,8 +1,18 @@
 import { TestExecutor } from "@ttsc/testing";
 import path from "node:path";
 
+const base = path.join(process.cwd(), "src");
+const dir = process.env.TTSC_TEST_DIR;
+const dirs = process.env.TTSC_TEST_DIRS?.split(",")
+  .map((value) => value.trim())
+  .filter(Boolean);
+
 TestExecutor.main({
-  location: path.join(process.cwd(), "src", "features"),
+  location: dirs?.length
+    ? dirs.map((value) => path.join(base, value))
+    : dir
+      ? path.join(base, dir)
+      : [path.join(base, "features"), path.join(base, "native-plugins")],
 }).catch((error) => {
   console.error(error);
   process.exit(1);

--- a/tests/test-unplugin/src/internal/adapter-vite-lifecycle.ts
+++ b/tests/test-unplugin/src/internal/adapter-vite-lifecycle.ts
@@ -202,53 +202,60 @@ export async function assertViteBuildEndDisposesTheLastOverlappingCacheOwner(): 
     },
   );
 
-  await invokeVitePluginHook(plugin.buildStart, oldLifecycle);
-  assert.ok(await deliver(modules[0]!));
-  assert.equal(runCount(), 1);
+  try {
+    await invokeVitePluginHook(plugin.buildStart, oldLifecycle);
+    assert.ok(await deliver(modules[0]!));
+    assert.equal(runCount(), 1);
 
-  // Vite closes even a container that never reached buildStart. Its buildEnd
-  // must not consume the live lifecycle owned by a different container.
-  await invokeVitePluginHook(plugin.buildEnd, unstartedLifecycle);
-  fs.appendFileSync(
-    path.join(project.root, "plugin.cjs"),
-    "\n// changed after an unstarted container ended\n",
-    "utf8",
-  );
-  assert.ok(await deliver(modules[1]!));
-  assert.equal(
-    runCount(),
-    1,
-    "an unstarted container's buildEnd must not reset the live build-scoped generation",
-  );
+    // Vite closes even a container that never reached buildStart. Its buildEnd
+    // must not consume the live lifecycle owned by a different container.
+    await invokeVitePluginHook(plugin.buildEnd, unstartedLifecycle);
+    fs.appendFileSync(
+      path.join(project.root, "plugin.cjs"),
+      "\n// changed after an unstarted container ended\n",
+      "utf8",
+    );
+    assert.ok(await deliver(modules[1]!));
+    assert.equal(
+      runCount(),
+      1,
+      "an unstarted container's buildEnd must not reset the live build-scoped generation",
+    );
 
-  // Model Vite restart ordering: replacement buildStart precedes old buildEnd.
-  await invokeVitePluginHook(plugin.buildStart, replacementLifecycle);
-  assert.ok(await deliver(modules[2]!));
-  assert.equal(runCount(), 2);
-  await invokeVitePluginHook(plugin.buildEnd, oldLifecycle);
+    // Model Vite restart ordering: replacement buildStart precedes old buildEnd.
+    await invokeVitePluginHook(plugin.buildStart, replacementLifecycle);
+    assert.ok(await deliver(modules[2]!));
+    assert.equal(runCount(), 2);
+    await invokeVitePluginHook(plugin.buildEnd, oldLifecycle);
 
-  fs.appendFileSync(
-    path.join(project.root, "plugin.cjs"),
-    "\n// changed after the replacement generation was captured\n",
-    "utf8",
-  );
-  assert.ok(await deliver(modules[3]!));
-  assert.equal(
-    runCount(),
-    2,
-    "the old container's buildEnd must not reset the replacement's build-scoped generation",
-  );
+    fs.appendFileSync(
+      path.join(project.root, "plugin.cjs"),
+      "\n// changed after the replacement generation was captured\n",
+      "utf8",
+    );
+    assert.ok(await deliver(modules[3]!));
+    assert.equal(
+      runCount(),
+      2,
+      "the old container's buildEnd must not reset the replacement's build-scoped generation",
+    );
 
-  await invokeVitePluginHook(plugin.buildEnd, replacementLifecycle);
-  assert.ok(await deliver(modules[0]!));
-  assert.equal(
-    runCount(),
-    3,
-    "the last container's buildEnd must dispose its generation before any later transform",
-  );
-
-  // Pair one final lifecycle solely to dispose the post-close diagnostic run.
-  const finalLifecycle = {};
-  await invokeVitePluginHook(plugin.buildStart, finalLifecycle);
-  await invokeVitePluginHook(plugin.buildEnd, finalLifecycle);
+    await invokeVitePluginHook(plugin.buildEnd, replacementLifecycle);
+    assert.ok(await deliver(modules[0]!));
+    assert.equal(
+      runCount(),
+      3,
+      "the last container's buildEnd must dispose its generation before any later transform",
+    );
+  } finally {
+    // buildEnd is idempotent per context. End every modeled owner even when a
+    // transform/assertion failed, then pair one fresh lifecycle to reset any
+    // ownerless persistent generation created by the post-close diagnostic.
+    await invokeVitePluginHook(plugin.buildEnd, unstartedLifecycle);
+    await invokeVitePluginHook(plugin.buildEnd, oldLifecycle);
+    await invokeVitePluginHook(plugin.buildEnd, replacementLifecycle);
+    const cleanupLifecycle = {};
+    await invokeVitePluginHook(plugin.buildStart, cleanupLifecycle);
+    await invokeVitePluginHook(plugin.buildEnd, cleanupLifecycle);
+  }
 }

--- a/tests/test-unplugin/src/internal/adapter-vite-lifecycle.ts
+++ b/tests/test-unplugin/src/internal/adapter-vite-lifecycle.ts
@@ -18,6 +18,8 @@ import { createCacheProject, projectModules } from "./transform-project-cache";
  * `server.close()` and hold the test runner process open.
  */
 interface IViteAdapterSession {
+  /** End the driven Vite lifecycle and dispose its private cache. */
+  close: () => Promise<void>;
   /** Deliver one module through the adapter's `transform` hook. */
   deliver: (file: string) => Promise<unknown>;
   /** Absolute module paths of the fixture, sorted. */
@@ -40,6 +42,7 @@ export async function startViteAdapterSession(options: {
   watching: boolean;
 }): Promise<IViteAdapterSession> {
   const plugin = await loadViteAdapterPlugin();
+  const lifecycle = {};
   const project = createCacheProject({ fileCount: options.fileCount ?? 4 });
   invokeVitePluginHook(
     plugin.configResolved,
@@ -50,8 +53,11 @@ export async function startViteAdapterSession(options: {
       server: options.watching ? { watch: {} } : { watch: null },
     },
   );
-  await invokeVitePluginHook(plugin.buildStart, {});
+  await invokeVitePluginHook(plugin.buildStart, lifecycle);
   return {
+    close: async () => {
+      await invokeVitePluginHook(plugin.buildEnd, lifecycle);
+    },
     deliver: async (file: string) =>
       invokeVitePluginHook(
         plugin.transform,
@@ -88,18 +94,22 @@ function touchUnrelatedInput(session: IViteAdapterSession): void {
  */
 export async function assertWatcherlessServeTakesTheBuildScopedCache(): Promise<void> {
   const session = await startViteAdapterSession({ watching: false });
-  assert.ok(await session.deliver(session.modules[0]!));
-  assert.equal(session.projectCompiles(), 1);
+  try {
+    assert.ok(await session.deliver(session.modules[0]!));
+    assert.equal(session.projectCompiles(), 1);
 
-  touchUnrelatedInput(session);
-  for (const file of session.modules.slice(1)) {
-    assert.ok(await session.deliver(file));
+    touchUnrelatedInput(session);
+    for (const file of session.modules.slice(1)) {
+      assert.ok(await session.deliver(file));
+    }
+    assert.equal(
+      session.projectCompiles(),
+      1,
+      "a watcherless serve session must deliver every remaining module from the one generation it already compiled",
+    );
+  } finally {
+    await session.close();
   }
-  assert.equal(
-    session.projectCompiles(),
-    1,
-    "a watcherless serve session must deliver every remaining module from the one generation it already compiled",
-  );
 }
 
 /**
@@ -112,18 +122,22 @@ export async function assertWatcherlessServeTakesTheBuildScopedCache(): Promise<
  */
 export async function assertWatchingServeKeepsPersistentValidation(): Promise<void> {
   const session = await startViteAdapterSession({ watching: true });
-  assert.ok(await session.deliver(session.modules[0]!));
-  assert.equal(session.projectCompiles(), 1);
+  try {
+    assert.ok(await session.deliver(session.modules[0]!));
+    assert.equal(session.projectCompiles(), 1);
 
-  touchUnrelatedInput(session);
-  for (const file of session.modules.slice(1)) {
-    assert.ok(await session.deliver(file));
+    touchUnrelatedInput(session);
+    for (const file of session.modules.slice(1)) {
+      assert.ok(await session.deliver(file));
+    }
+    assert.equal(
+      session.projectCompiles(),
+      2,
+      "a watching dev server must replace the generation the changed input invalidated, then reuse the replacement",
+    );
+  } finally {
+    await session.close();
   }
-  assert.equal(
-    session.projectCompiles(),
-    2,
-    "a watching dev server must replace the generation the changed input invalidated, then reuse the replacement",
-  );
 }
 
 /**
@@ -136,15 +150,105 @@ export async function assertWatchingServeKeepsPersistentValidation(): Promise<vo
  */
 export async function assertWatcherlessServeRevalidatesARepeatedModule(): Promise<void> {
   const session = await startViteAdapterSession({ watching: false });
-  const first = session.modules[0]!;
-  assert.ok(await session.deliver(first));
-  assert.equal(session.projectCompiles(), 1);
+  try {
+    const first = session.modules[0]!;
+    assert.ok(await session.deliver(first));
+    assert.equal(session.projectCompiles(), 1);
 
-  touchUnrelatedInput(session);
-  assert.ok(await session.deliver(first));
-  assert.equal(
-    session.projectCompiles(),
-    2,
-    "a module delivered twice in one watcherless session must validate on its second delivery",
+    touchUnrelatedInput(session);
+    assert.ok(await session.deliver(first));
+    assert.equal(
+      session.projectCompiles(),
+      2,
+      "a module delivered twice in one watcherless session must validate on its second delivery",
+    );
+  } finally {
+    await session.close();
+  }
+}
+
+/**
+ * Assert overlapping Vite containers retain only their newest live cache.
+ *
+ * Vite constructs a replacement container before ending the old one during a
+ * restart. The old buildEnd must not clear the replacement generation, while
+ * the replacement's eventual buildEnd must dispose it and its trackers.
+ */
+export async function assertViteBuildEndDisposesTheLastOverlappingCacheOwner(): Promise<void> {
+  const plugin = await loadViteAdapterPlugin();
+  const unstartedLifecycle = {};
+  const oldLifecycle = {};
+  const replacementLifecycle = {};
+  const project = createCacheProject({ fileCount: 4 });
+  const modules = projectModules(project.root);
+  const runCount = () =>
+    fs.existsSync(project.runLog)
+      ? fs.readFileSync(project.runLog, "utf8").length
+      : 0;
+  const deliver = async (file: string) =>
+    invokeVitePluginHook(
+      plugin.transform,
+      { addWatchFile: () => undefined },
+      fs.readFileSync(file, "utf8"),
+      file,
+    );
+  invokeVitePluginHook(
+    plugin.configResolved,
+    {},
+    {
+      command: "serve",
+      resolve: { alias: [] },
+      server: { watch: null },
+    },
   );
+
+  await invokeVitePluginHook(plugin.buildStart, oldLifecycle);
+  assert.ok(await deliver(modules[0]!));
+  assert.equal(runCount(), 1);
+
+  // Vite closes even a container that never reached buildStart. Its buildEnd
+  // must not consume the live lifecycle owned by a different container.
+  await invokeVitePluginHook(plugin.buildEnd, unstartedLifecycle);
+  fs.appendFileSync(
+    path.join(project.root, "plugin.cjs"),
+    "\n// changed after an unstarted container ended\n",
+    "utf8",
+  );
+  assert.ok(await deliver(modules[1]!));
+  assert.equal(
+    runCount(),
+    1,
+    "an unstarted container's buildEnd must not reset the live build-scoped generation",
+  );
+
+  // Model Vite restart ordering: replacement buildStart precedes old buildEnd.
+  await invokeVitePluginHook(plugin.buildStart, replacementLifecycle);
+  assert.ok(await deliver(modules[2]!));
+  assert.equal(runCount(), 2);
+  await invokeVitePluginHook(plugin.buildEnd, oldLifecycle);
+
+  fs.appendFileSync(
+    path.join(project.root, "plugin.cjs"),
+    "\n// changed after the replacement generation was captured\n",
+    "utf8",
+  );
+  assert.ok(await deliver(modules[3]!));
+  assert.equal(
+    runCount(),
+    2,
+    "the old container's buildEnd must not reset the replacement's build-scoped generation",
+  );
+
+  await invokeVitePluginHook(plugin.buildEnd, replacementLifecycle);
+  assert.ok(await deliver(modules[0]!));
+  assert.equal(
+    runCount(),
+    3,
+    "the last container's buildEnd must dispose its generation before any later transform",
+  );
+
+  // Pair one final lifecycle solely to dispose the post-close diagnostic run.
+  const finalLifecycle = {};
+  await invokeVitePluginHook(plugin.buildStart, finalLifecycle);
+  await invokeVitePluginHook(plugin.buildEnd, finalLifecycle);
 }

--- a/tests/test-unplugin/src/internal/adapter-vite-serve.ts
+++ b/tests/test-unplugin/src/internal/adapter-vite-serve.ts
@@ -158,6 +158,10 @@ export async function startViteServer(
   fixture: IViteServeCandidateFixture,
 ): Promise<any> {
   const unpluginVite = await TestUnpluginRuntime.loadUnpluginAdapter("vite");
+  // Vite 7 cannot load a URL beneath the 8.3 spelling Windows may return from
+  // os.tmpdir(), even though Node can stat that alias. Give Vite the same long
+  // physical root its resolver will put into the resolved module id.
+  const viteRoot = fs.realpathSync.native(fixture.app);
   return viteCreateServer({
     appType: "custom",
     configFile: false,
@@ -166,7 +170,7 @@ export async function startViteServer(
     // restarts; the linked package resolves as source without it.
     optimizeDeps: { include: [], noDiscovery: true },
     plugins: [unpluginVite()],
-    root: fixture.app,
+    root: viteRoot,
     // `watch: null` disables the server's own chokidar watcher: these
     // scenarios assert the adapter's filesystem poll (which must work exactly
     // where chokidar does not look), and a chokidar instance can outlive

--- a/tests/test-unplugin/src/internal/adapter-vite-serve.ts
+++ b/tests/test-unplugin/src/internal/adapter-vite-serve.ts
@@ -293,6 +293,7 @@ export async function collectServeWatchRegistrations(
 ): Promise<string[]> {
   const plugin = await loadViteAdapterPlugin();
   const invoke = invokeVitePluginHook;
+  const lifecycle = {};
   invoke(
     plugin.configResolved,
     {},
@@ -302,15 +303,19 @@ export async function collectServeWatchRegistrations(
       server: options.watching ? { watch: {} } : { watch: null },
     },
   );
-  await invoke(plugin.buildStart, {});
+  await invoke(plugin.buildStart, lifecycle);
   const watched: string[] = [];
-  await invoke(
-    plugin.transform,
-    { addWatchFile: (file: string) => watched.push(file) },
-    fs.readFileSync(fixture.mainFile, "utf8"),
-    fixture.mainFile,
-  );
-  return watched;
+  try {
+    await invoke(
+      plugin.transform,
+      { addWatchFile: (file: string) => watched.push(file) },
+      fs.readFileSync(fixture.mainFile, "utf8"),
+      fixture.mainFile,
+    );
+    return watched;
+  } finally {
+    await invoke(plugin.buildEnd, lifecycle);
+  }
 }
 
 /** Resolve the ttsc plugin object out of the Vite adapter's factory result. */

--- a/tests/test-unplugin/src/internal/adapter-vite.ts
+++ b/tests/test-unplugin/src/internal/adapter-vite.ts
@@ -69,13 +69,16 @@ async function assertViteServeWithoutAWatcherServesTheStartupGeneration(): Promi
   });
   const lazy = path.join(root, "src", "lazy.ts");
   fs.writeFileSync(lazy, "export const lazy = 1;\n", "utf8");
+  // Vite 7 resolves Windows temp roots to their long physical spelling and
+  // cannot then load a URL from the 8.3 root spelling supplied by os.tmpdir().
+  const viteRoot = fs.realpathSync.native(root);
   const server = await viteCreateServer({
     appType: "custom",
     configFile: false,
     logLevel: "silent",
     optimizeDeps: { include: [], noDiscovery: true },
     plugins: [unpluginVite()],
-    root,
+    root: viteRoot,
     server: { hmr: false, middlewareMode: true, watch: null },
   });
   try {

--- a/tests/test-unplugin/src/internal/real-native-envelope.ts
+++ b/tests/test-unplugin/src/internal/real-native-envelope.ts
@@ -1,0 +1,533 @@
+import {
+  TestProject,
+  TestUnpluginProject,
+  TestUnpluginRuntime,
+} from "@ttsc/testing";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+
+interface IRealNativeEnvelopeGraph {
+  candidates?: Record<string, string[]>;
+  configs: string[];
+  edges: Record<string, string[]>;
+  globals: string[];
+  inputHashes?: Record<string, string | null>;
+  inputRealpaths?: Record<string, string | null>;
+}
+
+interface IRealNativeEnvelopeTransformation {
+  graph?: IRealNativeEnvelopeGraph;
+  type: string;
+  typescript?: Record<string, string>;
+}
+
+type RealNativeEnvelopeCache = Map<
+  string,
+  Promise<{ result: IRealNativeEnvelopeTransformation }>
+>;
+
+interface IRealNativeEnvelopeApi {
+  beginTtscTransformBuild(cache: RealNativeEnvelopeCache): void;
+  createTtscTransformCache(): RealNativeEnvelopeCache;
+  resetTtscTransformCache(cache: RealNativeEnvelopeCache): void;
+  resolveOptions(options: { project: string }): unknown;
+  transformTtsc(
+    file: string,
+    source: string,
+    options: unknown,
+    aliases: undefined,
+    cache: RealNativeEnvelopeCache,
+  ): Promise<{ code: string } | undefined>;
+}
+
+/** A real native-host project whose linked plugin observes Program invocations. */
+export interface IRealNativeEnvelopeFixture {
+  /** Selected declaration whose compiler proof must survive the JSON boundary. */
+  declaration: string;
+  /** Missing source that supersedes the package's selected JavaScript entry. */
+  missingCandidate: string;
+  /** Sibling source modules delivered independently by a bundler. */
+  modules: string[];
+  /** Project root containing the tsconfig, plugin descriptor, and packages. */
+  root: string;
+  /** Log outside the project, appended once from each linked ApplyProgram call. */
+  runLog: string;
+}
+
+/**
+ * Materialize a package-resolution fixture driven by ttsc's utility host.
+ *
+ * The Go package is deliberately not `main`: ttsc copies it into the ordinary
+ * utility host as a linked contributor, whose no-op `ApplyProgram` method runs
+ * in the same native invocation that produces `driver.NewTransformGraph`.
+ */
+export function createRealNativeEnvelopeFixture(): IRealNativeEnvelopeFixture {
+  TestUnpluginProject.ensureSharedCacheDir();
+  const root = TestProject.tmpdir("ttsc-unplugin-real-envelope-");
+  const runLog = path.join(
+    TestProject.tmpdir("ttsc-unplugin-real-envelope-log-"),
+    "program-runs.bin",
+  );
+  const modules = Array.from({ length: 4 }, (_, index) =>
+    path.join(root, "src", `mod${index}.ts`),
+  );
+  const declaration = path.join(
+    root,
+    "node_modules",
+    "typed-dep",
+    "dist",
+    "index.d.ts",
+  );
+  const missingCandidate = path.join(
+    root,
+    "node_modules",
+    "linked-pkg",
+    "index.ts",
+  );
+
+  TestProject.writeFiles(root, {
+    "go.mod": "module example.com/ttscunpluginrealenvelope\n\ngo 1.26\n",
+    "package.json": JSON.stringify({ private: true, type: "module" }, null, 2),
+    "plugin.cjs": [
+      'const path = require("node:path");',
+      "",
+      "module.exports = (context) => ({",
+      '  name: context.plugin.name ?? "real-envelope-compile-probe",',
+      '  source: path.resolve(context.dirname, "compile-probe"),',
+      "});",
+      "",
+    ].join("\n"),
+    "compile-probe/probe.go": [
+      "package cacheprobe",
+      "",
+      "import (",
+      '  "fmt"',
+      '  "os"',
+      '  "path/filepath"',
+      "",
+      '  "github.com/samchon/ttsc/packages/ttsc/driver"',
+      ")",
+      "",
+      "type plugin struct{}",
+      "",
+      "func (plugin) ApplyProgram(_ *driver.Program, context driver.PluginContext) error {",
+      '  runLog, ok := context.Entry.Config["runLog"].(string)',
+      '  if !ok || runLog == "" {',
+      '    return fmt.Errorf("real-envelope compile probe requires a runLog string")',
+      "  }",
+      "  if !filepath.IsAbs(runLog) {",
+      "    runLog = filepath.Join(context.Cwd, runLog)",
+      "  }",
+      "  file, err := os.OpenFile(runLog, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600)",
+      "  if err != nil {",
+      "    return err",
+      "  }",
+      "  if _, err := file.Write([]byte{1}); err != nil {",
+      "    _ = file.Close()",
+      "    return err",
+      "  }",
+      "  return file.Close()",
+      "}",
+      "",
+      "func init() {",
+      "  driver.RegisterPlugin(plugin{})",
+      "}",
+      "",
+    ].join("\n"),
+    "tsconfig.json": JSON.stringify(
+      {
+        compilerOptions: {
+          allowJs: true,
+          module: "Node16",
+          moduleResolution: "Node16",
+          plugins: [
+            {
+              name: "real-envelope-compile-probe",
+              runLog,
+              transform: "./plugin.cjs",
+            },
+          ],
+          strict: true,
+          target: "ES2022",
+        },
+        include: ["src"],
+      },
+      null,
+      2,
+    ),
+    "node_modules/typed-dep/package.json": JSON.stringify(
+      {
+        main: "dist/index.js",
+        name: "typed-dep",
+        type: "module",
+        types: "dist/index.d.ts",
+        version: "0.0.0",
+      },
+      null,
+      2,
+    ),
+    "node_modules/typed-dep/dist/index.d.ts":
+      "export interface Shared { label: string; }\n",
+    "node_modules/typed-dep/dist/index.js": 'export const runtime = "typed";\n',
+    "node_modules/linked-pkg/package.json": JSON.stringify(
+      {
+        main: "index.js",
+        name: "linked-pkg",
+        type: "module",
+        version: "0.0.0",
+      },
+      null,
+      2,
+    ),
+    "node_modules/linked-pkg/index.d.ts":
+      "export declare const linked: string;\n",
+    "node_modules/linked-pkg/index.js": 'export const linked = "js";\n',
+    ...Object.fromEntries(
+      modules.map((file, index) => [
+        path.relative(root, file),
+        [
+          'import type { Shared } from "typed-dep";',
+          'import { linked } from "linked-pkg";',
+          "",
+          `export const value${index}: Shared = { label: linked + ${JSON.stringify(String(index))} };`,
+          "",
+        ].join("\n"),
+      ]),
+    ),
+  });
+  return { declaration, missingCandidate, modules, root, runLog };
+}
+
+/** Assert persistent and build-scoped core delivery plus Vite wiring. */
+export async function assertRealEnvelopeServesSiblingModulesFromOneCompile(): Promise<void> {
+  const fixture = createRealNativeEnvelopeFixture();
+  const api = await loadApi();
+  await assertCoreLifecycle(api, fixture, false);
+  await assertCoreLifecycle(api, fixture, true);
+  await assertViteLifecycle(fixture);
+}
+
+/** Assert a newly available superseding candidate replaces one generation. */
+export async function assertRealEnvelopeCandidateAppearanceReplacesGeneration(): Promise<void> {
+  const fixture = createRealNativeEnvelopeFixture();
+  const api = await loadApi();
+  const cache = api.createTtscTransformCache();
+  const options = api.resolveOptions({
+    project: path.join(fixture.root, "tsconfig.json"),
+  });
+  resetRunLog(fixture.runLog);
+  try {
+    await deliver(api, cache, options, fixture.modules[0]!);
+    assert.equal(programRuns(fixture.runLog), 1);
+    await assertProductionEnvelope(cache, fixture);
+
+    fs.writeFileSync(
+      fixture.missingCandidate,
+      'export const linked = "typescript";\n',
+      "utf8",
+    );
+    await deliver(api, cache, options, fixture.modules[1]!);
+    assert.equal(
+      programRuns(fixture.runLog),
+      2,
+      "a superseding package candidate must replace the generation before its next importer is delivered",
+    );
+    for (const file of fixture.modules.slice(2)) {
+      await deliver(api, cache, options, file);
+    }
+    assert.equal(
+      programRuns(fixture.runLog),
+      2,
+      "sibling deliveries must reuse the generation created after candidate appearance",
+    );
+  } finally {
+    api.resetTtscTransformCache(cache);
+  }
+}
+
+/** Assert a changed selected declaration replaces one persistent generation. */
+export async function assertRealEnvelopeDeclarationChangeReplacesGeneration(): Promise<void> {
+  const fixture = createRealNativeEnvelopeFixture();
+  const api = await loadApi();
+  const cache = api.createTtscTransformCache();
+  const options = api.resolveOptions({
+    project: path.join(fixture.root, "tsconfig.json"),
+  });
+  resetRunLog(fixture.runLog);
+  try {
+    await deliver(api, cache, options, fixture.modules[0]!);
+    assert.equal(programRuns(fixture.runLog), 1);
+    await assertProductionEnvelope(cache, fixture);
+
+    fs.writeFileSync(
+      fixture.declaration,
+      "export interface Shared { label: string; revision?: number; }\n",
+      "utf8",
+    );
+    await deliver(api, cache, options, fixture.modules[1]!);
+    assert.equal(
+      programRuns(fixture.runLog),
+      2,
+      "a selected declaration edit must replace the generation before its next importer is delivered",
+    );
+    for (const file of fixture.modules.slice(2)) {
+      await deliver(api, cache, options, file);
+    }
+    assert.equal(
+      programRuns(fixture.runLog),
+      2,
+      "sibling deliveries must reuse the generation created after the declaration edit",
+    );
+  } finally {
+    api.resetTtscTransformCache(cache);
+  }
+}
+
+/** Drive one core cache lifecycle and assert its real envelope before reuse. */
+async function assertCoreLifecycle(
+  api: IRealNativeEnvelopeApi,
+  fixture: IRealNativeEnvelopeFixture,
+  buildScoped: boolean,
+): Promise<void> {
+  const cache = api.createTtscTransformCache();
+  if (buildScoped) api.beginTtscTransformBuild(cache);
+  const options = api.resolveOptions({
+    project: path.join(fixture.root, "tsconfig.json"),
+  });
+  resetRunLog(fixture.runLog);
+  try {
+    await deliver(api, cache, options, fixture.modules[0]!);
+    assert.equal(programRuns(fixture.runLog), 1);
+    await assertProductionEnvelope(cache, fixture);
+    for (const file of fixture.modules.slice(1)) {
+      await deliver(api, cache, options, file);
+    }
+    assert.equal(
+      programRuns(fixture.runLog),
+      1,
+      `${buildScoped ? "build-scoped" : "persistent"} delivery must serve every sibling module from one production host invocation`,
+    );
+  } finally {
+    api.resetTtscTransformCache(cache);
+  }
+}
+
+/** Drive the public Vite adapter over the same production-host fixture. */
+async function assertViteLifecycle(
+  fixture: IRealNativeEnvelopeFixture,
+): Promise<void> {
+  const { createServer } = TestUnpluginProject.REQUIRE_FROM_UNPLUGIN(
+    "vite",
+  ) as {
+    createServer(config: object): Promise<any>;
+  };
+  const unpluginVite = await TestUnpluginRuntime.loadUnpluginAdapter("vite");
+  const viteRoot = fs.realpathSync.native(fixture.root);
+  resetRunLog(fixture.runLog);
+  const server = await createServer({
+    appType: "custom",
+    configFile: false,
+    logLevel: "silent",
+    optimizeDeps: { include: [], noDiscovery: true },
+    plugins: [unpluginVite()],
+    root: viteRoot,
+    server: { hmr: false, middlewareMode: true, watch: null },
+  });
+  try {
+    for (const file of fixture.modules) {
+      const url = `/${path.relative(fixture.root, file).split(path.sep).join("/")}`;
+      const result = await server.transformRequest(url);
+      assert.ok(result?.code, `Vite must transform ${url}`);
+    }
+    assert.equal(
+      programRuns(fixture.runLog),
+      1,
+      "the Vite watcherless lifecycle must serve every sibling module from one production host invocation",
+    );
+  } finally {
+    await server.close();
+  }
+}
+
+/** Load the compiled public unplugin API exercised by consumers. */
+async function loadApi(): Promise<IRealNativeEnvelopeApi> {
+  return (await TestUnpluginRuntime.loadUnpluginApi()) as IRealNativeEnvelopeApi;
+}
+
+/** Deliver one source file through the public transform API. */
+async function deliver(
+  api: IRealNativeEnvelopeApi,
+  cache: RealNativeEnvelopeCache,
+  options: unknown,
+  file: string,
+): Promise<void> {
+  const transformed = await api.transformTtsc(
+    file,
+    fs.readFileSync(file, "utf8"),
+    options,
+    undefined,
+    cache,
+  );
+  assert.ok(transformed?.code, `transformTtsc must deliver ${file}`);
+}
+
+/** Inspect the actual generation admitted by @ttsc/unplugin. */
+async function assertProductionEnvelope(
+  cache: RealNativeEnvelopeCache,
+  fixture: IRealNativeEnvelopeFixture,
+): Promise<void> {
+  assert.equal(cache.size, 1, "one project must own one cached generation");
+  const generation = [...cache.values()][0];
+  assert.ok(generation, "the first delivery must admit a generation");
+  const { result } = await generation;
+  assert.equal(result.type, "success");
+  assert.ok(result.typescript, "the native host must return TypeScript output");
+  for (const file of fixture.modules) {
+    const key = findGraphSpelling(
+      fixture.root,
+      Object.keys(result.typescript),
+      file,
+    );
+    assert.ok(
+      key,
+      `the native envelope must contain the sibling output ${graphKey(fixture.root, file)}`,
+    );
+  }
+
+  const graph = result.graph;
+  assert.ok(
+    graph,
+    "the production native host must return its reference graph",
+  );
+  const candidates = Object.values(graph.candidates ?? {}).flat();
+  assert.ok(candidates.length > 0, "the real graph must contain candidates");
+  const realized = new Set([
+    ...Object.keys(graph.edges),
+    ...Object.values(graph.edges).flat(),
+    ...graph.globals,
+    ...graph.configs,
+    ...Object.keys(graph.candidates ?? {}),
+  ]);
+  const candidateOnly = candidates.filter(
+    (candidate) => !realized.has(candidate),
+  );
+  assert.ok(
+    candidateOnly.length > 0,
+    "the fixture must produce a candidate that is not a realized graph member",
+  );
+  const unproven = candidateOnly.find(
+    (candidate) =>
+      !Object.prototype.hasOwnProperty.call(
+        graph.inputHashes ?? {},
+        candidate,
+      ) &&
+      !Object.prototype.hasOwnProperty.call(
+        graph.inputRealpaths ?? {},
+        candidate,
+      ),
+  );
+  assert.ok(
+    unproven,
+    "the fixture must produce a candidate-only path with no compiler hash or realpath proof",
+  );
+
+  const knownCandidate = findGraphSpelling(
+    fixture.root,
+    candidates,
+    fixture.missingCandidate,
+  );
+  assert.ok(
+    knownCandidate,
+    `the real graph must retain the superseding package candidate ${graphKey(fixture.root, fixture.missingCandidate)}`,
+  );
+  assert.equal(fs.existsSync(fixture.missingCandidate), false);
+
+  const declaration = findGraphSpelling(
+    fixture.root,
+    Object.values(graph.edges).flat(),
+    fixture.declaration,
+  );
+  assert.ok(
+    declaration,
+    `the selected declaration must be a realized edge: ${graphKey(fixture.root, fixture.declaration)}`,
+  );
+  assert.match(
+    graph.inputHashes?.[declaration] ?? "",
+    /^[0-9a-f]{64}$/,
+    "the selected declaration must carry a compiler content proof",
+  );
+  assert.equal(
+    typeof graph.inputRealpaths?.[declaration],
+    "string",
+    "the selected declaration must carry a compiler realpath proof",
+  );
+}
+
+/** Find the producer's spelling for one semantic filesystem path. */
+function findGraphSpelling(
+  root: string,
+  spellings: readonly string[],
+  file: string,
+): string | undefined {
+  const expected = comparablePath(file);
+  return spellings.find(
+    (spelling) =>
+      comparablePath(graphAbsolutePath(root, spelling)) === expected,
+  );
+}
+
+/** Resolve one relative-or-absolute graph key to a native absolute path. */
+function graphAbsolutePath(root: string, spelling: string): string {
+  const native = spelling.split("/").join(path.sep);
+  return path.resolve(
+    path.isAbsolute(native) ? native : path.join(root, native),
+  );
+}
+
+/** Apply the host filesystem's path-case contract for semantic comparisons. */
+function comparablePath(file: string): string {
+  const resolved = physicalPath(file);
+  return process.platform === "win32" ? resolved.toLowerCase() : resolved;
+}
+
+/** Resolve aliases even when the final candidate does not exist yet. */
+function physicalPath(file: string): string {
+  let existing = path.resolve(file);
+  const missing: string[] = [];
+  while (!fs.existsSync(existing)) {
+    const parent = path.dirname(existing);
+    if (parent === existing) break;
+    missing.unshift(path.basename(existing));
+    existing = parent;
+  }
+  try {
+    existing = fs.realpathSync.native(existing);
+  } catch {
+    // The lexical root is still the only usable identity on an unreadable path.
+  }
+  return path.resolve(existing, ...missing);
+}
+
+/** Convert an absolute fixture path into the native envelope's key vocabulary. */
+function graphKey(root: string, file: string): string {
+  const relative = path.relative(root, file);
+  const selected =
+    relative !== "" &&
+    !relative.startsWith(`..${path.sep}`) &&
+    relative !== ".." &&
+    !path.isAbsolute(relative)
+      ? relative
+      : path.resolve(file);
+  return selected.split(path.sep).join("/");
+}
+
+/** Reset the observer without introducing a file under the project root. */
+function resetRunLog(runLog: string): void {
+  fs.writeFileSync(runLog, Buffer.alloc(0));
+}
+
+/** Count linked ApplyProgram calls from the one-byte append protocol. */
+function programRuns(runLog: string): number {
+  return fs.existsSync(runLog) ? fs.statSync(runLog).size : 0;
+}

--- a/tests/test-unplugin/src/internal/real-native-envelope.ts
+++ b/tests/test-unplugin/src/internal/real-native-envelope.ts
@@ -335,15 +335,49 @@ async function assertViteLifecycle(
     server: { hmr: false, middlewareMode: true, watch: null },
   });
   try {
+    const graph =
+      server.environments?.client?.moduleGraph ?? server.moduleGraph;
+    const nodes: any[] = [];
     for (const file of fixture.modules) {
       const url = `/${path.relative(fixture.root, file).split(path.sep).join("/")}`;
       const result = await server.transformRequest(url);
       assert.ok(result?.code, `Vite must transform ${url}`);
+      const node = await graph.getModuleByUrl(url);
+      assert.ok(node, `Vite's module graph must contain ${url}`);
+      assert.ok(
+        node.transformResult,
+        `Vite must cache the first transform result for ${url}`,
+      );
+      nodes.push(node);
     }
     assert.equal(
       programRuns(fixture.runLog),
       1,
       "the Vite watcherless lifecycle must serve every sibling module from one production host invocation",
+    );
+
+    // Vite can transpile TypeScript even if the ttsc adapter bypasses a module,
+    // so returned code alone does not prove all four requests crossed our
+    // transform hook. The adapter registers this real missing candidate for
+    // every importer it serves; its private poll invalidates exactly those
+    // module nodes when the candidate appears, even with Vite's watcher off.
+    fs.writeFileSync(
+      fixture.missingCandidate,
+      'export const linked = "typescript";\n',
+      "utf8",
+    );
+    await waitFor(
+      () =>
+        nodes.every(
+          (node) =>
+            node.transformResult === null || node.transformResult === undefined,
+        ),
+      "every sibling module to be invalidated by the adapter's candidate registry",
+    );
+    assert.equal(
+      programRuns(fixture.runLog),
+      1,
+      "candidate notification must invalidate sibling deliveries without compiling until Vite requests them again",
     );
   } finally {
     await server.close();
@@ -362,14 +396,27 @@ async function deliver(
   options: unknown,
   file: string,
 ): Promise<void> {
-  const transformed = await api.transformTtsc(
+  await api.transformTtsc(
     file,
     fs.readFileSync(file, "utf8"),
     options,
     undefined,
     cache,
   );
-  assert.ok(transformed?.code, `transformTtsc must deliver ${file}`);
+}
+
+/** Poll an asynchronous adapter consequence until it is observed. */
+async function waitFor(
+  predicate: () => boolean,
+  what: string,
+  timeout = 20_000,
+): Promise<void> {
+  const deadline = Date.now() + timeout;
+  while (Date.now() < deadline) {
+    if (predicate()) return;
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  assert.fail(`timed out waiting for ${what}`);
 }
 
 /** Inspect the actual generation admitted by @ttsc/unplugin. */

--- a/tests/test-unplugin/src/internal/transform-project-cache.ts
+++ b/tests/test-unplugin/src/internal/transform-project-cache.ts
@@ -3147,6 +3147,11 @@ function createCacheProject(options: ICacheProjectOptions): {
 /**
  * Write the multi-file counting transform sidecar.
  *
+ * This is a synthetic protocol double, not the production driver host. Its
+ * local envelope fields intentionally support adversarial, contradictory, and
+ * race-specific states; the real-host cache gate under `native-plugins/cache`
+ * owns semantic calibration against `driver.NewTransformGraph`.
+ *
  * It echoes every `src/*.ts` file (rewriting the `PROBE` marker so output
  * differs from input), appends one byte to the configured `runLog` per
  * invocation so the test can count whole-project transforms, and optionally

--- a/tests/test-unplugin/src/native-plugins/cache/test_real_native_envelope_candidate_appearance_replaces_generation.ts
+++ b/tests/test-unplugin/src/native-plugins/cache/test_real_native_envelope_candidate_appearance_replaces_generation.ts
@@ -1,0 +1,17 @@
+import { assertRealEnvelopeCandidateAppearanceReplacesGeneration } from "../../internal/real-native-envelope";
+
+/**
+ * Verifies a real superseding candidate replaces the persistent generation.
+ *
+ * Candidate-only paths without compiler proofs are allowed to enter the cache,
+ * but that admission must not serve stale resolution after a higher-priority
+ * package source appears. This is the freshness twin of the one-compile gate.
+ *
+ * 1. Deliver one importer and prove the production envelope and first run.
+ * 2. Create the missing `index.ts` above the selected package `index.js`.
+ * 3. Deliver the remaining importers and require one replacement compile only.
+ */
+export const test_real_native_envelope_candidate_appearance_replaces_generation =
+  async () => {
+    await assertRealEnvelopeCandidateAppearanceReplacesGeneration();
+  };

--- a/tests/test-unplugin/src/native-plugins/cache/test_real_native_envelope_declaration_change_replaces_generation.ts
+++ b/tests/test-unplugin/src/native-plugins/cache/test_real_native_envelope_declaration_change_replaces_generation.ts
@@ -1,0 +1,17 @@
+import { assertRealEnvelopeDeclarationChangeReplacesGeneration } from "../../internal/real-native-envelope";
+
+/**
+ * Verifies a selected declaration edit replaces the persistent generation.
+ *
+ * The positive cache gate is sound only if realized compiler proofs retain
+ * their opposite verdict from speculative unproven candidates. A changed
+ * declaration reached by every importer must invalidate once, then be reused.
+ *
+ * 1. Deliver one importer and prove the selected declaration's native proofs.
+ * 2. Change that declaration before delivering a sibling importer.
+ * 3. Require one replacement compile and reuse it for every remaining sibling.
+ */
+export const test_real_native_envelope_declaration_change_replaces_generation =
+  async () => {
+    await assertRealEnvelopeDeclarationChangeReplacesGeneration();
+  };

--- a/tests/test-unplugin/src/native-plugins/cache/test_real_native_envelope_serves_sibling_modules_from_one_compile.ts
+++ b/tests/test-unplugin/src/native-plugins/cache/test_real_native_envelope_serves_sibling_modules_from_one_compile.ts
@@ -1,0 +1,19 @@
+import { assertRealEnvelopeServesSiblingModulesFromOneCompile } from "../../internal/real-native-envelope";
+
+/**
+ * Verifies one real compiler-produced envelope serves every sibling module.
+ *
+ * Synthetic cache fixtures can count their own sidecar runs while drifting from
+ * the production graph contract. This case links a no-op observer into ttsc's
+ * ordinary utility host, asserts candidate and proof witnesses on the admitted
+ * native envelope, and then crosses the public Vite lifecycle.
+ *
+ * 1. Deliver four modules through persistent and build-scoped core caches.
+ * 2. Assert each real envelope contains the candidate-only and realized proofs.
+ * 3. Deliver the same project through Vite and require one native invocation in
+ *    every arm.
+ */
+export const test_real_native_envelope_serves_sibling_modules_from_one_compile =
+  async () => {
+    await assertRealEnvelopeServesSiblingModulesFromOneCompile();
+  };

--- a/tests/utils/src/unplugin/TestUnpluginProject.ts
+++ b/tests/utils/src/unplugin/TestUnpluginProject.ts
@@ -215,6 +215,12 @@ export namespace TestUnpluginProject {
   /**
    * Write the tiny Go transformer used by unplugin adapter tests.
    *
+   * This is a handwritten synthetic protocol double: it owns its JSON envelope
+   * shape and does not stand in for the production driver's reference graph.
+   * The real-host contract is calibrated by test-unplugin's native envelope
+   * cache gate; this fixture stays synthetic so tests can request controlled
+   * operations and deliberately incomplete shapes.
+   *
    * The plugin supports multiple operations so adapter tests can prove plugin
    * ordering, generated tsconfig paths, config path absolutization, and cache
    * invalidation without depending on a production utility plugin.


### PR DESCRIPTION
## Intent

Bind #1291's one-project-compile invariant to an envelope produced by the real TypeScript-Go native host, so a future producer/consumer mismatch fails the ordinary unplugin CI lane before it reaches an application.

This draft pull request owns the complete accepted cycle for #1291.

## Scope

- Add a linked no-op Go observer that counts production native-host Program invocations without monkey-patching or fabricating an envelope.
- Prove the returned production envelope contains real resolution candidates, candidate-only paths without compiler proofs, a realized declaration proof, and every sibling source output.
- Assert one generation across persistent, build-scoped, and Vite adapter multi-module delivery.
- Prove every Vite sibling crossed the adapter by invalidating all four module nodes through the real missing-candidate registry.
- Preserve freshness through real candidate-appearance and selected-declaration-change twins.
- Dispose generation-owned filesystem trackers at the last owning Vite `buildEnd` without letting an unstarted or superseded container clear a live replacement.
- Identify synthetic protocol doubles and clarify the opt-in performance harness documentation.
- Keep the gate in the normal `@ttsc/test-unplugin` and root CI path without wall-time thresholds.

## Deferred

- Moving every pre-existing Go-building unplugin fixture from `features` to `native-plugins` is broader layout debt and is not required by #1291. New native-host cases follow the current placement contract.
- Intentionally malformed, contradictory, race-specific, and performance-specific envelope producers remain local protocol doubles; the production-host fixture becomes their canonical semantic calibration point.

## Verification

- [x] Focused real-envelope positive and freshness cases
- [x] Deliberate pre-#1247-equivalent cache mutant rejected by the positive gate
- [x] A-F opt-in unplugin performance scenarios
- [x] Repository test-package type checking
- [x] Targeted formatting and diff-integrity checks
- [ ] Root Go validation (reported green packages through lint and reached graph; detached run's final exit code unavailable, so exact-head CI is authoritative)
- [x] Initial implementation Individual Self-Review ([three accepted findings](https://github.com/samchon/ttsc/pull/1292#pullrequestreview-5039898320))
- [x] First correction Individual Self-Review ([one accepted failure-path finding](https://github.com/samchon/ttsc/pull/1292#pullrequestreview-5040034448))
- [x] Failure-path correction Individual Self-Review ([clean](https://github.com/samchon/ttsc/pull/1292#pullrequestreview-5040064430))
- [x] Overall Self-Review ([round 3 clean on the final head](https://github.com/samchon/ttsc/pull/1292#pullrequestreview-5040053620); prior rounds are historical)
- [x] Exact-head GitHub checks (23 checks passed on `2218b7f44f299f2e43a71595bd96a68bc454a5a0`)

The accepted Individual findings are corrected locally: identity transforms are legal, the Vite arm now has adapter-owned evidence for every sibling, and overlapping/unstarted Vite lifecycle ownership is regression-tested. The correction-focused suite and repository type checking pass.

The complete unplugin run also identified a pre-existing Windows failure in the directory-shaped configuration candidate case. It reproduces independently of this diff and is recorded for the post-merge discovery round. The Windows Vite 7 short-path fixture failure that did intersect this issue's adapter surface is fixed here and its focused cases pass.
