### PR TITLE
docs(graph): tighten the chapter and the package README

### DIFF
--- a/packages/graph/README.md
+++ b/packages/graph/README.md
@@ -4,13 +4,9 @@
 
 [![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/samchon/ttsc/blob/master/LICENSE) [![NPM Version](https://img.shields.io/npm/v/@ttsc/graph.svg)](https://www.npmjs.com/package/@ttsc/graph) [![NPM Downloads](https://img.shields.io/npm/dm/@ttsc/graph.svg)](https://www.npmjs.com/package/@ttsc/graph) [![Build Status](https://github.com/samchon/ttsc/workflows/test/badge.svg)](https://github.com/samchon/ttsc/actions?query=workflow%3Atest) [![Guide Documents](https://img.shields.io/badge/Guide-Documents-forestgreen)](https://ttsc.dev/docs/graph) [![Discord Badge](https://img.shields.io/badge/discord-samchon-d91965?style=flat&labelColor=5866f2&logo=discord&logoColor=white&link=https://discord.gg/E94XhzrUCZ)](https://discord.gg/E94XhzrUCZ)
 
-`@ttsc/graph` is an MCP server that gives AI agents a code graph instead of source files.
+Your coding agent answers from the compiler instead of reading files.
 
-It indexes a TypeScript codebase into a graph of declarations and their relationships, and answers an agent's code questions from that index through a single tool. Every node and edge is resolved by the TypeScript compiler itself, so the graph is exact for TypeScript and TSX, never text-guessed.
-
-Coding agents normally answer a code question by grepping the repository and reading file after file into context, and that reading is most of the token bill. The graph removes the need for it, and its own answers stay small in turn: they carry names, signatures, relationships, and source spans, never file bodies.
-
-Since neither side of that exchange grows with the repository, the cost falls by about the same proportion in every situation, on every codebase, for an agent that trusts the graph result enough to stop there. codex/gpt-5.6-sol does: it answers the onboarding question in one to three graph calls, opens no file at all, and spends 4% of what it spends without the server. That even distribution is what separates this from [`codegraph`](https://github.com/colbymchenry/codegraph) and [`serena`](https://github.com/oraios/serena), whose cost swings with the repository, and it shows directly in the chart below:
+One MCP tool answers a code question from a graph the TypeScript checker resolved, and its replies carry names, signatures, relationships, and source spans, never file bodies. Neither the crawl nor the answer grows with the repository, so the cost stays flat where [`codegraph`](https://github.com/colbymchenry/codegraph) and [`serena`](https://github.com/oraios/serena) swing with repository size:
 
 ![Agent token cost, common question, per repository](https://ttsc.dev/benchmark/svg/graph-common-codex-gpt-5.6-sol.svg)
 
@@ -69,8 +65,6 @@ The interactive charts, every model, and the method are on the benchmark page: h
 
 ```ts
 /**
- * ## Code Graph MCP
- *
  * `inspect_typescript_graph` returns a compiler-built TypeScript graph contract
  * for the current on-disk source snapshot.
  *
@@ -80,65 +74,6 @@ The interactive charts, every model, and the method are on the benchmark page: h
  *
  * Returned graph facts are sacred, infallible compiler truth for the snapshot
  * synchronized by that call. Never verify them with files or more graph calls.
- *
- * ## Requests
- *
- * A request is a union: pick the single type below that best fits the question,
- * and submit exactly that one.
- *
- * - `tour`: architecture, runtime flow, orientation, or a code tour. One call is
- *   the whole answer; do not split it.
- * - `entrypoints`: find where execution starts when entry points are unknown.
- * - `lookup`: locate a named symbol, or — with a documentation target as the
- *   query (`docs/pricing.md#sale`, `POST:/orders`) — the declarations whose
- *   documentation cites it.
- * - `trace`: follow calls or data flow forward or backward from a symbol, or —
- *   with `to` — the path between two symbols when both ends are known, which is
- *   the one call that answers "how does A reach B".
- * - `details`: signatures, members, and relations of named symbols — including
- *   the classes that implement an interface, which is the one call that answers
- *   "what actually implements this".
- * - `overview`: project layers and folder structure.
- * - `escape`: the answer is outside the graph (source body text, non-TypeScript
- *   files, exact search).
- *
- * ## Chain of Thought
- *
- * Fill these fields in order before the call; each one narrows the reasoning
- * toward the single request you submit.
- *
- * - `question`: the code question, in the user's own words.
- * - `draft`: `{ reason, type }` — why the smallest request that could answer it,
- *   then that request's `type`.
- * - `review`: fix a broad, stale, or duplicate draft. If the graph already
- *   answered, or the evidence is outside it, escape.
- * - `request`: the final choice. A `tour` takes one more step of reasoning — its
- *   `reinterpretations`: a list of symbol names, never a sentence, naming the
- *   machinery you expect the answer to be made of. The graph looks each name up,
- *   steers the tour with the ones it holds and drops the rest, so a wrong guess is
- *   free and a right one saves a call. Send `[]` when the question names no
- *   machinery.
- *
- * ## Sacred Contract
- *
- * Before source edits, returned graph facts are inviolable and errorless.
- *
- * Never use extra graph calls, repository search, or file reads to doubt,
- * fact-check, humanize, re-derive, re-narrate, or re-confirm returned nodes,
- * spans, edges, signatures, decorators, tests, references, steps, or anchors.
- *
- * The server already did, and `audit` says so on every result: each name, span,
- * edge, signature, and step in it resolves to the type-checked program for the
- * snapshot the call synced to, with nothing matched, ranked, or inferred.
- *
- * ## Stop
- *
- * The graph answers in one shot; know when it has and stop cleanly.
- *
- * - A returned result is the whole answer: answer from it and stop. A span is a
- *   citation, not a cue to open the file.
- * - Follow the result's `next`: `answer` means stop and answer from it, `inspect`
- *   means make exactly the one request it names, `outside` means escape.
  */
 export interface ITtscGraphApplication {
   /**

--- a/website/src/content/docs/graph/compare.mdx
+++ b/website/src/content/docs/graph/compare.mdx
@@ -2,17 +2,13 @@ import TtscWebsiteBenchmarkGraphCommon from "../../../components/benchmark/graph
 
 # Comparison
 
-This page compares `@ttsc/graph` with the other tools that give a coding agent a view of a codebase over MCP: [`codegraph`](https://github.com/colbymchenry/codegraph), [`codebase-memory-mcp`](https://github.com/DeusData/codebase-memory-mcp), and [`serena`](https://github.com/oraios/serena). It is for a developer choosing between them.
+Four tools give a coding agent a view of a codebase over MCP: `@ttsc/graph`, [`codegraph`](https://github.com/colbymchenry/codegraph), [`codebase-memory-mcp`](https://github.com/DeusData/codebase-memory-mcp), and [`serena`](https://github.com/oraios/serena).
 
-`@ttsc/graph` did not invent this category. `codegraph` put a code graph in front of an agent over MCP first, `codebase-memory-mcp` took the same idea across 158 languages, and `serena` reached it from the language-server side. `@ttsc/graph` is built on what they proved was worth wanting, aimed at one case they were not built for: the open-ended "how does this work?" question, answered without the token cost climbing. The differences below are design differences, not a scoreboard.
+`@ttsc/graph` did not invent the category. `codegraph` put a code graph in front of an agent first, `codebase-memory-mcp` took it across 158 languages, and `serena` reached it from the language-server side. This one is aimed at the case they were not built for: the open-ended "how does this work?" question, answered without the token cost climbing.
 
 Every claim about another tool below links to the source it comes from, and the full list is in [Sources](#sources). The facts are current as of mid-2026 and taken from each tool's own repository and docs. All four are moving targets, so check the linked sources before relying on a specific number.
 
-## The landscape
-
-The four tools side by side, then the measured cost.
-
-### At a glance
+## At a glance
 
 |  | `@ttsc/graph` | `codegraph` | `codebase-memory-mcp` | `serena` |
 | --- | --- | --- | --- | --- |
@@ -24,21 +20,15 @@ The four tools side by side, then the measured cost.
 | Instruction strategy | States a condition, first-class `escape`, does not force | Forces hard: call before Read, do not grep | No MCP-handshake instructions; install-time skills and hooks | Replacement system prompt; recommends disabling Claude Code's own read and edit tools |
 | Its own headline claim | About 10x fewer tokens on open-ended questions | 58% fewer tool calls, file reads to about zero | Up to 120x fewer tokens on structural queries | Symbol tools "more token-efficient than typical alternatives" |
 
-### Measured cost
+## Measured cost
 
 The chart below is the shared onboarding question across the benchmark repositories, on the primary model lane. `@ttsc/graph` holds a flat, low median token cost as the repository grows, while the comparators swing with repository size and sometimes land above the no-MCP baseline.
 
 <TtscWebsiteBenchmarkGraphCommon summary />
 
-This is the summary view. The [full benchmark](/docs/benchmark/graph) adds the per-repository prompts, every model, and structural coverage, and the [launch post](/blog/i-made-ts-compiler-graph-mcp) covers the method and where the numbers hold or break down.
+The [full benchmark](/docs/benchmark/graph) adds the per-repository prompts, every model, and structural coverage, and the [launch post](/blog/i-made-ts-compiler-graph-mcp) covers the method and where the numbers hold or break down.
 
-## How they differ
-
-The design differences that decide cost and trust, one at a time.
-
-### What a query returns
-
-This is the difference that decides the token bill on a broad question, so it comes first.
+## What a query returns
 
 ![What each tool hands back to the agent](/blog/images/response-shapes.svg)
 
@@ -52,17 +42,15 @@ This is the difference that decides the token bill on a broad question, so it co
 
 `serena` returns symbol overviews and then source bodies on demand through its symbol tools ([tools](https://oraios.github.io/serena/01-about/035_tools.html)), rather than a whole-graph index.
 
-### How relationships are resolved
+## How relationships are resolved
 
-`@ttsc/graph` reads the program `ttsc` has already type-checked, so module resolution is finished before the graph is drawn. Edges that a text tool can only guess at are exact: `tsconfig` path aliases, cross-package references in a pnpm monorepo, symlinks, and barrel re-exports all land on the real declaration. The cost of that exactness is scope, covered in the last section.
+`@ttsc/graph` reads the program `ttsc` has already type-checked, so module resolution is finished before the graph is drawn. Edges that a text tool can only guess at are exact: `tsconfig` path aliases, cross-package references in a pnpm monorepo, symlinks, and barrel re-exports all land on the real declaration.
 
 `codegraph` and `codebase-memory-mcp` build their graphs from a tree-sitter parse. That is what lets them span many languages from one codebase, and it resolves what the syntax makes plain. Edges that depend on module resolution or types are inferred from text, so they can be approximate where an alias, a re-export, or a cross-package hop hides the real target.
 
 `serena` is backed by a language server, so its symbols come out resolved by the same semantic engine an IDE uses, not guessed from text. The difference from `@ttsc/graph` is shape rather than accuracy: an LSP answers symbol-scoped questions (definition, references, implementations) on request, where `@ttsc/graph` hands back a whole resolved graph with an architecture and impact projection in one response.
 
-### Tool surface and instructions
-
-A capable graph is no use if the agent never calls it, and the four tools take very different paths to adoption.
+## Tool surface and instructions
 
 ![A hammer held in the hand next to a hammer bolted where the hand used to be](/blog/images/hammer-tool-vs-prosthesis.png)
 
@@ -80,23 +68,19 @@ Its reasoning is that Claude Code's built-in tool descriptions run about sixteen
 
 `@ttsc/graph` reaches adoption from the other direction: by the shape of the tool, a typed chain of thought inside a single call, rather than the loudness of the prompt. That mechanism is the subject of the [launch post](/blog/i-made-ts-compiler-graph-mcp).
 
-### Setup and freshness
+## Setup and freshness
 
 `@ttsc/graph` has no separate index step or `init` command. Its native compiler session checks the current project snapshot before each graph operation. Unchanged calls reuse the warm in-memory indexes, source edits reuse tsgo's incremental Program when safe, and config, root-file-set, deletion, or module-resolution changes reload before the tool answers. A refresh failure returns an error rather than the previous graph.
 
 The others build an index first. `codegraph` needs `codegraph init` to construct the graph into a local `.codegraph/` directory, `codebase-memory-mcp` needs `index_repository` (and auto-indexing turned on if you want it kept current), and `serena` activates the project and starts a language server, which carries a cold-start before the first answer.
 
-### Language scope
+## Language scope
 
 This is where `@ttsc/graph` gives up the most. It is TypeScript only, because a compiler-exact graph is bound to one compiler. `codegraph` covers 20-plus languages, `serena` 40-plus, and `codebase-memory-mcp` 158. If your work is not in TypeScript, `@ttsc/graph` has nothing to hand over, and one of the others is the right pick.
 
 Inside TypeScript, the trade runs the other way. `@ttsc/graph` spends its narrow scope on depth: a resolved graph and an architecture and impact projection, in one index. It trades breadth for depth on purpose, which is the opposite bet from the multi-language tools.
 
-For how these choices play out in measured token cost, see the [Benchmark](/docs/benchmark/graph). For why `@ttsc/graph` makes them, see the [launch post](/blog/i-made-ts-compiler-graph-mcp).
-
 ## Sources
-
-The claims above are drawn from each tool's own repository and documentation, current as of mid-2026.
 
 - `codegraph`: MCP instruction text and tool guidance in [`src/mcp/server-instructions.ts`](https://github.com/colbymchenry/codegraph/blob/main/src/mcp/server-instructions.ts); project [README](https://github.com/colbymchenry/codegraph) for `codegraph_explore`, the `CODEGRAPH_MCP_TOOLS` gate, tree-sitter extraction, and `codegraph init`.
 - `codebase-memory-mcp`: [repository](https://github.com/DeusData/codebase-memory-mcp) for the fourteen tools (including `query_graph` with its openCypher subset and `get_code_snippet` by qualified name), the install-time skills and hooks written per agent, auto-index defaulting off, and the 158-language tree-sitter coverage.

--- a/website/src/content/docs/graph/index.mdx
+++ b/website/src/content/docs/graph/index.mdx
@@ -3,41 +3,13 @@ import TtscWebsiteGraphViewer3D from "../../../components/graph/TtscWebsiteGraph
 
 # Compiler Knowledge Graph
 
-`@ttsc/graph` gives a coding agent a compiler-resolved graph of your TypeScript project, over MCP.
-
-It runs `ttscgraph`, a native binary that keeps the type-checked project and graph shards resident in memory. Before each graph operation it checks the config, root-file set, module-resolution inputs, and source contents. The first request publishes a complete content-addressed shard manifest. An unchanged project sends no graph payload, a private body edit whose declaration shape is unchanged avoids the reverse-dependency closure, and a changed TypeScript declaration shape expands through that resolved closure. Re-export and implementation-source ownership seams are still rebuilt with their source. Config, file-addition, deletion, or resolution changes trigger a safe reload with explicit shard replacements and deletions. The TypeScript client validates the base generation, shard and generation digests, manifest, fact ownership, and every edge endpoint before it replaces the current graph, so a malformed or interrupted transaction never becomes visible. Every relationship it reports is the current compiler's own answer, not a guess from reading text.
-
-A native snapshot request has no deadline. Indexing time belongs to the size of your repository — the three-million-line VS Code fixture takes 29 seconds cold — and a guessed ceiling would eventually call a valid cold compiler stalled. A request still ends the moment its native process does, and programmatic users can pass an `AbortSignal` to `session.graph({ signal })` to end one deliberately; cancellation terminates that process, clears its pending request, and lets the next call start a fresh session.
-
-## Why an agent needs it
-
-What the graph saves an agent, and what that looks like in tokens.
-
-### The crawl it replaces
+Your coding agent answers from the compiler instead of reading files.
 
 ![A file-by-file source crawl collapsing into a compiler-built graph index](/blog/images/source-crawl-vs-compiler-index.png)
 
-> On the left, the agent is lost in a maze of files, chasing imports dozens deep. On the right, it reads one compiler-built graph of nodes and edges, each with a `file:line` anchor it can open and check.
+Ask an agent how something works and it opens a file, follows an import, opens the next, and repeats. That crawl is most of the token bill, and the relationships it infers are guesses from whatever text it happened to read.
 
-Ask an agent how something works and, without the graph, it reconstructs the picture by hand: open a file, follow an import, open the next, and repeat. That is slow, it spends tokens, and the relationships it infers are guesses from whatever text it happened to read.
-
-The graph hands it the answer up front through one MCP tool, `inspect_typescript_graph`. The agent chooses one request branch per call: `tour`, `overview`, `entrypoints`, `lookup`, `trace`, `details`, or `escape`. The agent stops fanning out across files.
-
-### The token cost
-
-Here is the median token cost on the shared onboarding question, `@ttsc/graph` against no MCP and the three comparators. Lower is better, and it stays flat as the repository grows.
-
-<TtscWebsiteBenchmarkGraphCommon summary />
-
-The [full benchmark](/docs/benchmark/graph) has every model, the per-repository prompts, the structural coverage, and the method.
-
-## What the graph answers
-
-The questions it resolves, and the edges only a compiler gets right.
-
-### Structure, flow, and impact
-
-The graph answers the questions an agent actually asks, all from the same checker-resolved facts:
+One MCP tool, `inspect_typescript_graph`, answers instead. Its replies carry names, signatures, relationships, and source spans, never file bodies, so neither the question nor the answer grows with the repository.
 
 - **How is this project laid out?** Entry points, layers, and the symbols the most code leans on: `overview`.
 - **Give me a code tour.** Central flow, nearby paths, tests, and answer anchors: `tour`.
@@ -46,50 +18,29 @@ The graph answers the questions an agent actually asks, all from the same checke
 - **What is this, exactly?** The declaration shape, its range, its dependencies, and its dependents: `details`.
 - **Which code implements this specification?** The declarations whose documentation cites a document section, an API operation, or a data model: `lookup`, with the target as the query.
 
-When a handle names several declarations, the graph scores every match by export surface and graph use before it caps the response. Equal scores use the declaration's stable graph id, so compiler visitation order cannot hide a stronger match or reshuffle a tie.
+Every node and edge is the compiler's own answer, which is what a text search cannot give you.
 
-In path mode, tracing a symbol to itself is a complete one-node path with no hops. In an open trace, `truncated` means an eligible node or relationship was left out by the depth, node, or hop bound. Reaching the configured depth on a leaf, or seeing only relationships excluded by the selected focus or external-node policy, remains complete.
+- **pnpm workspaces.** A `workspace:*` dependency is followed into the sibling package's real source, so a cross-package call lands on the true declaration rather than the barrel it passed through.
+- **Path aliases.** A `@app/*` import from `tsconfig` resolves to the real file.
+- **Barrel re-exports.** An `index.ts` that only re-exports is unwrapped to the file that declares the symbol.
+- **Your code, not the world.** Anything in `node_modules` or a `.d.ts` is an outside boundary rather than a place to walk into, and generated sources your `.gitignore` covers are de-ranked.
+- **Documentation links.** A `{@link Symbol}` the checker resolves is an edge like any other, and a tag the type system does not recognize is carried as written, so `lookup` answers which declarations cite `docs/pricing.md#sale`.
 
-When path mode finds nothing, it says which of two things happened. A walk that ran the eligible graph out reports that the graph holds no connection between the two ends. A walk that stopped on the requested `maxDepth` with graph still ahead of it reports the bound and how to continue, because a boundary is a fact about the request, not about the code.
+## [Benchmark](/docs/benchmark/graph)
 
-A call that lands on a declaration with no body of its own (an interface member, an abstract method, an ambient declaration) continues into the implementations that run, as a `dispatches` hop cited at the implementation. Bodilessness is read from the declaration, so an implementation that calls nothing is still the code that runs, and a concrete method that has a body is the destination rather than a stop on the way to its own override. Reverse and impact traces cross the same seam the other way, so changing an implementation reaches the declaration it implements and everything that calls that declaration.
+<TtscWebsiteBenchmarkGraphCommon summary />
 
-A tree-sitter graph has no types and resolves edges by guessing from text. An editor's language server has types but no architecture projection. Only a graph built on the real checker holds the resolved structure and the affected set in one place. Every node and edge is resolved by the compiler, so an agent never mistakes inference for fact.
+The median token cost on one shared onboarding question, against no MCP and the three comparators. Lower is better.
 
-### What only the compiler can resolve
+The line stays flat because neither side of the exchange grows with the repository: the agent stops fanning out across files, and the graph answers in names and edges rather than bodies. The comparators swing with repository size because their cost still follows how much source has to be read.
 
-A text search or a tree-sitter parse stops where the syntax stops. A real type checker does not. So these edges are correct where a text tool can only guess:
+Indexing is the other half of the trade. The graph is a byproduct of the type-check the compiler already runs, so the three-million-line VS Code fixture is ready in 29 seconds, where a separate index spends minutes before it can answer anything.
 
-- **pnpm / workspace monorepos.** A `workspace:*` dependency is followed into the sibling package's real source. A call across packages lands on the true declaration, not the barrel it passed through.
-- **Path aliases.** A `@app/*` import from `tsconfig` is resolved to the real file, so the edge is right where a text tool sees only the alias string.
-- **Barrel re-exports.** An `index.ts` that only re-exports is unwrapped to the file that actually declares the symbol.
-- **Your code vs the world.** Anything in `node_modules` or a `.d.ts` is reported as an outside boundary, not walked into. This includes packages whose entry point is raw `.ts`: the compiler may load that source for type checking, but the graph still stops at the imported symbol. The graph stays your code.
-- **Generated code stays out of the way.** A source file your `.gitignore` covers, such as a Prisma client or other codegen emitted as `.ts`, is de-ranked: it never dominates a broad or keyword match, though it stays reachable as an edge target and by its exact name. The graph surfaces what you wrote, not what a generator did.
-- **Object-literal ownership.** `details` lists direct, statically named properties in declaration order. Spread properties do not promote names from another object, dynamic computed names are omitted, and nested members stay with their nested object.
-- **Documentation links are edges.** A `{@link Symbol}` the checker resolves is a reference like any other — an import that exists only to support one survives `noUnusedLocals` — so it is an edge in the graph, under its own `doc_ref` kind. The tag around it decides nothing, and a documentation mention is neither execution nor a type position, so a trace reaches it only under the full focus.
-- **Documentation tags, reported not interpreted.** A declaration answering to something outside the type system says so in a tag — `@evidence docs/pricing.md#sale`, `@reference …`, a convention of your own — and the graph carries the tag as written. `details` returns a declaration's tags; `lookup` takes a target and answers with the declarations citing it, which is the question that otherwise costs a search of the whole repository. The population is the tags TypeScript does not recognize, so no convention is privileged and none is judged: the graph never claims a target resolves, is covered, or is true.
-
-- **What a citation names can be a node too.** A target outside the type system — a document section, a data model field, an API operation — has no TypeScript declaration to point at, so it used to stay a string. A lint plugin that already parses those artifacts can publish them through the `graph-nodes` capability, and the graph indexes what it was handed: one node per artifact, keyed by the address you wrote, carrying the artifact's readable name and the line it starts on, contained by the artifact that contains it. Then `lookup` on `docs/pricing.md#sale` answers with the section itself as well as the declarations citing it, and the citation is an edge rather than a token.
-
-  The graph interprets none of it. It never parses an address — a Markdown anchor, `prisma:Sale.price`, and `POST:/orders` are produced by the parsers that own them — and it never carries what the linter decided: no coverage, no exclusion, no diagnostic. Those are the linter's product and it delivers them as compile errors. Because these facts come from a plugin's own process rather than from the compiler's Program, the dump names a second producer for them, and `provenance.capabilities` lists `artifactNodes` only when the producer actually asked — so "this project publishes none" and "nobody was asked" stay different answers. A project with no such plugin gets the graph it always got.
-
-Source-derived display text is fail-closed. The snapshot manifest covers every source the checker loaded, including outside `.d.ts` boundary leaves and virtual compiler libraries. The server reuses a disk file only when its raw bytes match the disk snapshot and its compiler-decoded text matches the checker snapshot, so UTF-8 BOM and UTF-16 sources keep their display facts without mixing live-disk content into older graph facts. Its line slicing follows the compiler's ECMAScript LF, CRLF, CR, LS, and PS model, so signatures and JSDoc keep the same coordinates under every valid source spelling. A missing digest, read failure, or mismatch omits the optional text.
-
-Graph identities are portable across checkout directories. Project files remain project-relative; sibling and project-reference files use the same `../` coordinate everywhere; package declarations retain their complete resolution path, including pnpm version and peer-context segments; and compiler libraries retain `bundled:///...`. The producer applies this one mapping to nodes, edges, evidence, diagnostics, and provenance, and refuses a cross-drive source or any identity collision before it writes a snapshot.
-
-## Get started
-
-Install, connect an agent, and where to read next.
-
-### Install and connect
-
-`@ttsc/graph` resolves the native binary from the `ttsc` platform package installed in the project it graphs, so install `ttsc` alongside it. When you launch from an unrelated directory and name the project with `--cwd`, the binary is resolved from that target project, not from the launcher's working directory.
+## [Setup](/docs/setup/graph)
 
 ```bash
 npm install -D ttsc @ttsc/graph typescript
 ```
-
-Add the server to your MCP client. For Claude Code, a `.mcp.json` in your project root:
 
 ```json
 {
@@ -102,14 +53,16 @@ Add the server to your MCP client. For Claude Code, a `.mcp.json` in your projec
 }
 ```
 
-Start the agent from your project root so the server finds your `tsconfig.json`, or point it at a project explicitly with `--cwd` and `--tsconfig`. The server never writes into your `CLAUDE.md`, `AGENTS.md`, or any other agent config file, so installing it has no side effects on your repository.
+Start the agent from your project root so the server finds your `tsconfig.json`, or name the project with `--cwd` and `--tsconfig`. The native binary is resolved from the project being graphed, which is why `ttsc` is installed alongside.
 
-Your agent picks the tool up from the MCP handshake and calls it when it needs to. The full setup walk-through is in [Setup → Coding Agents](/docs/setup/graph).
+The server never writes into your `CLAUDE.md`, `AGENTS.md`, or any other agent config, so installing it changes nothing in your repository.
 
-### Where to next
+## [Comparison](/docs/graph/compare)
 
-- [Comparison](/docs/graph/compare): how it differs from codegraph, codebase-memory-mcp, and serena.
-- [Launch post](/blog/i-made-ts-compiler-graph-mcp): the design story, why it is one tool over an index, and where the numbers hold or break down.
-- [3D Viewer](/docs/graph/viewer): browse the whole graph in your browser, or load your own project. Here it is live, the benchmark repositories rendered as navigable graphs; the [viewer page](/docs/graph/viewer) explains the colors and the reduction:
+How it differs from `codegraph`, `codebase-memory-mcp`, and `serena`: the resolution backend, the language scope, the index each one builds, and what that costs in tokens and in time.
+
+## [3D Viewer](/docs/graph/viewer)
+
+The same checker-resolved graph, rendered as a navigable ontology. Pick a benchmark repository or load your own project.
 
 <TtscWebsiteGraphViewer3D compact />

--- a/website/src/content/docs/graph/viewer.mdx
+++ b/website/src/content/docs/graph/viewer.mdx
@@ -4,19 +4,15 @@ import TtscWebsiteGraphViewer3D from "../../../components/graph/TtscWebsiteGraph
 
 The same checker-resolved graph the MCP tools answer from, rendered as a navigable 3D ontology. Every node is a module or a declaration (module, class, interface, function, method, type, enum, variable); every edge is a resolved relationship the compiler reported.
 
-The examples below are the [benchmark](/docs/benchmark/graph) fixture repositories, from VS Code's 6,093 files down to Zod. Pick one, or load a graph from your own project (see the next section). Drag to orbit, scroll to zoom, hover a node for its name, kind, and file.
+The examples below are the [benchmark](/docs/benchmark/graph) fixture repositories, from VS Code down to Zod. Drag to orbit, scroll to zoom, hover a node for its name, kind, and file.
 
-The graph is explorable, not just viewable. Click a node to focus it: its neighborhood lights up, the rest dims, and an info panel shows the declaration, its file, and its edges by family, with an "isolate 2 hops" button that re-lays out just that neighborhood. The explorer sidebar goes further: the Files tab is a directory tree of the graph (click a directory or file to spotlight it, dimming everything else in place), and the Symbols tab finds a declaration by name (picking a result flies the camera to it) and spotlights node kinds and edge families the same way. Nothing you pick removes anything from the view; only the explicit isolate does.
+Click a node to focus it: its neighborhood lights up, the rest dims, and an info panel shows the declaration, its file, and its edges by family, with an "isolate 2 hops" button that re-lays out just that neighborhood.
+
+The explorer sidebar goes further. The Files tab is a directory tree of the graph, and the Symbols tab finds a declaration by name and flies the camera to it. Both spotlight in place rather than removing anything, and only the explicit isolate changes what is drawn.
 
 <TtscWebsiteGraphViewer3D />
 
-## Use it on your own project
-
-Run the viewer on your code, or export the raw graph.
-
-### Run the viewer
-
-Run the viewer locally:
+## Run the viewer
 
 ```bash
 npx @ttsc/graph view
@@ -24,13 +20,9 @@ npx @ttsc/graph view
 
 `view` builds your project's graph, reduces it, and opens this viewer in your browser from a local port. Nothing leaves your machine.
 
-It resolves the project from the working directory and `tsconfig.json` by default; `--cwd`, `--tsconfig`, `--port`, `--max-nodes`, and `--no-open` override that. `--port` accepts an integer from 0 through 65,535, and `--max-nodes` accepts a positive integer. A missing, malformed, or unknown option stops before the graph is built. Like the MCP server, it needs `ttsc` installed so the native `ttscgraph` binary is present. Before starting the server, `view` rejects a dump whose schema or structure does not match the installed `@ttsc/graph`; a schema mismatch reports both versions and explains how to select a matching binary.
+It resolves the project from the working directory and `tsconfig.json`, and `--cwd`, `--tsconfig`, `--port`, `--max-nodes`, and `--no-open` override that. Like the MCP server, it needs `ttsc` installed so the native `ttscgraph` binary is present.
 
-If the requested port cannot be bound, the command reports the endpoint and operating-system error, then exits non-zero.
-
-### Export the graph as JSON
-
-For the data as a file instead:
+## Export the graph as JSON
 
 ```bash
 npx @ttsc/graph dump --tsconfig tsconfig.json > graph.json
@@ -38,13 +30,9 @@ npx @ttsc/graph dump --tsconfig tsconfig.json > graph.json
 
 `dump` prints the whole graph as JSON: every node and edge the build resolved, with none of the per-response caps the MCP tool applies. It is the same export the MCP server loads at startup, so what you dump is exactly what the agent queries.
 
-That file is what "Load your own JSON" above accepts. The viewer reduces it client-side before rendering (the exact reduction is in [What is left out](#what-is-left-out)) so a large project stays legible. Current dumps preserve their portable project and sibling-relative structure; legacy payloads passed directly to the reducer that contain absolute paths are rerooted at their shared source directory. The viewer also takes an already-reduced payload, so a graph you trimmed yourself loads as-is.
+That file is what "Load your own JSON" above accepts. The viewer reduces it client-side before rendering, by the rules in [What is left out](#what-is-left-out), and takes an already-reduced payload as-is.
 
-## Reading the graph
-
-What the colors and sizes mean, and what the viewer leaves out.
-
-### What the colors mean
+## What the colors mean
 
 Nodes are colored by declaration kind and sized by how many other declarations connect to them, so the load-bearing symbols stand out.
 
@@ -58,7 +46,7 @@ Edges are colored by family. The graph itself distinguishes finer relationship k
 
 Every kind a dump carries folds onto one of those five, so no edge is drawn without a name beside it.
 
-### What is left out
+## What is left out
 
 The viewer is a projection, not the whole graph. Reduction happens before rendering (in the browser for an uploaded dump, in Node for `view`), in this order:
 


### PR DESCRIPTION
The same pass the evidence chapter got, applied to `@ttsc/graph`.

- **Overview** drops the resident-session, shard-manifest, and fail-closed internals it opened with, and links Benchmark, Setup, Comparison, and 3D Viewer from their own headings.
- **Comparison** and **3D Viewer** lose the scaffolding headings that only held subsections, and the sentences that announced what came next.
- The **README** opens on what the tool does rather than on its own numbers. Its contract block keeps the interface and its namespace types; only the leading JSDoc is cut to its first section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)