### PR TITLE
fix(driver): report config directories by physical identity

### DIFF
--- a/packages/ttsc/driver/config_discovery.go
+++ b/packages/ttsc/driver/config_discovery.go
@@ -120,7 +120,10 @@ func ReportRejectedConfigCandidates(candidates []ConfigCandidate, hashReporter, 
     if hashReporter != nil {
       hashReporter(candidate.Path, hash)
     }
-    if realpathReporter != nil {
+    // A nil report is the explicit observed-missing state, not an unknown
+    // proof. Only absent candidates may publish it; a directory whose physical
+    // identity could not be resolved must leave the realpath observation out.
+    if realpathReporter != nil && (!candidate.Directory || realpath != nil) {
       realpathReporter(candidate.Path, realpath)
     }
   }

--- a/packages/ttsc/driver/config_discovery.go
+++ b/packages/ttsc/driver/config_discovery.go
@@ -107,8 +107,14 @@ func ReportRejectedConfigCandidates(candidates []ConfigCandidate, hashReporter, 
       digest := observedDirectoryDigest
       hash = &digest
       if resolved, err := filepath.Abs(candidate.Path); err == nil {
-        cleaned := filepath.Clean(resolved)
-        realpath = &cleaned
+        // Abs and Clean preserve aliases (Windows 8.3 names, symlinks, and
+        // junctions). The descriptor-side observer reports a physical path, so
+        // publishing the lexical spelling here would make the two proofs
+        // conflict and leave every persistent consumer unable to reuse.
+        if physical, err := filepath.EvalSymlinks(resolved); err == nil {
+          cleaned := filepath.Clean(physical)
+          realpath = &cleaned
+        }
       }
     }
     if hashReporter != nil {

--- a/packages/ttsc/test/driver/report_rejected_config_candidates_records_each_in_its_own_state_test.go
+++ b/packages/ttsc/test/driver/report_rejected_config_candidates_records_each_in_its_own_state_test.go
@@ -34,8 +34,8 @@ func TestReportRejectedConfigCandidatesRecordsEachInItsOwnState(t *testing.T) {
     func(file string, realpath *string) { realpaths[file] = realpath },
   )
 
-  if len(hashes) != 3 || len(realpaths) != 3 {
-    t.Fatalf("expected both halves for every candidate, got %v and %v", hashes, realpaths)
+  if len(hashes) != 3 || len(realpaths) != 2 {
+    t.Fatalf("expected every hash and only proven realpaths, got %v and %v", hashes, realpaths)
   }
   if hashes[absent] != nil || realpaths[absent] != nil {
     t.Fatalf("an absent candidate must be reported as absent, got %v and %v", hashes[absent], realpaths[absent])
@@ -53,9 +53,10 @@ func TestReportRejectedConfigCandidatesRecordsEachInItsOwnState(t *testing.T) {
   if *hashes[directory] == "" {
     t.Fatalf("expected the directory-kind digest, got an empty hash")
   }
-  if hashes[disappearedDirectory] == nil || realpaths[disappearedDirectory] != nil {
+  _, hasDisappearedRealpath := realpaths[disappearedDirectory]
+  if hashes[disappearedDirectory] == nil || hasDisappearedRealpath {
     t.Fatalf(
-      "a vanished directory must keep its observed kind without fabricated physical proof, got %v and %v",
+      "a vanished directory must keep its observed kind without any fabricated physical proof, got %v and %v",
       hashes[disappearedDirectory],
       realpaths[disappearedDirectory],
     )

--- a/packages/ttsc/test/driver/report_rejected_config_candidates_records_each_in_its_own_state_test.go
+++ b/packages/ttsc/test/driver/report_rejected_config_candidates_records_each_in_its_own_state_test.go
@@ -19,18 +19,23 @@ func TestReportRejectedConfigCandidatesRecordsEachInItsOwnState(t *testing.T) {
   root := t.TempDir()
   absent := filepath.Join(root, "demo.config.ts")
   directory := filepath.Join(root, "demo.config.json")
+  disappearedDirectory := filepath.Join(root, "gone.config.json")
   writeProjectFile(t, root, filepath.Join("demo.config.json", "keep.txt"), "")
   hashes := map[string]*string{}
   realpaths := map[string]*string{}
 
   driver.ReportRejectedConfigCandidates(
-    []driver.ConfigCandidate{{Path: absent}, {Directory: true, Path: directory}},
+    []driver.ConfigCandidate{
+      {Path: absent},
+      {Directory: true, Path: directory},
+      {Directory: true, Path: disappearedDirectory},
+    },
     func(file string, hash *string) { hashes[file] = hash },
     func(file string, realpath *string) { realpaths[file] = realpath },
   )
 
-  if len(hashes) != 2 || len(realpaths) != 2 {
-    t.Fatalf("expected both halves for both candidates, got %v and %v", hashes, realpaths)
+  if len(hashes) != 3 || len(realpaths) != 3 {
+    t.Fatalf("expected both halves for every candidate, got %v and %v", hashes, realpaths)
   }
   if hashes[absent] != nil || realpaths[absent] != nil {
     t.Fatalf("an absent candidate must be reported as absent, got %v and %v", hashes[absent], realpaths[absent])
@@ -38,10 +43,21 @@ func TestReportRejectedConfigCandidatesRecordsEachInItsOwnState(t *testing.T) {
   if hashes[directory] == nil || realpaths[directory] == nil {
     t.Fatalf("a directory candidate must carry both proofs, got %v and %v", hashes[directory], realpaths[directory])
   }
-  if *realpaths[directory] != filepath.Clean(directory) {
-    t.Fatalf("expected the directory's own path, got %q", *realpaths[directory])
+  physical, err := filepath.EvalSymlinks(directory)
+  if err != nil {
+    t.Fatal(err)
+  }
+  if *realpaths[directory] != filepath.Clean(physical) {
+    t.Fatalf("expected the directory's physical path %q, got %q", physical, *realpaths[directory])
   }
   if *hashes[directory] == "" {
     t.Fatalf("expected the directory-kind digest, got an empty hash")
+  }
+  if hashes[disappearedDirectory] == nil || realpaths[disappearedDirectory] != nil {
+    t.Fatalf(
+      "a vanished directory must keep its observed kind without fabricated physical proof, got %v and %v",
+      hashes[disappearedDirectory],
+      realpaths[disappearedDirectory],
+    )
   }
 }

--- a/packages/ttsc/test/driver/report_rejected_config_candidates_resolves_directory_alias_test.go
+++ b/packages/ttsc/test/driver/report_rejected_config_candidates_resolves_directory_alias_test.go
@@ -1,0 +1,48 @@
+package driver_test
+
+import (
+  "os"
+  "path/filepath"
+  "testing"
+
+  "github.com/samchon/ttsc/packages/ttsc/driver"
+)
+
+// TestReportRejectedConfigCandidatesResolvesDirectoryAlias verifies a lexical
+// alias is never published as a directory candidate's physical identity.
+//
+// Plugin discovery and the linked native plugin observe the same candidate in
+// two stages. The JavaScript stage reports a realpath. If this Go stage reports
+// the symlink spelling instead, the envelope merge drops the conflicting proof
+// and every persistent adapter recompiles the whole project per module.
+func TestReportRejectedConfigCandidatesResolvesDirectoryAlias(t *testing.T) {
+  root := t.TempDir()
+  targetRoot := filepath.Join(root, "physical")
+  target := filepath.Join(targetRoot, "demo.config.json")
+  if err := os.MkdirAll(target, 0o755); err != nil {
+    t.Fatal(err)
+  }
+  aliasRoot := filepath.Join(root, "alias")
+  if err := os.Symlink(targetRoot, aliasRoot); err != nil {
+    t.Skipf("directory symlink is unavailable: %v", err)
+  }
+  alias := filepath.Join(aliasRoot, "demo.config.json")
+  physical, err := filepath.EvalSymlinks(alias)
+  if err != nil {
+    t.Fatal(err)
+  }
+
+  var reported *string
+  driver.ReportRejectedConfigCandidates(
+    []driver.ConfigCandidate{{Directory: true, Path: alias}},
+    nil,
+    func(_ string, realpath *string) { reported = realpath },
+  )
+
+  if reported == nil {
+    t.Fatalf("expected physical target %q, got no proof", physical)
+  }
+  if *reported != filepath.Clean(physical) {
+    t.Fatalf("expected physical target %q, got %q", physical, *reported)
+  }
+}

--- a/packages/ttsc/test/driver/report_rejected_config_candidates_resolves_windows_short_path_test.go
+++ b/packages/ttsc/test/driver/report_rejected_config_candidates_resolves_windows_short_path_test.go
@@ -1,0 +1,65 @@
+//go:build windows
+
+package driver_test
+
+import (
+  "os"
+  "path/filepath"
+  "strings"
+  "testing"
+
+  "github.com/samchon/ttsc/packages/ttsc/driver"
+  "golang.org/x/sys/windows"
+)
+
+// TestReportRejectedConfigCandidatesResolvesWindowsShortPath pins the concrete
+// 8.3 spelling that exposed a permanently incomplete host-input manifest.
+func TestReportRejectedConfigCandidatesResolvesWindowsShortPath(t *testing.T) {
+  directory := filepath.Join(t.TempDir(), "directory candidate long name", "demo.config.json")
+  if err := os.MkdirAll(directory, 0o755); err != nil {
+    t.Fatal(err)
+  }
+  short := windowsShortPath(t, directory)
+  physical, err := filepath.EvalSymlinks(short)
+  if err != nil {
+    t.Fatal(err)
+  }
+
+  var reported *string
+  driver.ReportRejectedConfigCandidates(
+    []driver.ConfigCandidate{{Directory: true, Path: short}},
+    nil,
+    func(_ string, realpath *string) { reported = realpath },
+  )
+
+  if reported == nil {
+    t.Fatalf("expected long physical target %q for short spelling %q, got no proof", physical, short)
+  }
+  if *reported != filepath.Clean(physical) {
+    t.Fatalf("expected long physical target %q for short spelling %q, got %q", physical, short, *reported)
+  }
+}
+
+// windowsShortPath returns a distinct DOS alias, or skips on a volume where
+// 8.3 name creation is disabled and the boundary cannot be manufactured.
+func windowsShortPath(t *testing.T, value string) string {
+  t.Helper()
+  input, err := windows.UTF16PtrFromString(value)
+  if err != nil {
+    t.Fatal(err)
+  }
+  needed, err := windows.GetShortPathName(input, nil, 0)
+  if err != nil || needed == 0 {
+    t.Skipf("Windows short paths are unavailable: %v", err)
+  }
+  buffer := make([]uint16, needed)
+  written, err := windows.GetShortPathName(input, &buffer[0], uint32(len(buffer)))
+  if err != nil {
+    t.Fatal(err)
+  }
+  short := windows.UTF16ToString(buffer[:written])
+  if strings.EqualFold(filepath.Clean(short), filepath.Clean(value)) {
+    t.Skip("the test volume did not assign a distinct 8.3 alias")
+  }
+  return short
+}

--- a/tests/test-unplugin/src/features/transform/test_transformttsc_directory_shaped_config_candidate_keeps_the_generation.ts
+++ b/tests/test-unplugin/src/features/transform/test_transformttsc_directory_shaped_config_candidate_keeps_the_generation.ts
@@ -11,10 +11,12 @@ import { assertDirectoryShapedConfigCandidateKeepsTheGeneration } from "../../in
  * a digest its own filesystem keeps producing — the generation is then refused
  * on every delivery for the rest of its life rather than invalidated once.
  *
- * 1. Compile a package whose config directory also carries a directory named
- *    `banner.config.ts`.
- * 2. Assert that path reached the envelope.
- * 3. Deliver again and assert the generation object is the same one.
+ * 1. Compile a package whose nearer config directory carries a directory named
+ *    `banner.config.json` while an outer config supplies the banner.
+ * 2. Assert that path's digest and physical identity reached a complete envelope,
+ *    then deliver again and retain the same generation.
+ * 3. Replace the directory with a real config, require one new generation and its
+ *    nearer banner, then deliver once more and retain that generation.
  */
 export const test_transformttsc_directory_shaped_config_candidate_keeps_the_generation =
   async () => {

--- a/tests/test-unplugin/src/internal/transform-utility-plugin-config.ts
+++ b/tests/test-unplugin/src/internal/transform-utility-plugin-config.ts
@@ -1112,9 +1112,10 @@ async function assertDirectoryShapedConfigCandidateKeepsTheGeneration() {
     plugin: "banner",
     source: 'export const value: string = "kept";\n',
   });
-  // Beside the config the walk settles on, so the search reaches it, rejects
-  // it, and reports it from the directory it stopped in.
-  const directory = path.join(path.dirname(middle), "banner.config.ts");
+  // One level nearer than the config the walk settles on. The search rejects
+  // the directory on its way outward, and replacing it with a file must later
+  // supersede the outer config rather than merely change an inert neighbour.
+  const directory = path.join(middle, "banner.config.json");
   fs.mkdirSync(directory, { recursive: true });
 
   const file = path.join(root, "src", "main.ts");
@@ -1178,6 +1179,44 @@ async function assertDirectoryShapedConfigCandidateKeepsTheGeneration() {
     "a directory wearing a config name must not make the generation unreusable",
   );
   assert.match(second.code, /OUTER BANNER/);
+
+  fs.rmSync(directory, { recursive: true });
+  fs.writeFileSync(
+    directory,
+    JSON.stringify({ text: "NEARER BANNER" }),
+    "utf8",
+  );
+  const third = await transformTtsc(
+    file,
+    source,
+    resolveOptions(),
+    undefined,
+    cache,
+  );
+  assert.ok(third);
+  const replacementGeneration = [...cache.values()][0];
+  assert.notEqual(
+    replacementGeneration,
+    firstGeneration,
+    "replacing the directory candidate with a config file must replace the generation",
+  );
+  assert.match(third.code, /NEARER BANNER/);
+  assert.doesNotMatch(third.code, /OUTER BANNER/);
+
+  const fourth = await transformTtsc(
+    file,
+    source,
+    resolveOptions(),
+    undefined,
+    cache,
+  );
+  assert.ok(fourth);
+  assert.equal(
+    [...cache.values()][0],
+    replacementGeneration,
+    "the replacement config must compile exactly one new reusable generation",
+  );
+  assert.match(fourth.code, /NEARER BANNER/);
 }
 
 /**

--- a/tests/test-unplugin/src/internal/transform-utility-plugin-config.ts
+++ b/tests/test-unplugin/src/internal/transform-utility-plugin-config.ts
@@ -4,6 +4,7 @@ import {
   TestUnpluginRuntime,
 } from "@ttsc/testing";
 import assert from "node:assert/strict";
+import crypto from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 
@@ -1130,13 +1131,37 @@ async function assertDirectoryShapedConfigCandidateKeepsTheGeneration() {
   assert.match(first.code, /OUTER BANNER/);
   const firstGeneration = [...cache.values()][0];
   const cached = (await firstGeneration!) as {
-    result?: { hostInputs?: string[] };
+    projectSnapshotComplete?: boolean;
+    result?: {
+      hostInputHashes?: Record<string, string | null>;
+      hostInputRealpaths?: Record<string, string | null>;
+      hostInputs?: string[];
+    };
   };
+  const absoluteDirectory = path.resolve(directory);
   assert.ok(
     cached.result?.hostInputs?.some(
       (input) => path.resolve(input) === path.resolve(directory),
     ),
     `the directory-shaped candidate is missing from the envelope: ${JSON.stringify(cached.result?.hostInputs ?? [])}`,
+  );
+  assert.equal(
+    cached.result?.hostInputHashes?.[absoluteDirectory],
+    crypto
+      .createHash("sha256")
+      .update("ttsc:host-input:directory\0")
+      .digest("hex"),
+    "the directory-shaped candidate must carry the directory-kind digest",
+  );
+  assert.equal(
+    cached.result?.hostInputRealpaths?.[absoluteDirectory],
+    fs.realpathSync.native(directory),
+    "descriptor and linked-host observations must agree on the physical directory",
+  );
+  assert.equal(
+    cached.projectSnapshotComplete,
+    true,
+    "the directory-shaped candidate must leave a reusable generation snapshot",
   );
 
   const second = await transformTtsc(

--- a/tests/test-unplugin/src/internal/transform-utility-plugin-config.ts
+++ b/tests/test-unplugin/src/internal/transform-utility-plugin-config.ts
@@ -1098,11 +1098,13 @@ async function assertUnrelatedFileInAProbedDirectoryKeepsTheGeneration() {
  * generation is refused on every delivery for the rest of its life, which is
  * the shape samchon/ttsc#1245 was filed for.
  *
- * 1. Compile a package whose config directory also carries a _directory_ named
- *    `banner.config.ts`.
- * 2. Assert that path reached the envelope, so the case is about how it was
- *    recorded rather than about it being dropped.
- * 3. Deliver again and assert the generation object is the same one.
+ * 1. Compile through an outer config while a nearer `banner.config.json` candidate
+ *    is a directory.
+ * 2. Require that directory's digest and physical identity in a complete envelope,
+ *    then deliver again and retain the same generation.
+ * 3. Replace the directory with a real nearer config and require one new
+ *    generation with the nearer banner.
+ * 4. Deliver once more and retain that replacement generation.
  */
 async function assertDirectoryShapedConfigCandidateKeepsTheGeneration() {
   const { createTtscTransformCache, resolveOptions, transformTtsc } =


### PR DESCRIPTION
Closes #1293.

The driver now resolves an existing directory-shaped rejected config candidate
to its physical identity before reporting it. When that identity cannot be
confirmed, it preserves the directory digest but does not fabricate a lexical
`realpath` proof. This aligns the Go producer with the descriptor-side observer
without weakening conflict detection or unplugin's persistent-manifest gate.

## Scope

- make `driver.ReportRejectedConfigCandidates` report an existing directory's
  physical identity rather than its lexical absolute spelling;
- preserve the directory-kind digest and absent candidates' paired null state;
- strengthen Go and real linked-host regression coverage across non-canonical
  spellings;
- leave conflict-dropping and unplugin's strict manifest gate intact.

## Verification ledger

- [x] Focused and full Go driver tests
- [x] Exact Windows 8.3 short-path unplugin reproduction
- [x] Utility-plugin Go suites
- [x] Full unplugin suite under a short `%TEMP%` spelling
- [x] Typecheck
- [x] Full Go repository tests
- [x] Individual Self-Review for every implementation/correction commit
- [x] Overall Self-Review clean on final head `8100cc36e`
- [x] Exact-head GitHub checks (27/27 successful on `8100cc36e`)

## Self-Review ledger

- [Implementation Individual review — P2 accepted](https://github.com/samchon/ttsc/pull/1294#pullrequestreview-5041221369)
- [First correction Individual review — clean](https://github.com/samchon/ttsc/pull/1294#pullrequestreview-5041283360)
- [Overall review round 1 — P2 accepted](https://github.com/samchon/ttsc/pull/1294#pullrequestreview-5041287940)
- [State-transition correction Individual review — P3 accepted](https://github.com/samchon/ttsc/pull/1294#pullrequestreview-5041424631)
- [Documentation correction Individual review — clean](https://github.com/samchon/ttsc/pull/1294#pullrequestreview-5041452848)
- [Overall review round 2 — clean](https://github.com/samchon/ttsc/pull/1294#pullrequestreview-5041456287)

The detailed reproduction, root-cause trace, consequence surface, rejected
alternatives, and acceptance criteria are in #1293.
