### PR TITLE
fix(unplugin): finish the membership policy, and discharge the last cycle's obligations

### DIFF
--- a/packages/lint/linthost/rules_imports.go
+++ b/packages/lint/linthost/rules_imports.go
@@ -1,8 +1,8 @@
 package linthost
 
 import (
-	shimast "github.com/microsoft/typescript-go/shim/ast"
-	shimscanner "github.com/microsoft/typescript-go/shim/scanner"
+  shimast "github.com/microsoft/typescript-go/shim/ast"
+  shimscanner "github.com/microsoft/typescript-go/shim/scanner"
 )
 
 // noImportTypeSideEffects: an import whose every named specifier
@@ -14,92 +14,92 @@ type noImportTypeSideEffects struct{}
 
 func (noImportTypeSideEffects) Name() string { return "typescript/no-import-type-side-effects" }
 func (noImportTypeSideEffects) Visits() []shimast.Kind {
-	return []shimast.Kind{shimast.KindImportDeclaration}
+  return []shimast.Kind{shimast.KindImportDeclaration}
 }
 func (noImportTypeSideEffects) Check(ctx *Context, node *shimast.Node) {
-	decl := node.AsImportDeclaration()
-	if decl == nil || decl.ImportClause == nil {
-		return
-	}
-	clause := decl.ImportClause.AsImportClause()
-	if clause == nil {
-		return
-	}
-	// `import type { … }` already hoists the modifier; nothing to do.
-	if clause.PhaseModifier == shimast.KindTypeKeyword {
-		return
-	}
-	// The rule only applies to named imports; default imports cannot
-	// carry an inline `type` modifier.
-	if clause.NamedBindings == nil || clause.NamedBindings.Kind != shimast.KindNamedImports {
-		return
-	}
-	// A clause with a default binding alongside named imports is a
-	// mixed import; hoisting `type` would change semantics for the
-	// default. Skip.
-	if clause.Name() != nil {
-		return
-	}
-	named := clause.NamedBindings.AsNamedImports()
-	if named == nil || named.Elements == nil || len(named.Elements.Nodes) == 0 {
-		return
-	}
-	for _, spec := range named.Elements.Nodes {
-		s := spec.AsImportSpecifier()
-		if s == nil || !s.IsTypeOnly {
-			return
-		}
-	}
-	message := "Use top-level `import type` instead of marking every specifier individually."
-	// Compute edits: insert ` type` after the leading `import` keyword,
-	// then delete each specifier's `type ` prefix. All edits must be
-	// non-overlapping; the keyword insertion is at offset 6 (after
-	// `import`), and each specifier-level delete is strictly inside the
-	// braces, so they never overlap.
-	// Anchor the `import` keyword at the first real token, not at
-	// node.Pos() which points into leading trivia. A raw findKeyword scan
-	// from node.Pos() would match the word `import` inside a leading
-	// comment (`// re-import below`) and insert ` type` into the comment,
-	// while the specifier loop still strips each `type ` — silently
-	// turning the type-only imports back into value imports. keywordStart
-	// mirrors the prefer-namespace-keyword pattern: SkipTrivia past
-	// comments/whitespace, then match the keyword at the token boundary.
-	importKwStart := keywordStart(ctx.File, node, "import")
-	if importKwStart < 0 {
-		ctx.Report(node, message)
-		return
-	}
-	importKwEnd := importKwStart + len("import")
-	edits := []TextEdit{
-		{Pos: importKwEnd, End: importKwEnd, Text: " type"},
-	}
-	src := ctx.File.Text()
-	for _, spec := range named.Elements.Nodes {
-		// Locate the `type` keyword token at the head of each specifier by
-		// skipping leading trivia (whitespace + comments). A naive
-		// findKeyword scan would risk matching `type` inside a block comment
-		// such as `/* type alias */`, corrupting the source. SkipTrivia
-		// anchors the scan at the actual first token byte.
-		typePos := shimscanner.SkipTrivia(src, spec.Pos())
-		if typePos < 0 || typePos+len("type") > len(src) {
-			continue
-		}
-		if src[typePos:typePos+len("type")] != "type" {
-			continue
-		}
-		after := typePos + len("type")
-		// Defensive: ensure the keyword is followed by a non-identifier byte
-		// — otherwise we'd be matching an identifier prefix like `typeOf`.
-		if after < len(src) && isIdentifierPart(src[after]) {
-			continue
-		}
-		deleteEnd := after
-		if deleteEnd < len(src) && (src[deleteEnd] == ' ' || src[deleteEnd] == '\t') {
-			deleteEnd++
-		}
-		edits = append(edits, TextEdit{Pos: typePos, End: deleteEnd, Text: ""})
-	}
-	ctx.ReportFix(node, message, edits...)
+  decl := node.AsImportDeclaration()
+  if decl == nil || decl.ImportClause == nil {
+    return
+  }
+  clause := decl.ImportClause.AsImportClause()
+  if clause == nil {
+    return
+  }
+  // `import type { … }` already hoists the modifier; nothing to do.
+  if clause.PhaseModifier == shimast.KindTypeKeyword {
+    return
+  }
+  // The rule only applies to named imports; default imports cannot
+  // carry an inline `type` modifier.
+  if clause.NamedBindings == nil || clause.NamedBindings.Kind != shimast.KindNamedImports {
+    return
+  }
+  // A clause with a default binding alongside named imports is a
+  // mixed import; hoisting `type` would change semantics for the
+  // default. Skip.
+  if clause.Name() != nil {
+    return
+  }
+  named := clause.NamedBindings.AsNamedImports()
+  if named == nil || named.Elements == nil || len(named.Elements.Nodes) == 0 {
+    return
+  }
+  for _, spec := range named.Elements.Nodes {
+    s := spec.AsImportSpecifier()
+    if s == nil || !s.IsTypeOnly {
+      return
+    }
+  }
+  message := "Use top-level `import type` instead of marking every specifier individually."
+  // Compute edits: insert ` type` after the leading `import` keyword,
+  // then delete each specifier's `type ` prefix. All edits must be
+  // non-overlapping; the keyword insertion is at offset 6 (after
+  // `import`), and each specifier-level delete is strictly inside the
+  // braces, so they never overlap.
+  // Anchor the `import` keyword at the first real token, not at
+  // node.Pos() which points into leading trivia. A raw findKeyword scan
+  // from node.Pos() would match the word `import` inside a leading
+  // comment (`// re-import below`) and insert ` type` into the comment,
+  // while the specifier loop still strips each `type ` — silently
+  // turning the type-only imports back into value imports. keywordStart
+  // mirrors the prefer-namespace-keyword pattern: SkipTrivia past
+  // comments/whitespace, then match the keyword at the token boundary.
+  importKwStart := keywordStart(ctx.File, node, "import")
+  if importKwStart < 0 {
+    ctx.Report(node, message)
+    return
+  }
+  importKwEnd := importKwStart + len("import")
+  edits := []TextEdit{
+    {Pos: importKwEnd, End: importKwEnd, Text: " type"},
+  }
+  src := ctx.File.Text()
+  for _, spec := range named.Elements.Nodes {
+    // Locate the `type` keyword token at the head of each specifier by
+    // skipping leading trivia (whitespace + comments). A naive
+    // findKeyword scan would risk matching `type` inside a block comment
+    // such as `/* type alias */`, corrupting the source. SkipTrivia
+    // anchors the scan at the actual first token byte.
+    typePos := shimscanner.SkipTrivia(src, spec.Pos())
+    if typePos < 0 || typePos+len("type") > len(src) {
+      continue
+    }
+    if src[typePos:typePos+len("type")] != "type" {
+      continue
+    }
+    after := typePos + len("type")
+    // Defensive: ensure the keyword is followed by a non-identifier byte
+    // — otherwise we'd be matching an identifier prefix like `typeOf`.
+    if after < len(src) && isIdentifierPart(src[after]) {
+      continue
+    }
+    deleteEnd := after
+    if deleteEnd < len(src) && (src[deleteEnd] == ' ' || src[deleteEnd] == '\t') {
+      deleteEnd++
+    }
+    edits = append(edits, TextEdit{Pos: typePos, End: deleteEnd, Text: ""})
+  }
+  ctx.ReportFix(node, message, edits...)
 }
 
 // noUselessEmptyExport: `export {}` is only useful as a module marker.
@@ -109,67 +109,67 @@ type noUselessEmptyExport struct{}
 
 func (noUselessEmptyExport) Name() string { return "typescript/no-useless-empty-export" }
 func (noUselessEmptyExport) Visits() []shimast.Kind {
-	return []shimast.Kind{shimast.KindSourceFile, shimast.KindModuleBlock}
+  return []shimast.Kind{shimast.KindSourceFile, shimast.KindModuleBlock}
 }
 func (noUselessEmptyExport) Check(ctx *Context, node *shimast.Node) {
-	if ctx.File != nil && ctx.File.IsDeclarationFile {
-		return
-	}
-	statements := node.Statements()
-	if len(statements) == 0 {
-		return
-	}
-	emptyExports := []*shimast.Node{}
-	foundOtherModuleSyntax := false
-	for _, stmt := range statements {
-		if stmt == nil {
-			continue
-		}
-		if isEmptyExportDeclaration(stmt) {
-			emptyExports = append(emptyExports, stmt)
-			continue
-		}
-		if isModuleSyntaxStatement(stmt) {
-			foundOtherModuleSyntax = true
-		}
-	}
-	if !foundOtherModuleSyntax {
-		return
-	}
-	for _, stmt := range emptyExports {
-		ctx.Report(stmt, "Empty export does not change module-ness here.")
-	}
+  if ctx.File != nil && ctx.File.IsDeclarationFile {
+    return
+  }
+  statements := node.Statements()
+  if len(statements) == 0 {
+    return
+  }
+  emptyExports := []*shimast.Node{}
+  foundOtherModuleSyntax := false
+  for _, stmt := range statements {
+    if stmt == nil {
+      continue
+    }
+    if isEmptyExportDeclaration(stmt) {
+      emptyExports = append(emptyExports, stmt)
+      continue
+    }
+    if isModuleSyntaxStatement(stmt) {
+      foundOtherModuleSyntax = true
+    }
+  }
+  if !foundOtherModuleSyntax {
+    return
+  }
+  for _, stmt := range emptyExports {
+    ctx.Report(stmt, "Empty export does not change module-ness here.")
+  }
 }
 
 func isEmptyExportDeclaration(node *shimast.Node) bool {
-	if node == nil || node.Kind != shimast.KindExportDeclaration {
-		return false
-	}
-	decl := node.AsExportDeclaration()
-	if decl == nil || decl.ExportClause == nil || decl.ModuleSpecifier != nil {
-		return false
-	}
-	if decl.ExportClause.Kind != shimast.KindNamedExports {
-		return false
-	}
-	named := decl.ExportClause.AsNamedExports()
-	return named != nil && (named.Elements == nil || len(named.Elements.Nodes) == 0)
+  if node == nil || node.Kind != shimast.KindExportDeclaration {
+    return false
+  }
+  decl := node.AsExportDeclaration()
+  if decl == nil || decl.ExportClause == nil || decl.ModuleSpecifier != nil {
+    return false
+  }
+  if decl.ExportClause.Kind != shimast.KindNamedExports {
+    return false
+  }
+  named := decl.ExportClause.AsNamedExports()
+  return named != nil && (named.Elements == nil || len(named.Elements.Nodes) == 0)
 }
 
 func isModuleSyntaxStatement(node *shimast.Node) bool {
-	if node == nil {
-		return false
-	}
-	switch node.Kind {
-	case shimast.KindImportDeclaration, shimast.KindImportEqualsDeclaration, shimast.KindExportAssignment:
-		return true
-	case shimast.KindExportDeclaration:
-		return !isEmptyExportDeclaration(node)
-	}
-	return hasModifier(node, shimast.KindExportKeyword)
+  if node == nil {
+    return false
+  }
+  switch node.Kind {
+  case shimast.KindImportDeclaration, shimast.KindImportEqualsDeclaration, shimast.KindExportAssignment:
+    return true
+  case shimast.KindExportDeclaration:
+    return !isEmptyExportDeclaration(node)
+  }
+  return hasModifier(node, shimast.KindExportKeyword)
 }
 
 func init() {
-	Register(noImportTypeSideEffects{})
-	Register(noUselessEmptyExport{})
+  Register(noImportTypeSideEffects{})
+  Register(noUselessEmptyExport{})
 }

--- a/packages/lint/linthost/rules_imports.go
+++ b/packages/lint/linthost/rules_imports.go
@@ -1,8 +1,8 @@
 package linthost
 
 import (
-  shimast "github.com/microsoft/typescript-go/shim/ast"
-  shimscanner "github.com/microsoft/typescript-go/shim/scanner"
+	shimast "github.com/microsoft/typescript-go/shim/ast"
+	shimscanner "github.com/microsoft/typescript-go/shim/scanner"
 )
 
 // noImportTypeSideEffects: an import whose every named specifier
@@ -14,92 +14,92 @@ type noImportTypeSideEffects struct{}
 
 func (noImportTypeSideEffects) Name() string { return "typescript/no-import-type-side-effects" }
 func (noImportTypeSideEffects) Visits() []shimast.Kind {
-  return []shimast.Kind{shimast.KindImportDeclaration}
+	return []shimast.Kind{shimast.KindImportDeclaration}
 }
 func (noImportTypeSideEffects) Check(ctx *Context, node *shimast.Node) {
-  decl := node.AsImportDeclaration()
-  if decl == nil || decl.ImportClause == nil {
-    return
-  }
-  clause := decl.ImportClause.AsImportClause()
-  if clause == nil {
-    return
-  }
-  // `import type { … }` already hoists the modifier; nothing to do.
-  if clause.PhaseModifier == shimast.KindTypeKeyword {
-    return
-  }
-  // The rule only applies to named imports; default imports cannot
-  // carry an inline `type` modifier.
-  if clause.NamedBindings == nil || clause.NamedBindings.Kind != shimast.KindNamedImports {
-    return
-  }
-  // A clause with a default binding alongside named imports is a
-  // mixed import; hoisting `type` would change semantics for the
-  // default. Skip.
-  if clause.Name() != nil {
-    return
-  }
-  named := clause.NamedBindings.AsNamedImports()
-  if named == nil || named.Elements == nil || len(named.Elements.Nodes) == 0 {
-    return
-  }
-  for _, spec := range named.Elements.Nodes {
-    s := spec.AsImportSpecifier()
-    if s == nil || !s.IsTypeOnly {
-      return
-    }
-  }
-  message := "Use top-level `import type` instead of marking every specifier individually."
-  // Compute edits: insert ` type` after the leading `import` keyword,
-  // then delete each specifier's `type ` prefix. All edits must be
-  // non-overlapping; the keyword insertion is at offset 6 (after
-  // `import`), and each specifier-level delete is strictly inside the
-  // braces, so they never overlap.
-  // Anchor the `import` keyword at the first real token, not at
-  // node.Pos() which points into leading trivia. A raw findKeyword scan
-  // from node.Pos() would match the word `import` inside a leading
-  // comment (`// re-import below`) and insert ` type` into the comment,
-  // while the specifier loop still strips each `type ` — silently
-  // turning the type-only imports back into value imports. keywordStart
-  // mirrors the prefer-namespace-keyword pattern: SkipTrivia past
-  // comments/whitespace, then match the keyword at the token boundary.
-  importKwStart := keywordStart(ctx.File, node, "import")
-  if importKwStart < 0 {
-    ctx.Report(node, message)
-    return
-  }
-  importKwEnd := importKwStart + len("import")
-  edits := []TextEdit{
-    {Pos: importKwEnd, End: importKwEnd, Text: " type"},
-  }
-  src := ctx.File.Text()
-  for _, spec := range named.Elements.Nodes {
-    // Locate the `type` keyword token at the head of each specifier by
-    // skipping leading trivia (whitespace + comments). A naive
-    // findKeyword scan would risk matching `type` inside a block comment
-    // such as `/* type alias */`, corrupting the source. SkipTrivia
-    // anchors the scan at the actual first token byte.
-    typePos := shimscanner.SkipTrivia(src, spec.Pos())
-    if typePos < 0 || typePos+len("type") > len(src) {
-      continue
-    }
-    if src[typePos:typePos+len("type")] != "type" {
-      continue
-    }
-    after := typePos + len("type")
-    // Defensive: ensure the keyword is followed by a non-identifier byte
-    // — otherwise we'd be matching an identifier prefix like `typeOf`.
-    if after < len(src) && isIdentifierPart(src[after]) {
-      continue
-    }
-    deleteEnd := after
-    if deleteEnd < len(src) && (src[deleteEnd] == ' ' || src[deleteEnd] == '\t') {
-      deleteEnd++
-    }
-    edits = append(edits, TextEdit{Pos: typePos, End: deleteEnd, Text: ""})
-  }
-  ctx.ReportFix(node, message, edits...)
+	decl := node.AsImportDeclaration()
+	if decl == nil || decl.ImportClause == nil {
+		return
+	}
+	clause := decl.ImportClause.AsImportClause()
+	if clause == nil {
+		return
+	}
+	// `import type { … }` already hoists the modifier; nothing to do.
+	if clause.PhaseModifier == shimast.KindTypeKeyword {
+		return
+	}
+	// The rule only applies to named imports; default imports cannot
+	// carry an inline `type` modifier.
+	if clause.NamedBindings == nil || clause.NamedBindings.Kind != shimast.KindNamedImports {
+		return
+	}
+	// A clause with a default binding alongside named imports is a
+	// mixed import; hoisting `type` would change semantics for the
+	// default. Skip.
+	if clause.Name() != nil {
+		return
+	}
+	named := clause.NamedBindings.AsNamedImports()
+	if named == nil || named.Elements == nil || len(named.Elements.Nodes) == 0 {
+		return
+	}
+	for _, spec := range named.Elements.Nodes {
+		s := spec.AsImportSpecifier()
+		if s == nil || !s.IsTypeOnly {
+			return
+		}
+	}
+	message := "Use top-level `import type` instead of marking every specifier individually."
+	// Compute edits: insert ` type` after the leading `import` keyword,
+	// then delete each specifier's `type ` prefix. All edits must be
+	// non-overlapping; the keyword insertion is at offset 6 (after
+	// `import`), and each specifier-level delete is strictly inside the
+	// braces, so they never overlap.
+	// Anchor the `import` keyword at the first real token, not at
+	// node.Pos() which points into leading trivia. A raw findKeyword scan
+	// from node.Pos() would match the word `import` inside a leading
+	// comment (`// re-import below`) and insert ` type` into the comment,
+	// while the specifier loop still strips each `type ` — silently
+	// turning the type-only imports back into value imports. keywordStart
+	// mirrors the prefer-namespace-keyword pattern: SkipTrivia past
+	// comments/whitespace, then match the keyword at the token boundary.
+	importKwStart := keywordStart(ctx.File, node, "import")
+	if importKwStart < 0 {
+		ctx.Report(node, message)
+		return
+	}
+	importKwEnd := importKwStart + len("import")
+	edits := []TextEdit{
+		{Pos: importKwEnd, End: importKwEnd, Text: " type"},
+	}
+	src := ctx.File.Text()
+	for _, spec := range named.Elements.Nodes {
+		// Locate the `type` keyword token at the head of each specifier by
+		// skipping leading trivia (whitespace + comments). A naive
+		// findKeyword scan would risk matching `type` inside a block comment
+		// such as `/* type alias */`, corrupting the source. SkipTrivia
+		// anchors the scan at the actual first token byte.
+		typePos := shimscanner.SkipTrivia(src, spec.Pos())
+		if typePos < 0 || typePos+len("type") > len(src) {
+			continue
+		}
+		if src[typePos:typePos+len("type")] != "type" {
+			continue
+		}
+		after := typePos + len("type")
+		// Defensive: ensure the keyword is followed by a non-identifier byte
+		// — otherwise we'd be matching an identifier prefix like `typeOf`.
+		if after < len(src) && isIdentifierPart(src[after]) {
+			continue
+		}
+		deleteEnd := after
+		if deleteEnd < len(src) && (src[deleteEnd] == ' ' || src[deleteEnd] == '\t') {
+			deleteEnd++
+		}
+		edits = append(edits, TextEdit{Pos: typePos, End: deleteEnd, Text: ""})
+	}
+	ctx.ReportFix(node, message, edits...)
 }
 
 // noUselessEmptyExport: `export {}` is only useful as a module marker.
@@ -109,67 +109,67 @@ type noUselessEmptyExport struct{}
 
 func (noUselessEmptyExport) Name() string { return "typescript/no-useless-empty-export" }
 func (noUselessEmptyExport) Visits() []shimast.Kind {
-  return []shimast.Kind{shimast.KindSourceFile, shimast.KindModuleBlock}
+	return []shimast.Kind{shimast.KindSourceFile, shimast.KindModuleBlock}
 }
 func (noUselessEmptyExport) Check(ctx *Context, node *shimast.Node) {
-  if ctx.File != nil && ctx.File.IsDeclarationFile {
-    return
-  }
-  statements := node.Statements()
-  if len(statements) == 0 {
-    return
-  }
-  emptyExports := []*shimast.Node{}
-  foundOtherModuleSyntax := false
-  for _, stmt := range statements {
-    if stmt == nil {
-      continue
-    }
-    if isEmptyExportDeclaration(stmt) {
-      emptyExports = append(emptyExports, stmt)
-      continue
-    }
-    if isModuleSyntaxStatement(stmt) {
-      foundOtherModuleSyntax = true
-    }
-  }
-  if !foundOtherModuleSyntax {
-    return
-  }
-  for _, stmt := range emptyExports {
-    ctx.Report(stmt, "Empty export does not change module-ness here.")
-  }
+	if ctx.File != nil && ctx.File.IsDeclarationFile {
+		return
+	}
+	statements := node.Statements()
+	if len(statements) == 0 {
+		return
+	}
+	emptyExports := []*shimast.Node{}
+	foundOtherModuleSyntax := false
+	for _, stmt := range statements {
+		if stmt == nil {
+			continue
+		}
+		if isEmptyExportDeclaration(stmt) {
+			emptyExports = append(emptyExports, stmt)
+			continue
+		}
+		if isModuleSyntaxStatement(stmt) {
+			foundOtherModuleSyntax = true
+		}
+	}
+	if !foundOtherModuleSyntax {
+		return
+	}
+	for _, stmt := range emptyExports {
+		ctx.Report(stmt, "Empty export does not change module-ness here.")
+	}
 }
 
 func isEmptyExportDeclaration(node *shimast.Node) bool {
-  if node == nil || node.Kind != shimast.KindExportDeclaration {
-    return false
-  }
-  decl := node.AsExportDeclaration()
-  if decl == nil || decl.ExportClause == nil || decl.ModuleSpecifier != nil {
-    return false
-  }
-  if decl.ExportClause.Kind != shimast.KindNamedExports {
-    return false
-  }
-  named := decl.ExportClause.AsNamedExports()
-  return named != nil && (named.Elements == nil || len(named.Elements.Nodes) == 0)
+	if node == nil || node.Kind != shimast.KindExportDeclaration {
+		return false
+	}
+	decl := node.AsExportDeclaration()
+	if decl == nil || decl.ExportClause == nil || decl.ModuleSpecifier != nil {
+		return false
+	}
+	if decl.ExportClause.Kind != shimast.KindNamedExports {
+		return false
+	}
+	named := decl.ExportClause.AsNamedExports()
+	return named != nil && (named.Elements == nil || len(named.Elements.Nodes) == 0)
 }
 
 func isModuleSyntaxStatement(node *shimast.Node) bool {
-  if node == nil {
-    return false
-  }
-  switch node.Kind {
-  case shimast.KindImportDeclaration, shimast.KindImportEqualsDeclaration, shimast.KindExportAssignment:
-    return true
-  case shimast.KindExportDeclaration:
-    return !isEmptyExportDeclaration(node)
-  }
-  return hasModifier(node, shimast.KindExportKeyword)
+	if node == nil {
+		return false
+	}
+	switch node.Kind {
+	case shimast.KindImportDeclaration, shimast.KindImportEqualsDeclaration, shimast.KindExportAssignment:
+		return true
+	case shimast.KindExportDeclaration:
+		return !isEmptyExportDeclaration(node)
+	}
+	return hasModifier(node, shimast.KindExportKeyword)
 }
 
 func init() {
-  Register(noImportTypeSideEffects{})
-  Register(noUselessEmptyExport{})
+	Register(noImportTypeSideEffects{})
+	Register(noUselessEmptyExport{})
 }

--- a/packages/metro/README.md
+++ b/packages/metro/README.md
@@ -74,6 +74,22 @@ For each TypeScript file Metro asks to transform:
 
 The plugin contract and `tsconfig` discovery match the Unplugin integrations. Metro's worker has no build-start callback, so its shared transform cache validates the complete project snapshot on every hit instead of using a build-scoped first-delivery shortcut.
 
+### Files outside the program
+
+Metro resolves its own module graph, and that graph is not the set of files your `tsconfig` describes. A file Metro delivers that the compiled program does not contain is passed to the upstream transformer untransformed, and reported once per pass naming the file and the `tsconfig` it is missing from:
+
+```
+ttsc: /app/scripts/tool.ts is not part of the program described by /app/tsconfig.json,
+so it was left untransformed. Add it to that project's "include" if ttsc plugins
+should apply to it.
+```
+
+This is not a build error. The file is simply not this project's to transform, and the usual cause is a Metro graph reaching past the `tsconfig`'s `include` — a source beside `src` rather than inside it, or one in a sibling workspace folder. Add it to that project's `include` if `ttsc` plugins should apply to it.
+
+The report matters because passing through is not the same as leaving alone: a file that skips the `ttsc` pass keeps whatever plugin-driven syntax it carries, which fails at runtime rather than at build time. Declaration and JavaScript files never reach the pass at all, so they are not reported; they are filtered before it, as `include` / `exclude` above describes.
+
+This is the shared core's answer rather than Metro's own, so every `@ttsc/unplugin` adapter gives the identical one. `@ttsc/metro` used to be alone in treating it as non-fatal while every adapter failed the build.
+
 ## Cache invalidation
 
 Metro keys its transform cache on each file's own content plus one static transformer key, and its babel-transformer contract has no per-file dependency registration. A `ttsc` transform can depend on a _type_ in another file, so `@ttsc/metro` folds a project fingerprint into that static key: every regular file reached by the non-following project walk, plus reference-graph inputs outside that walk (`node_modules` declarations, monorepo sibling sources, files reached through symlinks or Windows junctions, and out-of-root tsconfig `extends` ancestry) recorded under `node_modules/.cache/ttsc-metro`. Editing any of them re-keys the next run, so `metro bundle` and dev-server starts pick up cross-file type changes without `--reset-cache`.

--- a/packages/metro/README.md
+++ b/packages/metro/README.md
@@ -76,7 +76,7 @@ The plugin contract and `tsconfig` discovery match the Unplugin integrations. Me
 
 ### Files outside the program
 
-Metro resolves its own module graph, and that graph is not the set of files your `tsconfig` describes. A file Metro delivers that the compiled program does not contain is passed to the upstream transformer untransformed, and reported once per pass naming the file and the `tsconfig` it is missing from:
+Metro resolves its own module graph, and that graph is not the set of files your `tsconfig` describes. A file Metro delivers that the compiled program does not contain is passed to the upstream transformer untransformed, and reported naming the file and the `tsconfig` it is missing from — once per file per compile in each Metro worker, since a Metro worker has no build boundary to reset the report at:
 
 ```
 ttsc: /app/scripts/tool.ts is not part of the program described by /app/tsconfig.json,

--- a/packages/metro/src/core/fingerprint.ts
+++ b/packages/metro/src/core/fingerprint.ts
@@ -151,23 +151,47 @@ export function fingerprintRoots(
 }
 
 /**
- * The membership policy for one transform, resolved once and handed to every
- * watch input that transform reports.
+ * One project, and the membership policy that describes it.
+ *
+ * The recorder's question is whether the project walk already covers an input,
+ * so it needs both the walk's roots and the policy that walk used, and it is
+ * wrong exactly when those two describe different projects. Passing them
+ * separately made that mismatch expressible — the policy for one project
+ * alongside the root of another — and passing the policy alone made it
+ * expressible in a quieter way still, since a recorder that resolved its own
+ * could describe a different program than the walk hashed. Both halves travel
+ * together so neither can be supplied without the other (samchon/ttsc#1316).
+ */
+export interface TtscMetroProjectView {
+  /** The base directory both fingerprint sides agree on. */
+  readonly base: string;
+  /** The caller's explicit `project`, if any. */
+  readonly explicitProject: string | undefined;
+  /** The membership policy resolved for that project. */
+  readonly policy: ReturnType<typeof readProjectMembershipPolicy>;
+}
+
+/**
+ * Resolve one transform's project view, once, for every watch input it reports.
  *
  * Exported because the recorder is asked once per input while the answer is a
  * property of the project, and validating the memo means stat-ing the whole
  * `extends` chain (samchon/ttsc#1316).
  */
-export function resolveMembershipPolicy(props: {
+export function resolveProjectView(props: {
   compilerOptions?: Record<string, unknown>;
   explicitProject?: string;
   projectRoot?: string;
-}): ReturnType<typeof readProjectMembershipPolicy> {
+}): TtscMetroProjectView {
   const base = resolveFingerprintBase(props.projectRoot);
-  return membershipPolicy(
-    resolveProjectTsconfig(base, props.explicitProject),
-    props.compilerOptions,
-  );
+  return {
+    base,
+    explicitProject: props.explicitProject,
+    policy: membershipPolicy(
+      resolveProjectTsconfig(base, props.explicitProject),
+      props.compilerOptions,
+    ),
+  };
 }
 
 /**
@@ -312,7 +336,7 @@ export function computeProjectFingerprint(props: {
     // overlay while the recorder resolves with it leaves an overlay-admitted
     // input in neither half, which is the both-sides-disagree hole in its
     // quietest form (samchon/ttsc#1316).
-    const policy = resolveMembershipPolicy({
+    const project = resolveProjectView({
       compilerOptions: props.compilerOptions,
       explicitProject: props.explicitProject,
       projectRoot: props.projectRoot,
@@ -320,7 +344,7 @@ export function computeProjectFingerprint(props: {
     for (const root of fingerprintRoots(base, props.explicitProject)) {
       hash.update(
         stableStringify(
-          collectProjectInputHashes(root, undefined, undefined, policy),
+          collectProjectInputHashes(root, undefined, undefined, project.policy),
         ),
       );
     }
@@ -528,34 +552,29 @@ export function readSnapshotState(base: string): SnapshotState | undefined {
  */
 export function createSnapshotRecorder(): {
   record: (props: {
-    explicitProject?: string;
     input: string;
     /**
-     * The policy the walk of this same project uses, resolved once per
-     * transform through {@link resolveMembershipPolicy}.
+     * The project this input belongs to, with the policy its walk uses,
+     * resolved once per transform through {@link resolveProjectView}.
      *
-     * Required rather than defaulted, because the recorder's only question is
-     * whether the walk already covers this input. A policy the recorder derived
-     * on its own could describe a different program than the walk actually
-     * hashed — that is exactly what happened when the overlay reached one half
-     * and not the other — and the input would then be covered by neither.
-     * Demanding it from the caller keeps the disagreement unrepresentable
-     * instead of merely absent.
+     * One value rather than a root and a policy side by side, because the
+     * recorder is wrong precisely when those two describe different projects.
+     * Deriving the policy here instead would be the same fault in a quieter
+     * form: a recorder that resolved its own could describe a different program
+     * than the walk hashed, which is what happened when the caller's
+     * compiler-options overlay reached one half and not the other, and the
+     * input was then covered by neither (samchon/ttsc#1316).
      *
-     * It is hoisted for cost as well: `record` runs once per watch input rather
-     * than once per file, and validating the memo means stat-ing the whole
-     * `extends` chain, measured at 12 microseconds per stat — a few thousand
-     * modules times fifteen inputs each cost over half a second per run for an
-     * answer that cannot change between two inputs of one file
-     * (samchon/ttsc#1316).
+     * Resolving it once per transform is also what makes it affordable.
+     * `record` runs once per watch input rather than once per file, and
+     * validating the memo means stat-ing the whole `extends` chain, measured at
+     * 12 microseconds per stat — a few thousand modules times fifteen inputs
+     * each cost over half a second per run for an answer that cannot change
+     * between two inputs of one file.
      */
-    policy: ReturnType<typeof readProjectMembershipPolicy>;
-    projectRoot?: string;
+    project: TtscMetroProjectView;
   }) => void;
-  recordVolatile: (props: {
-    explicitProject?: string;
-    projectRoot?: string;
-  }) => void;
+  recordVolatile: (props: { project: TtscMetroProjectView }) => void;
 } {
   const suffix = `${process.pid.toString(36)}-${randomBytes(6).toString("hex")}`;
   interface BaseState {
@@ -567,18 +586,15 @@ export function createSnapshotRecorder(): {
   }
   const states = new Map<string, BaseState>();
 
-  function stateFor(
-    projectRoot: string | undefined,
-    explicitProject: string | undefined,
-  ): BaseState {
-    const base = resolveFingerprintBase(projectRoot);
+  function stateFor(project: TtscMetroProjectView): BaseState {
+    const base = project.base;
     let state = states.get(base);
     if (state === undefined) {
       state = {
         dirty: false,
         files: new Set(),
         observed: false,
-        roots: fingerprintRoots(base, explicitProject),
+        roots: fingerprintRoots(base, project.explicitProject),
         volatile: false,
       };
       states.set(base, state);
@@ -621,8 +637,8 @@ export function createSnapshotRecorder(): {
 
   return {
     record(props) {
-      const base = resolveFingerprintBase(props.projectRoot);
-      const state = stateFor(props.projectRoot, props.explicitProject);
+      const base = props.project.base;
+      const state = stateFor(props.project);
       const input = path.resolve(props.input);
       const firstObservation = !state.observed;
       state.observed = true;
@@ -630,7 +646,13 @@ export function createSnapshotRecorder(): {
         state.files.has(input) ||
         (fs.existsSync(input) &&
           state.roots.some((root) =>
-            isProjectWalkPath(root, input, undefined, undefined, props.policy),
+            isProjectWalkPath(
+              root,
+              input,
+              undefined,
+              undefined,
+              props.project.policy,
+            ),
           ))
       ) {
         // Even when every input belongs to the project walk, the worker must
@@ -647,8 +669,8 @@ export function createSnapshotRecorder(): {
       flush(base, state);
     },
     recordVolatile(props) {
-      const base = resolveFingerprintBase(props.projectRoot);
-      const state = stateFor(props.projectRoot, props.explicitProject);
+      const base = props.project.base;
+      const state = stateFor(props.project);
       if (state.volatile) {
         flush(base, state);
         return;

--- a/packages/metro/src/core/fingerprint.ts
+++ b/packages/metro/src/core/fingerprint.ts
@@ -171,7 +171,8 @@ export function resolveMembershipPolicy(props: {
 }
 
 /**
- * The membership policy of one project, memoized per resolved tsconfig.
+ * The membership policy of one project, memoized per resolved tsconfig and
+ * caller overlay.
  *
  * Every use of the walk pair has to ask the same policy, or the two halves
  * disagree about the same project. The walk hashes what the configuration can
@@ -192,15 +193,18 @@ function membershipPolicy(
   tsconfig: string,
   compilerOptions?: Record<string, unknown>,
 ): ReturnType<typeof readProjectMembershipPolicy> {
-  // Keyed by the config's own stamp, not by its path. A Metro worker outlives
-  // many runs, and this is consulted once per delivered file, so a plain
-  // path-keyed memo would hold the policy a project had when the worker
-  // started. An edit adding `exclude` would then leave the worker judging a
-  // file in-walk while the next run's walk skipped it, which is precisely the
-  // both-sides-disagree hole this policy exists to close.
-  // Keyed by the overlay as well as the config. The overlay is part of the
-  // answer, so a memo keyed by path alone would hand a caller who passed
-  // `allowJs` the policy resolved for a caller who did not.
+  // Keyed by the config's path and the caller's overlay, and never trusted on
+  // the key alone: a hit is served only while the config's own stamp still
+  // matches. A Metro worker outlives many runs, and this is consulted once per
+  // delivered file, so a memo that trusted its key would hold the policy a
+  // project had when the worker started. An edit adding `exclude` would then
+  // leave the worker judging a file in-walk while the next run's walk skipped
+  // it, which is precisely the both-sides-disagree hole this policy exists to
+  // close.
+  //
+  // The overlay belongs in the key rather than the stamp because it is part of
+  // the question, not part of any file: keyed by path alone the memo would hand
+  // a caller who passed `allowJs` the policy resolved for a caller who did not.
   const key = [tsconfig, stableStringify(compilerOptions ?? {})].join(
     String.fromCharCode(0),
   );
@@ -289,6 +293,7 @@ function resolveProjectTsconfig(
  * cross-run cache reuse for this run instead of serving stale output.
  */
 export function computeProjectFingerprint(props: {
+  compilerOptions?: Record<string, unknown>;
   explicitProject?: string;
   projectRoot?: string;
 }): string {
@@ -299,9 +304,19 @@ export function computeProjectFingerprint(props: {
     // does. Metro folds this into one static key, so an entry the program
     // could never contain used to re-key every transformed file rather than
     // costing one compile the way it does for a bundler (samchon/ttsc#1307).
-    const policy = membershipPolicy(
-      resolveProjectTsconfig(base, props.explicitProject),
-    );
+    //
+    // The caller's compiler-options overlay is part of that configuration, and
+    // has to reach the walk as well as the recorder. The two are the halves of
+    // one cache key and run in different processes, so they agree only by
+    // deriving from the same declared options: a walk resolved without the
+    // overlay while the recorder resolves with it leaves an overlay-admitted
+    // input in neither half, which is the both-sides-disagree hole in its
+    // quietest form (samchon/ttsc#1316).
+    const policy = resolveMembershipPolicy({
+      compilerOptions: props.compilerOptions,
+      explicitProject: props.explicitProject,
+      projectRoot: props.projectRoot,
+    });
     for (const root of fingerprintRoots(base, props.explicitProject)) {
       hash.update(
         stableStringify(
@@ -513,18 +528,28 @@ export function readSnapshotState(base: string): SnapshotState | undefined {
  */
 export function createSnapshotRecorder(): {
   record: (props: {
-    compilerOptions?: Record<string, unknown>;
     explicitProject?: string;
     input: string;
     /**
-     * The policy this transform already resolved, so the recorder does not
-     * re-derive it. `record` runs once per watch input rather than once per
-     * file, and validating the memo means stat-ing the whole `extends` chain,
-     * measured at 12 microseconds per stat: a few thousand modules times
-     * fifteen inputs each cost over half a second per run for an answer that
-     * cannot change between two inputs of one file (samchon/ttsc#1316).
+     * The policy the walk of this same project uses, resolved once per
+     * transform through {@link resolveMembershipPolicy}.
+     *
+     * Required rather than defaulted, because the recorder's only question is
+     * whether the walk already covers this input. A policy the recorder derived
+     * on its own could describe a different program than the walk actually
+     * hashed — that is exactly what happened when the overlay reached one half
+     * and not the other — and the input would then be covered by neither.
+     * Demanding it from the caller keeps the disagreement unrepresentable
+     * instead of merely absent.
+     *
+     * It is hoisted for cost as well: `record` runs once per watch input rather
+     * than once per file, and validating the memo means stat-ing the whole
+     * `extends` chain, measured at 12 microseconds per stat — a few thousand
+     * modules times fifteen inputs each cost over half a second per run for an
+     * answer that cannot change between two inputs of one file
+     * (samchon/ttsc#1316).
      */
-    policy?: ReturnType<typeof readProjectMembershipPolicy>;
+    policy: ReturnType<typeof readProjectMembershipPolicy>;
     projectRoot?: string;
   }) => void;
   recordVolatile: (props: {
@@ -601,17 +626,11 @@ export function createSnapshotRecorder(): {
       const input = path.resolve(props.input);
       const firstObservation = !state.observed;
       state.observed = true;
-      const policy =
-        props.policy ??
-        membershipPolicy(
-          resolveProjectTsconfig(base, props.explicitProject),
-          props.compilerOptions,
-        );
       if (
         state.files.has(input) ||
         (fs.existsSync(input) &&
           state.roots.some((root) =>
-            isProjectWalkPath(root, input, undefined, undefined, policy),
+            isProjectWalkPath(root, input, undefined, undefined, props.policy),
           ))
       ) {
         // Even when every input belongs to the project walk, the worker must

--- a/packages/metro/src/core/fingerprint.ts
+++ b/packages/metro/src/core/fingerprint.ts
@@ -48,6 +48,7 @@ import {
   collectExternalInputHashes,
   collectProjectInputHashes,
   isProjectWalkPath,
+  mergeMembershipPolicyOverlay,
   readProjectMembershipPolicy,
 } from "@ttsc/unplugin/api";
 import { createHash, randomBytes } from "node:crypto";
@@ -150,6 +151,26 @@ export function fingerprintRoots(
 }
 
 /**
+ * The membership policy for one transform, resolved once and handed to every
+ * watch input that transform reports.
+ *
+ * Exported because the recorder is asked once per input while the answer is a
+ * property of the project, and validating the memo means stat-ing the whole
+ * `extends` chain (samchon/ttsc#1316).
+ */
+export function resolveMembershipPolicy(props: {
+  compilerOptions?: Record<string, unknown>;
+  explicitProject?: string;
+  projectRoot?: string;
+}): ReturnType<typeof readProjectMembershipPolicy> {
+  const base = resolveFingerprintBase(props.projectRoot);
+  return membershipPolicy(
+    resolveProjectTsconfig(base, props.explicitProject),
+    props.compilerOptions,
+  );
+}
+
+/**
  * The membership policy of one project, memoized per resolved tsconfig.
  *
  * Every use of the walk pair has to ask the same policy, or the two halves
@@ -169,6 +190,7 @@ const MEMBERSHIP_POLICIES = new Map<
 
 function membershipPolicy(
   tsconfig: string,
+  compilerOptions?: Record<string, unknown>,
 ): ReturnType<typeof readProjectMembershipPolicy> {
   // Keyed by the config's own stamp, not by its path. A Metro worker outlives
   // many runs, and this is consulted once per delivered file, so a plain
@@ -180,7 +202,16 @@ function membershipPolicy(
   if (existing !== undefined && existing.stamp === stampOf(existing.sources)) {
     return existing.policy;
   }
-  const policy = readProjectMembershipPolicy(tsconfig);
+  // The caller's compiler-options overlay wins for the compile, so it has to
+  // win here too, exactly as it does in the adapter: a project given
+  // `allowJs: true` through `withTtsc` has a wider program than its tsconfig
+  // alone describes, and a narrower policy here would ask a different question
+  // about the same project (samchon/ttsc#1316).
+  const policy = mergeMembershipPolicyOverlay(
+    readProjectMembershipPolicy(tsconfig),
+    compilerOptions ?? {},
+    path.dirname(path.resolve(tsconfig)),
+  );
   // Stamp the whole `extends` chain, not the leaf. Adding `exclude` to a shared
   // `tsconfig.base.json` leaves the leaf's own mtime and size untouched while
   // changing every answer the policy gives, so a leaf-only stamp would keep the
@@ -201,7 +232,12 @@ function stampOf(sources: readonly string[]): string {
     .map((source) => {
       try {
         const stats = fs.statSync(source);
-        return `${source}:${stats.mtimeMs}:${stats.size}`;
+        // A directory occupying a candidate path can never be the config, so it
+        // contributes its existence and not its modification time, which moves
+        // whenever any child is added or removed (samchon/ttsc#1316).
+        return stats.isDirectory()
+          ? `${source}:directory`
+          : `${source}:${stats.mtimeMs}:${stats.size}`;
       } catch {
         // Absent now. `readProjectMembershipPolicy` answers for that too, and
         // the policy must be re-asked once the config appears.
@@ -471,8 +507,18 @@ export function readSnapshotState(base: string): SnapshotState | undefined {
  */
 export function createSnapshotRecorder(): {
   record: (props: {
+    compilerOptions?: Record<string, unknown>;
     explicitProject?: string;
     input: string;
+    /**
+     * The policy this transform already resolved, so the recorder does not
+     * re-derive it. `record` runs once per watch input rather than once per
+     * file, and validating the memo means stat-ing the whole `extends` chain,
+     * measured at 12 microseconds per stat: a few thousand modules times
+     * fifteen inputs each cost over half a second per run for an answer that
+     * cannot change between two inputs of one file (samchon/ttsc#1316).
+     */
+    policy?: ReturnType<typeof readProjectMembershipPolicy>;
     projectRoot?: string;
   }) => void;
   recordVolatile: (props: {
@@ -549,9 +595,12 @@ export function createSnapshotRecorder(): {
       const input = path.resolve(props.input);
       const firstObservation = !state.observed;
       state.observed = true;
-      const policy = membershipPolicy(
-        resolveProjectTsconfig(base, props.explicitProject),
-      );
+      const policy =
+        props.policy ??
+        membershipPolicy(
+          resolveProjectTsconfig(base, props.explicitProject),
+          props.compilerOptions,
+        );
       if (
         state.files.has(input) ||
         (fs.existsSync(input) &&

--- a/packages/metro/src/core/fingerprint.ts
+++ b/packages/metro/src/core/fingerprint.ts
@@ -198,7 +198,13 @@ function membershipPolicy(
   // started. An edit adding `exclude` would then leave the worker judging a
   // file in-walk while the next run's walk skipped it, which is precisely the
   // both-sides-disagree hole this policy exists to close.
-  const existing = MEMBERSHIP_POLICIES.get(tsconfig);
+  // Keyed by the overlay as well as the config. The overlay is part of the
+  // answer, so a memo keyed by path alone would hand a caller who passed
+  // `allowJs` the policy resolved for a caller who did not.
+  const key = [tsconfig, stableStringify(compilerOptions ?? {})].join(
+    String.fromCharCode(0),
+  );
+  const existing = MEMBERSHIP_POLICIES.get(key);
   if (existing !== undefined && existing.stamp === stampOf(existing.sources)) {
     return existing.policy;
   }
@@ -218,7 +224,7 @@ function membershipPolicy(
   // worker on the pre-edit policy for its lifetime.
   const sources =
     policy.sources.length === 0 ? [tsconfig] : [...policy.sources];
-  MEMBERSHIP_POLICIES.set(tsconfig, {
+  MEMBERSHIP_POLICIES.set(key, {
     policy,
     sources,
     stamp: stampOf(sources),

--- a/packages/metro/src/transformer.ts
+++ b/packages/metro/src/transformer.ts
@@ -27,6 +27,7 @@ import path from "node:path";
 import {
   computeProjectFingerprint,
   createSnapshotRecorder,
+  resolveMembershipPolicy,
   stableStringify,
 } from "./core/fingerprint";
 import type { ResolvedTtscMetroOptions } from "./core/options";
@@ -120,6 +121,11 @@ export async function transform(params: {
         : undefined;
     const explicitProject =
       typeof opts.ttsc.project === "string" ? opts.ttsc.project : undefined;
+    const membershipPolicy = resolveMembershipPolicy({
+      compilerOptions: opts.ttsc.compilerOptions,
+      explicitProject,
+      projectRoot,
+    });
     const result = await transformTtsc(
       resolveAbsoluteFilename(params.filename, params.options),
       params.src,
@@ -133,8 +139,17 @@ export async function transform(params: {
         // that the next run's getCacheKey re-hashes instead. Fires on cache
         // hits too, so a worker that never recompiled still records the
         // inputs backing the outputs it serves.
+        // The policy is resolved once for this file and handed to every one of
+        // its watch inputs. `record` runs per input, and validating the memo
+        // means stat-ing the whole `extends` chain, which is an answer that
+        // cannot change between two inputs of one file (samchon/ttsc#1316).
         addWatchFile: (input) =>
-          snapshotRecorder.record({ explicitProject, input, projectRoot }),
+          snapshotRecorder.record({
+            explicitProject,
+            input,
+            policy: membershipPolicy,
+            projectRoot,
+          }),
         // A volatile declaration means the output depends on non-file inputs
         // that no file fingerprint can represent; the snapshot marks it and
         // getCacheKey degrades to a per-run nonce (no cross-run reuse).

--- a/packages/metro/src/transformer.ts
+++ b/packages/metro/src/transformer.ts
@@ -27,7 +27,7 @@ import path from "node:path";
 import {
   computeProjectFingerprint,
   createSnapshotRecorder,
-  resolveMembershipPolicy,
+  resolveProjectView,
   stableStringify,
 } from "./core/fingerprint";
 import type { ResolvedTtscMetroOptions } from "./core/options";
@@ -121,7 +121,7 @@ export async function transform(params: {
         : undefined;
     const explicitProject =
       typeof opts.ttsc.project === "string" ? opts.ttsc.project : undefined;
-    const membershipPolicy = resolveMembershipPolicy({
+    const project = resolveProjectView({
       compilerOptions: opts.ttsc.compilerOptions,
       explicitProject,
       projectRoot,
@@ -139,22 +139,16 @@ export async function transform(params: {
         // that the next run's getCacheKey re-hashes instead. Fires on cache
         // hits too, so a worker that never recompiled still records the
         // inputs backing the outputs it serves.
-        // The policy is resolved once for this file and handed to every one of
-        // its watch inputs. `record` runs per input, and validating the memo
-        // means stat-ing the whole `extends` chain, which is an answer that
-        // cannot change between two inputs of one file (samchon/ttsc#1316).
-        addWatchFile: (input) =>
-          snapshotRecorder.record({
-            explicitProject,
-            input,
-            policy: membershipPolicy,
-            projectRoot,
-          }),
+        // The project view is resolved once for this file and handed to every
+        // one of its watch inputs. `record` runs per input, and validating the
+        // memo means stat-ing the whole `extends` chain, which is an answer
+        // that cannot change between two inputs of one file
+        // (samchon/ttsc#1316).
+        addWatchFile: (input) => snapshotRecorder.record({ input, project }),
         // A volatile declaration means the output depends on non-file inputs
         // that no file fingerprint can represent; the snapshot marks it and
         // getCacheKey degrades to a per-run nonce (no cross-run reuse).
-        markVolatile: () =>
-          snapshotRecorder.recordVolatile({ explicitProject, projectRoot }),
+        markVolatile: () => snapshotRecorder.recordVolatile({ project }),
       },
     );
     // A file the program does not contain comes back as `undefined` from the

--- a/packages/metro/src/transformer.ts
+++ b/packages/metro/src/transformer.ts
@@ -214,6 +214,10 @@ export function getCacheKey(...args: unknown[]): string {
   }
   hash.update(
     computeProjectFingerprint({
+      // The same overlay `transform` hands the recorder. Both read these
+      // options from `options()`, so the walk and the recorder judge one
+      // project by one program (samchon/ttsc#1316).
+      compilerOptions: opts.ttsc.compilerOptions,
       explicitProject:
         typeof opts.ttsc.project === "string" ? opts.ttsc.project : undefined,
       projectRoot: cacheKeyProjectRoot(args),

--- a/packages/unplugin/README.md
+++ b/packages/unplugin/README.md
@@ -338,7 +338,9 @@ Not every Vite alias form can be forwarded, because a tsconfig `paths` map canno
 | array form with a `RegExp` `find`, such as `{ find: /^~/ }` | no — `paths` has no regular-expression form |
 | a string `find` containing `*` | no — a `paths` key already reads `*` as its own wildcard |
 
-An alias that cannot be forwarded is reported once, naming the alias and the reason, and the compile resolves that specifier through the tsconfig's `paths` alone. Declare it there if `ttsc` must resolve through it — a prefix `RegExp` such as `/^~/` is written as a `"~/*"` entry. Reducing simple prefix patterns automatically is deliberately not attempted: distinguishing `/^~/` from `/^@app/`, which also matches `@apple`, needs enough of a regular-expression engine that a wrong reduction becomes likely, and a mistranslated alias resolves imports to the wrong file without saying so.
+In both unforwarded cases the compile resolves that specifier through the tsconfig's `paths` alone, so declare it there if `ttsc` must resolve through it — a prefix `RegExp` such as `/^~/` is written as a `"~/*"` entry. Reducing simple prefix patterns automatically is deliberately not attempted: distinguishing `/^~/` from `/^@app/`, which also matches `@apple`, needs enough of a regular-expression engine that a wrong reduction becomes likely, and a mistranslated alias resolves imports to the wrong file without saying so.
+
+A `find` containing `*` is also reported once on stderr, naming the alias and the reason. A `RegExp` `find` is not, and the asymmetry is deliberate: Vite merges two `RegExp` aliases of its own into every resolved config, for `@vite/env` and `@vite/client`, so a report on that form would fire in every build of every project and name aliases you never wrote.
 
 ### Cache and Watch Invalidation
 

--- a/packages/unplugin/README.md
+++ b/packages/unplugin/README.md
@@ -306,6 +306,8 @@ Each entrypoint supports ESM import and CJS require. In CommonJS configs, read t
 
 `@ttsc/unplugin/bun-register` is the Bun **runtime** entry rather than a bundler adapter, covered under [Bun](#bun) above. `@ttsc/unplugin/api` exposes the transform core itself (`transformTtsc`, `resolveOptions`, the cache lifecycle) for hosts that are not unplugin-shaped; `@ttsc/metro` is built on it.
 
+That entry point also exposes the project-membership rule — `readProjectMembershipPolicy`, `mergeMembershipPolicyOverlay`, `ITtscProjectMembershipPolicy`, `isProjectWalkPath` and the input-hash collectors — which decides which files can enter the compiled program and therefore which changes invalidate a cached compile. These exist so a host that keeps its own cache asks that question exactly the way the transform core asks it: `@ttsc/metro` folds them into Metro's static transformer key, and the two halves disagreeing about one project is the bug class they exist to prevent. They are shaped for that use rather than as a general-purpose configuration reader, and they move with the core rather than under a stability guarantee of their own. Build a host on them if you need it; pin your `@ttsc/unplugin` version if you do.
+
 ### Options
 
 ```ts
@@ -327,6 +329,16 @@ const options: TtscUnpluginOptions = {
 #### Path Aliases
 
 Under Vite, the adapter reads the resolved `resolve.alias` and layers it onto the generated config, so an alias declared only in `vite.config.ts` still resolves during the compile. No other host's alias configuration is read: under Rollup, Rolldown, webpack, Rspack, esbuild, Farm, Turbopack and Bun, the compile resolves through the tsconfig's own `paths` alone. Declare an alias in `paths` when a module has to resolve for the compiler as well as for the bundler, which is what those hosts need anyway for `tsc` to type-check the same imports.
+
+Not every Vite alias form can be forwarded, because a tsconfig `paths` map cannot express all of them:
+
+| `resolve.alias` form | Forwarded |
+| --- | --- |
+| `{ "@": "/src" }`, or the array form with a string `find` | yes |
+| array form with a `RegExp` `find`, such as `{ find: /^~/ }` | no — `paths` has no regular-expression form |
+| a string `find` containing `*` | no — a `paths` key already reads `*` as its own wildcard |
+
+An alias that cannot be forwarded is reported once, naming the alias and the reason, and the compile resolves that specifier through the tsconfig's `paths` alone. Declare it there if `ttsc` must resolve through it — a prefix `RegExp` such as `/^~/` is written as a `"~/*"` entry. Reducing simple prefix patterns automatically is deliberately not attempted: distinguishing `/^~/` from `/^@app/`, which also matches `@apple`, needs enough of a regular-expression engine that a wrong reduction becomes likely, and a mistranslated alias resolves imports to the wrong file without saying so.
 
 ### Cache and Watch Invalidation
 

--- a/packages/unplugin/src/core/index.ts
+++ b/packages/unplugin/src/core/index.ts
@@ -303,7 +303,10 @@ export type {
   TtscWatchInputEvidence,
 } from "./transform";
 export type { ITtscProjectMembershipPolicy } from "./tsconfigPaths";
-export { readProjectMembershipPolicy } from "./tsconfigPaths";
+export {
+  mergeMembershipPolicyOverlay,
+  readProjectMembershipPolicy,
+} from "./tsconfigPaths";
 export {
   beginTtscTransformBuild,
   collectExternalInputHashes,

--- a/packages/unplugin/src/core/transform.ts
+++ b/packages/unplugin/src/core/transform.ts
@@ -38,14 +38,16 @@ export type TtscTransformResult = Exclude<
 >;
 
 /**
- * Normalised alias entry used when building the `paths` overlay for the
- * generated tsconfig. Derived from either a Vite array alias or a webpack/
- * Rspack object alias.
+ * One alias entry as the host declared it — a Vite array alias or a
+ * webpack/Rspack object alias — before anything decides whether a tsconfig
+ * `paths` map can express it.
+ *
+ * `find` is `unknown` rather than `string` because Vite's array form accepts a
+ * `RegExp`, and narrowing it here is what used to drop that form before the one
+ * place that could report the drop ever saw it (samchon/ttsc#1315).
  */
-export interface TtscTransformAlias {
-  /** The alias key (module specifier prefix). */
-  find: string;
-  /** Absolute or cwd-relative path that the alias points to. */
+interface TtscDeclaredAlias {
+  find: unknown;
   replacement: string;
 }
 
@@ -6173,10 +6175,32 @@ function readPaths(value: unknown): Record<string, string[]> {
 function createAliasPaths(aliases: unknown): Record<string, string[]> {
   const paths: Record<string, string[]> = {};
   for (const alias of normalizeAliases(aliases)) {
-    if (typeof alias.find !== "string" || alias.find.length === 0) {
+    if (typeof alias.find !== "string") {
+      // Vite's array form accepts a `RegExp` find, and `{ find: /^~/ }` is a
+      // common way to spell a prefix alias. A tsconfig `paths` map has no
+      // regular-expression form, so there is nothing to translate it into
+      // (samchon/ttsc#1315). Reducing the simple prefix cases to a string is
+      // possible in principle and deliberately not done: telling `/^~/` from
+      // `/^~(?=\/)/` or `/^@app/` — which matches `@apple` too — means
+      // implementing enough of a regular-expression engine that a wrong
+      // reduction becomes likely, and a mistranslated alias resolves imports to
+      // the wrong file silently, which is worse than not forwarding it.
+      reportUntranslatableAlias(
+        String(alias.find),
+        'a tsconfig "paths" entry has no regular-expression form',
+      );
+      continue;
+    }
+    if (alias.find.length === 0) {
       continue;
     }
     if (alias.find.includes("*")) {
+      // A `paths` key reads `*` as its own wildcard, so forwarding a `find`
+      // that already contains one cannot preserve the caller's meaning.
+      reportUntranslatableAlias(
+        JSON.stringify(alias.find),
+        'a "paths" key already reads "*" as its own wildcard',
+      );
       continue;
     }
     const key = alias.find.replace(/\/+$/, "");
@@ -6194,9 +6218,49 @@ function createAliasPaths(aliases: unknown): Record<string, string[]> {
   return paths;
 }
 
-function normalizeAliases(aliases: unknown): TtscTransformAlias[] {
+/**
+ * Alias descriptions already reported in this process.
+ *
+ * The message is about configuration rather than about a module:
+ * `resolve.alias` is resolved once and then consulted on every delivery, so
+ * reporting per delivery would repeat one statement about the config for every
+ * file in the bundle. Keyed by the description, so a Vite dev server that
+ * reloads its config reports again only when the alias itself changed.
+ */
+const REPORTED_UNTRANSLATABLE_ALIASES = new Set<string>();
+
+/**
+ * Tell the user once that an alias they declared is not reaching the compile.
+ *
+ * A dropped alias is not silent in its consequence — the compile resolves
+ * through the tsconfig's own `paths`, and a module that resolves for the
+ * bundler but not for the compiler surfaces as the out-of-program report
+ * (samchon/ttsc#1308) — but that report names the module, not the alias, so the
+ * user cannot learn from it that a configuration they wrote was ignored.
+ */
+function reportUntranslatableAlias(description: string, reason: string): void {
+  if (REPORTED_UNTRANSLATABLE_ALIASES.has(description)) {
+    return;
+  }
+  REPORTED_UNTRANSLATABLE_ALIASES.add(description);
+  process.stderr.write(
+    `ttsc: the Vite alias ${description} was not forwarded to the compile, because ${reason}. Declare it in your tsconfig's "paths" if ttsc must resolve through it.\n`,
+  );
+}
+
+/**
+ * Collect the host's declared aliases without deciding which of them can be
+ * expressed as `paths`.
+ *
+ * That decision belongs to {@link createAliasPaths} alone. It used to be split:
+ * this function's type guard required a string `find` and dropped Vite's
+ * `RegExp` form before `createAliasPaths` ever saw it, which left
+ * `createAliasPaths`'s own non-string branch unreachable and put the drop
+ * somewhere nothing could report it (samchon/ttsc#1315).
+ */
+function normalizeAliases(aliases: unknown): TtscDeclaredAlias[] {
   if (Array.isArray(aliases)) {
-    return aliases.filter(isAlias);
+    return aliases.filter(isDeclaredAlias);
   }
   if (typeof aliases === "object" && aliases !== null) {
     return Object.entries(aliases)
@@ -6254,13 +6318,12 @@ function isRelativeSpecifier(value: string): boolean {
   );
 }
 
-function isAlias(value: unknown): value is TtscTransformAlias {
+function isDeclaredAlias(value: unknown): value is TtscDeclaredAlias {
   return (
     typeof value === "object" &&
     value !== null &&
     "find" in value &&
     "replacement" in value &&
-    typeof value.find === "string" &&
     typeof value.replacement === "string"
   );
 }
@@ -6313,21 +6376,6 @@ function selectTransformedSource(props: {
 }
 
 /**
- * Forward non-fatal plugin diagnostics to stderr, once per generation per pass.
- *
- * A `success` result may still carry warnings or informational messages from
- * plugins — `@ttsc/lint` reports every rule below error severity this way.
- * These are surfaced via stderr rather than throwing so the build continues.
- * Failures and exceptions are handled by the caller.
- *
- * They describe one compile of one program, so writing them per delivery
- * printed the same warning once per module and scaled the noise with exactly
- * the reuse the cache exists to provide (samchon/ttsc#1304). A pass that reuses
- * a retained generation still surfaces them once, because a build's warnings
- * are part of what that build reports; a host with no pass boundary surfaces
- * them once per generation, which is the same rule with one pass.
- */
-/**
  * Tell the user once that a module was left untransformed, and why.
  *
  * The condition is ordinary and the build continues, but it must never be
@@ -6355,6 +6403,21 @@ function reportMissingProgramOutput(
 `);
 }
 
+/**
+ * Forward non-fatal plugin diagnostics to stderr, once per generation per pass.
+ *
+ * A `success` result may still carry warnings or informational messages from
+ * plugins — `@ttsc/lint` reports every rule below error severity this way.
+ * These are surfaced via stderr rather than throwing so the build continues.
+ * Failures and exceptions are handled by the caller.
+ *
+ * They describe one compile of one program, so writing them per delivery
+ * printed the same warning once per module and scaled the noise with exactly
+ * the reuse the cache exists to provide (samchon/ttsc#1304). A pass that reuses
+ * a retained generation still surfaces them once, because a build's warnings
+ * are part of what that build reports; a host with no pass boundary surfaces
+ * them once per generation, which is the same rule with one pass.
+ */
 function reportSuccessDiagnostics(
   cached: TtscCachedProjectTransform,
   epoch: number | undefined,

--- a/packages/unplugin/src/core/transform.ts
+++ b/packages/unplugin/src/core/transform.ts
@@ -38,16 +38,23 @@ export type TtscTransformResult = Exclude<
 >;
 
 /**
- * One alias entry as the host declared it — a Vite array alias or a
- * webpack/Rspack object alias — before anything decides whether a tsconfig
- * `paths` map can express it.
+ * One alias entry as the host declared it, before anything decides whether a
+ * tsconfig `paths` map can express it.
+ *
+ * Both of Vite's spellings reach here, the `{ "@": "/src" }` object and the `{
+ * find, replacement }` array, and only Vite's: `aliases` is populated in
+ * `vite.configResolved` alone, and every other adapter passes `undefined`. (The
+ * previous wording credited the object form to webpack and Rspack, which never
+ * supply one.)
  *
  * `find` is `unknown` rather than `string` because Vite's array form accepts a
  * `RegExp`, and narrowing it here is what used to drop that form before the one
  * place that could report the drop ever saw it (samchon/ttsc#1315).
  */
 interface TtscDeclaredAlias {
+  /** The alias key, as declared: a module specifier prefix, or a `RegExp`. */
   find: unknown;
+  /** Absolute or cwd-relative path that the alias points to. */
   replacement: string;
 }
 

--- a/packages/unplugin/src/core/transform.ts
+++ b/packages/unplugin/src/core/transform.ts
@@ -6192,10 +6192,18 @@ function createAliasPaths(aliases: unknown): Record<string, string[]> {
       // implementing enough of a regular-expression engine that a wrong
       // reduction becomes likely, and a mistranslated alias resolves imports to
       // the wrong file silently, which is worse than not forwarding it.
-      reportUntranslatableAlias(
-        String(alias.find),
-        'a tsconfig "paths" entry has no regular-expression form',
-      );
+      //
+      // Not reported, unlike the wildcard below, and that asymmetry is the
+      // whole point: Vite merges two `RegExp` aliases of its own into every
+      // resolved config, `/^\/?@vite\/env/` and `/^\/?@vite\/client/`. Measured
+      // on a bare project with no user aliases at all, `resolve.alias` has
+      // exactly those two entries under both `serve` and `build`, so a report
+      // on this form would fire twice for every Vite user in every build, name
+      // aliases they never wrote, and say nothing about their configuration.
+      // A diagnostic that cannot distinguish the user's input from the host's
+      // is noise, and noise is what teaches people to stop reading the channel
+      // the out-of-program report depends on. The documentation carries this
+      // form instead, in both README and guide.
       continue;
     }
     if (alias.find.length === 0) {
@@ -6244,6 +6252,11 @@ const REPORTED_UNTRANSLATABLE_ALIASES = new Set<string>();
  * bundler but not for the compiler surfaces as the out-of-program report
  * (samchon/ttsc#1308) — but that report names the module, not the alias, so the
  * user cannot learn from it that a configuration they wrote was ignored.
+ *
+ * Only the wildcard form reaches here. Every entry it names was written by the
+ * user, because nothing injects one; the `RegExp` form is left to the
+ * documentation precisely because Vite does inject those, and
+ * {@link createAliasPaths} carries that measurement.
  */
 function reportUntranslatableAlias(description: string, reason: string): void {
   if (REPORTED_UNTRANSLATABLE_ALIASES.has(description)) {

--- a/packages/unplugin/src/next.ts
+++ b/packages/unplugin/src/next.ts
@@ -138,6 +138,14 @@ function withTtscTurbopackRules(
     if (loaders.some(referencesTtscLoader)) {
       continue;
     }
+    // The caller may have written the same file set under a different glob.
+    // Adding ours beside theirs makes every matching module run the loader
+    // twice, and the second pass receives the first pass's output, so the
+    // guard has to cover the spellings a caller plausibly uses rather than
+    // only the two this wrapper writes (samchon/ttsc#1314).
+    if (coveredByAnotherRule(rules, glob)) {
+      continue;
+    }
     const entry = { loader: TURBOPACK_LOADER, options: options ?? {} };
     // Appended, not prepended. Turbopack runs a rule's loaders through
     // webpack's own `loader-runner`, which runs the normal phase right to
@@ -152,6 +160,52 @@ function withTtscTurbopackRules(
           : { ...(rule as object), loaders: [...loaders, entry] };
   }
   return { ...(existing ?? {}), rules };
+}
+
+/**
+ * Whether some other rule already routes this glob's files through the loader.
+ *
+ * Deciding glob equivalence in general means implementing Turbopack's matcher,
+ * which is not worth it here. What is worth it is the set a user actually
+ * writes for these two extensions: a brace list naming the extension, and the
+ * same glob under a leading `**` path prefix. Anything outside that is left
+ * alone, which errs toward the wrapper doing nothing rather than toward
+ * registering a second time, because a missing rule is visible and a double
+ * transform is not.
+ */
+function coveredByAnotherRule(
+  rules: Record<string, unknown>,
+  glob: string,
+): boolean {
+  const extension = glob.slice(glob.lastIndexOf(".") + 1);
+  return Object.entries(rules).some(([candidate, rule]) => {
+    if (candidate === glob) {
+      return false;
+    }
+    if (!selectTurbopackLoaders(rule).some(referencesTtscLoader)) {
+      return false;
+    }
+    return matchesExtension(candidate, extension);
+  });
+}
+
+/**
+ * Whether one glob names this extension, for the shapes a hand-written rule
+ * takes: `*.ts`, `**` + `/*.ts`, and a brace list such as `*.{ts,tsx}`.
+ */
+function matchesExtension(glob: string, extension: string): boolean {
+  const tail = glob.slice(glob.lastIndexOf(".") + 1);
+  if (tail === extension) {
+    return true;
+  }
+  if (!tail.startsWith("{") || !tail.endsWith("}")) {
+    return false;
+  }
+  return tail
+    .slice(1, -1)
+    .split(",")
+    .map((part) => part.trim())
+    .includes(extension);
 }
 
 /**

--- a/packages/unplugin/src/next.ts
+++ b/packages/unplugin/src/next.ts
@@ -166,12 +166,14 @@ function withTtscTurbopackRules(
  * Whether some other rule already routes this glob's files through the loader.
  *
  * Deciding glob equivalence in general means implementing Turbopack's matcher,
- * which is not worth it here. What is recognised instead is the set of globs
- * that mean "every file with this extension", since only those can make the
- * wrapper's own rules redundant. Anything narrower is left alone and the
- * wrapper still adds its rules: skipping on a scoped glob would leave every
- * module outside that scope untransformed, which is samchon/ttsc#1310 again and
- * the quieter of the two failures.
+ * which is not worth it here. What is recognised instead is the spellings a
+ * caller plausibly writes for "every file with this extension", since only a
+ * glob that means every file can make the wrapper's own rules redundant. That
+ * is narrower than every glob with those semantics, and narrow on purpose:
+ * anything unrecognised is left alone and the wrapper still adds its rules,
+ * while skipping on a scoped glob would leave every module outside that scope
+ * untransformed, which is samchon/ttsc#1310 again and the quieter of the two
+ * failures. {@link matchesExtension} owns the rule and names what it declines.
  */
 function coveredByAnotherRule(
   rules: Record<string, unknown>,
@@ -200,26 +202,55 @@ function coveredByAnotherRule(
  * double registration this guard exists to prevent: a build that transforms
  * twice is wrong loudly, a build that never transforms is wrong quietly.
  *
- * So the shapes recognised are exactly the two that mean "every file with this
- * extension": `*.ts` and `**` + `/*.ts`, each also in brace-list form.
+ * Recognition is one rule rather than a list of shapes: expand a brace group
+ * into the globs it stands for, drop any leading `**` + `/` segments, and ask
+ * whether what remains is exactly `*.<extension>`. That covers every spelling a
+ * caller plausibly writes for "every file with this extension" — `*.ts`, `**` +
+ * `/*.ts`, `*.{ts,tsx}`, `**` + `/{*.ts,*.tsx}`, `{**` + `/,}*.ts` — without
+ * deciding glob equivalence in general.
+ *
+ * Expanding the brace before the test is what keeps the scoped case safe.
+ * `src/*.{ts,tsx}` expands to `src/*.ts` and `src/*.tsx`, neither of which
+ * survives the test, because the path segment is still there once the group is
+ * gone. A group that spans the scope itself is judged the same way:
+ * `{src/,}*.ts` offers `*.ts` among its alternatives, and that alternative
+ * really does name every file, so recognising it is correct rather than a
+ * leak.
+ *
+ * Two shapes stay unrecognised and deliberately so, since both fail in the loud
+ * direction: a character class (`*.[jt]s`) and a different case (`*.TS`).
  */
 function matchesExtension(glob: string, extension: string): boolean {
-  const unprefixed = glob.startsWith("**/") ? glob.slice(3) : glob;
-  if (!unprefixed.startsWith("*.")) {
-    return false;
+  return expandBraceGroup(glob).some((candidate) => {
+    let unprefixed = candidate;
+    while (unprefixed.startsWith("**/")) {
+      unprefixed = unprefixed.slice(3);
+    }
+    return unprefixed === `*.${extension}`;
+  });
+}
+
+/**
+ * Expand the first brace group in a glob into the globs it stands for, keeping
+ * whatever surrounds it.
+ *
+ * `*.{ts,tsx}` becomes `*.ts` and `*.tsx`; `{**` + `/,}*.ts` becomes `**` +
+ * `/*.ts` and `*.ts`. One group is enough: nothing a caller writes for two
+ * extensions needs two, and a glob with no group is returned unchanged, so
+ * {@link matchesExtension} has a single shape to test either way.
+ */
+function expandBraceGroup(glob: string): string[] {
+  const open = glob.indexOf("{");
+  const close = glob.indexOf("}", open + 1);
+  if (open === -1 || close === -1) {
+    return [glob];
   }
-  const tail = unprefixed.slice(2);
-  if (tail === extension) {
-    return true;
-  }
-  if (!tail.startsWith("{") || !tail.endsWith("}")) {
-    return false;
-  }
-  return tail
-    .slice(1, -1)
+  const prefix = glob.slice(0, open);
+  const suffix = glob.slice(close + 1);
+  return glob
+    .slice(open + 1, close)
     .split(",")
-    .map((part) => part.trim())
-    .includes(extension);
+    .map((part) => `${prefix}${part.trim()}${suffix}`);
 }
 
 /**

--- a/packages/unplugin/src/next.ts
+++ b/packages/unplugin/src/next.ts
@@ -166,12 +166,12 @@ function withTtscTurbopackRules(
  * Whether some other rule already routes this glob's files through the loader.
  *
  * Deciding glob equivalence in general means implementing Turbopack's matcher,
- * which is not worth it here. What is worth it is the set a user actually
- * writes for these two extensions: a brace list naming the extension, and the
- * same glob under a leading `**` path prefix. Anything outside that is left
- * alone, which errs toward the wrapper doing nothing rather than toward
- * registering a second time, because a missing rule is visible and a double
- * transform is not.
+ * which is not worth it here. What is recognised instead is the set of globs
+ * that mean "every file with this extension", since only those can make the
+ * wrapper's own rules redundant. Anything narrower is left alone and the
+ * wrapper still adds its rules: skipping on a scoped glob would leave every
+ * module outside that scope untransformed, which is samchon/ttsc#1310 again and
+ * the quieter of the two failures.
  */
 function coveredByAnotherRule(
   rules: Record<string, unknown>,
@@ -190,11 +190,25 @@ function coveredByAnotherRule(
 }
 
 /**
- * Whether one glob names this extension, for the shapes a hand-written rule
- * takes: `*.ts`, `**` + `/*.ts`, and a brace list such as `*.{ts,tsx}`.
+ * Whether one glob names this extension across the whole project.
+ *
+ * Unscoped only. A rule restricted to a path, `src/*.{ts,tsx}` or
+ * `node_modules/**` + `/*.ts`, covers its own subtree and says nothing about
+ * the rest of the project, so treating it as covering everything would leave
+ * every module outside that subtree with no ttsc rule at all. That is the
+ * silent failure samchon/ttsc#1310 is about, and it is strictly worse than the
+ * double registration this guard exists to prevent: a build that transforms
+ * twice is wrong loudly, a build that never transforms is wrong quietly.
+ *
+ * So the shapes recognised are exactly the two that mean "every file with this
+ * extension": `*.ts` and `**` + `/*.ts`, each also in brace-list form.
  */
 function matchesExtension(glob: string, extension: string): boolean {
-  const tail = glob.slice(glob.lastIndexOf(".") + 1);
+  const unprefixed = glob.startsWith("**/") ? glob.slice(3) : glob;
+  if (!unprefixed.startsWith("*.")) {
+    return false;
+  }
+  const tail = unprefixed.slice(2);
   if (tail === extension) {
     return true;
   }

--- a/scripts/ci/validation-plan.cjs
+++ b/scripts/ci/validation-plan.cjs
@@ -211,7 +211,7 @@ const LANES = [
       // reader over Windows path spellings from the consumer's side.
       "pnpm --filter @ttsc/test-metro start -- " +
       "--include=cache_key --include=records_only_external " +
-      "--include=records_linked",
+      "--include=records_linked --include=adapters_policy",
   },
   {
     id: "graph",

--- a/tests/test-metro/src/features/cache/test_cache_key_covers_overlay_admitted_sources.ts
+++ b/tests/test-metro/src/features/cache/test_cache_key_covers_overlay_admitted_sources.ts
@@ -1,0 +1,12 @@
+import { assertCacheKeyCoversOverlayAdmittedSources } from "../../internal/metro-cache";
+
+/**
+ * Verifies the cache key covers a source the caller's overlay admits.
+ *
+ * See {@link assertCacheKeyCoversOverlayAdmittedSources}: samchon/ttsc#1316's
+ * acceptance criterion, that `getCacheKey` responds to a `.js` file under
+ * `compilerOptions: { allowJs: true }` and leaves the key alone without it.
+ */
+export const test_cache_key_covers_overlay_admitted_sources = async () => {
+  await assertCacheKeyCoversOverlayAdmittedSources();
+};

--- a/tests/test-metro/src/features/cache/test_cache_key_ignores_output_in_an_unlisted_directory.ts
+++ b/tests/test-metro/src/features/cache/test_cache_key_ignores_output_in_an_unlisted_directory.ts
@@ -1,0 +1,13 @@
+import { assertCacheKeyIgnoresOutputInAnUnlistedDirectory } from "../../internal/metro-cache";
+
+/**
+ * Verifies emitted output in an unnamed directory leaves the cache key alone.
+ *
+ * See {@link assertCacheKeyIgnoresOutputInAnUnlistedDirectory}: the Metro half
+ * of samchon/ttsc#1307, required by samchon/ttsc#1317 and missing when that
+ * work merged.
+ */
+export const test_cache_key_ignores_output_in_an_unlisted_directory =
+  async () => {
+    await assertCacheKeyIgnoresOutputInAnUnlistedDirectory();
+  };

--- a/tests/test-metro/src/features/cache/test_metro_asks_the_adapters_policy.ts
+++ b/tests/test-metro/src/features/cache/test_metro_asks_the_adapters_policy.ts
@@ -1,0 +1,13 @@
+import { assertMetroAsksTheAdaptersPolicy } from "../../internal/metro-cache";
+
+/**
+ * Verifies Metro resolves the membership policy the way the adapter does.
+ *
+ * See {@link assertMetroAsksTheAdaptersPolicy}: the caller's compiler-options
+ * overlay must widen Metro's walk as it widens the compile, and a directory
+ * occupying an `extends` candidate must not churn the memo
+ * (samchon/ttsc#1316).
+ */
+export const test_metro_asks_the_adapters_policy = async () => {
+  await assertMetroAsksTheAdaptersPolicy();
+};

--- a/tests/test-metro/src/internal/metro-cache.ts
+++ b/tests/test-metro/src/internal/metro-cache.ts
@@ -342,14 +342,14 @@ export async function assertCacheKeyFoldsNonceAfterSnapshotWriteFailure(): Promi
   await prepareSnapshot(root);
   const originalIdentity = readMainSnapshot(root).id;
   const originalKey = await cacheKeyForRun(root);
-  const { createSnapshotRecorder, resolveMembershipPolicy } =
+  const { createSnapshotRecorder, resolveProjectView } =
     await TestMetroRuntime.loadFingerprint();
   const recorder = createSnapshotRecorder();
-  const policy = resolveMembershipPolicy({ projectRoot: root });
+  const project = resolveProjectView({ projectRoot: root });
 
   fs.chmodSync(snapshotDirectory(root), 0o555);
   try {
-    recorder.record({ input: external, policy, projectRoot: root });
+    recorder.record({ input: external, project });
     assert.deepEqual(listWorkerSnapshots(root), []);
     assert.equal(listSnapshotRecoveryFiles(root).length, 1);
     assert.notEqual(await cacheKeyForRun(root), await cacheKeyForRun(root));
@@ -358,7 +358,7 @@ export async function assertCacheKeyFoldsNonceAfterSnapshotWriteFailure(): Promi
   }
 
   // The same observation retries because the failed publication stayed dirty.
-  recorder.record({ input: external, policy, projectRoot: root });
+  recorder.record({ input: external, project });
   assert.deepEqual(workerSnapshotFiles(root), [external]);
   await prepareSnapshot(root);
 
@@ -673,15 +673,14 @@ export async function assertTransformerRecordsVolatileDeclarations(): Promise<vo
 export async function assertCacheKeyChangesWhenSupersedingCandidateAppears(): Promise<void> {
   const root = createBareProject();
   const candidate = path.join(root, "src", "generated.ts");
-  const { createSnapshotRecorder, resolveMembershipPolicy } =
+  const { createSnapshotRecorder, resolveProjectView } =
     await TestMetroRuntime.loadFingerprint();
 
   await prepareSnapshot(root);
   const firstWorker = createSnapshotRecorder();
   firstWorker.record({
     input: candidate,
-    policy: resolveMembershipPolicy({ projectRoot: root }),
-    projectRoot: root,
+    project: resolveProjectView({ projectRoot: root }),
   });
   assert.deepEqual(workerSnapshotFiles(root), [candidate]);
 
@@ -708,20 +707,21 @@ export async function assertCleanTransformClearsVolatileSnapshot(): Promise<void
   const options = {
     upstreamTransformer: TestMetroRuntime.fakeUpstreamPathOnDisk(),
   };
-  const { createSnapshotRecorder, resolveMembershipPolicy } =
+  const { createSnapshotRecorder, resolveProjectView } =
     await TestMetroRuntime.loadFingerprint();
 
   await prepareSnapshot(root);
   const volatileWorker = createSnapshotRecorder();
-  volatileWorker.recordVolatile({ projectRoot: root });
+  volatileWorker.recordVolatile({
+    project: resolveProjectView({ projectRoot: root }),
+  });
   await prepareSnapshot(root);
   assert.equal(readMainSnapshot(root).volatile, true);
 
   const cleanWorker = createSnapshotRecorder();
   cleanWorker.record({
     input: path.join(root, "src", "app.ts"),
-    policy: resolveMembershipPolicy({ projectRoot: root }),
-    projectRoot: root,
+    project: resolveProjectView({ projectRoot: root }),
   });
   await prepareSnapshot(root);
 
@@ -832,18 +832,18 @@ export async function assertMetroAsksTheAdaptersPolicy(): Promise<void> {
   const fingerprint = await TestMetroRuntime.loadFingerprint();
   const root = createBareProject();
 
-  const strict = fingerprint.resolveMembershipPolicy({ projectRoot: root });
+  const strict = fingerprint.resolveProjectView({ projectRoot: root });
   assert.ok(
-    !strict.inputExtensions.includes(".js"),
-    `a project without allowJs must not admit .js (got ${strict.inputExtensions.join(" ")})`,
+    !strict.policy.inputExtensions.includes(".js"),
+    `a project without allowJs must not admit .js (got ${strict.policy.inputExtensions.join(" ")})`,
   );
 
-  const widened = fingerprint.resolveMembershipPolicy({
+  const widened = fingerprint.resolveProjectView({
     compilerOptions: { allowJs: true },
     projectRoot: root,
   });
   assert.ok(
-    widened.inputExtensions.includes(".js"),
+    widened.policy.inputExtensions.includes(".js"),
     "the caller's compiler-options overlay must widen Metro's policy too",
   );
 
@@ -857,12 +857,12 @@ export async function assertMetroAsksTheAdaptersPolicy(): Promise<void> {
     "utf8",
   );
   fs.mkdirSync(path.join(root, "config"), { recursive: true });
-  const first = fingerprint.resolveMembershipPolicy({ projectRoot: root });
+  const first = fingerprint.resolveProjectView({ projectRoot: root });
   fs.writeFileSync(path.join(root, "config", "note.txt"), "one", "utf8");
-  const second = fingerprint.resolveMembershipPolicy({ projectRoot: root });
+  const second = fingerprint.resolveProjectView({ projectRoot: root });
   assert.equal(
-    first,
-    second,
+    first.policy,
+    second.policy,
     "a file inside a directory occupying an extends candidate must not refresh the policy",
   );
 }
@@ -918,9 +918,17 @@ export async function assertCacheKeyCoversOverlayAdmittedSources(): Promise<void
  *
  * The Metro half of samchon/ttsc#1307's sharpest case, required by
  * samchon/ttsc#1317 and missing when that work merged. Content-hashed output is
- * not a rewrite in place: every rebuild removes a name and adds another, which
- * is a directory membership change, and the walk used to record every entry
- * regardless of whether it could ever enter the program.
+ * not a rewrite in place: every rebuild adds a name nothing had seen before,
+ * and the walk used to hash every entry regardless of whether it could ever
+ * enter the program.
+ *
+ * Metro reaches that through file hashes alone rather than through the
+ * directory-membership snapshot the adapter also keeps — `getCacheKey` folds
+ * only `collectProjectInputHashes`, so what has to be absent here is the new
+ * file's own hash. The adapter's directory identities are what make the same
+ * output cost it a compile, and
+ * {@link assertHashedBundleOutputKeepsTheGeneration} in `@ttsc/test-unplugin`
+ * covers that side.
  *
  * It costs more here than it does for a bundler. Metro folds one static key
  * into every file's per-content cache key, so a walk that re-keyed on emitted

--- a/tests/test-metro/src/internal/metro-cache.ts
+++ b/tests/test-metro/src/internal/metro-cache.ts
@@ -342,12 +342,14 @@ export async function assertCacheKeyFoldsNonceAfterSnapshotWriteFailure(): Promi
   await prepareSnapshot(root);
   const originalIdentity = readMainSnapshot(root).id;
   const originalKey = await cacheKeyForRun(root);
-  const { createSnapshotRecorder } = await TestMetroRuntime.loadFingerprint();
+  const { createSnapshotRecorder, resolveMembershipPolicy } =
+    await TestMetroRuntime.loadFingerprint();
   const recorder = createSnapshotRecorder();
+  const policy = resolveMembershipPolicy({ projectRoot: root });
 
   fs.chmodSync(snapshotDirectory(root), 0o555);
   try {
-    recorder.record({ input: external, projectRoot: root });
+    recorder.record({ input: external, policy, projectRoot: root });
     assert.deepEqual(listWorkerSnapshots(root), []);
     assert.equal(listSnapshotRecoveryFiles(root).length, 1);
     assert.notEqual(await cacheKeyForRun(root), await cacheKeyForRun(root));
@@ -356,7 +358,7 @@ export async function assertCacheKeyFoldsNonceAfterSnapshotWriteFailure(): Promi
   }
 
   // The same observation retries because the failed publication stayed dirty.
-  recorder.record({ input: external, projectRoot: root });
+  recorder.record({ input: external, policy, projectRoot: root });
   assert.deepEqual(workerSnapshotFiles(root), [external]);
   await prepareSnapshot(root);
 
@@ -671,12 +673,14 @@ export async function assertTransformerRecordsVolatileDeclarations(): Promise<vo
 export async function assertCacheKeyChangesWhenSupersedingCandidateAppears(): Promise<void> {
   const root = createBareProject();
   const candidate = path.join(root, "src", "generated.ts");
-  const { createSnapshotRecorder } = await TestMetroRuntime.loadFingerprint();
+  const { createSnapshotRecorder, resolveMembershipPolicy } =
+    await TestMetroRuntime.loadFingerprint();
 
   await prepareSnapshot(root);
   const firstWorker = createSnapshotRecorder();
   firstWorker.record({
     input: candidate,
+    policy: resolveMembershipPolicy({ projectRoot: root }),
     projectRoot: root,
   });
   assert.deepEqual(workerSnapshotFiles(root), [candidate]);
@@ -704,7 +708,8 @@ export async function assertCleanTransformClearsVolatileSnapshot(): Promise<void
   const options = {
     upstreamTransformer: TestMetroRuntime.fakeUpstreamPathOnDisk(),
   };
-  const { createSnapshotRecorder } = await TestMetroRuntime.loadFingerprint();
+  const { createSnapshotRecorder, resolveMembershipPolicy } =
+    await TestMetroRuntime.loadFingerprint();
 
   await prepareSnapshot(root);
   const volatileWorker = createSnapshotRecorder();
@@ -715,6 +720,7 @@ export async function assertCleanTransformClearsVolatileSnapshot(): Promise<void
   const cleanWorker = createSnapshotRecorder();
   cleanWorker.record({
     input: path.join(root, "src", "app.ts"),
+    policy: resolveMembershipPolicy({ projectRoot: root }),
     projectRoot: root,
   });
   await prepareSnapshot(root);
@@ -858,5 +864,50 @@ export async function assertMetroAsksTheAdaptersPolicy(): Promise<void> {
     first,
     second,
     "a file inside a directory occupying an extends candidate must not refresh the policy",
+  );
+}
+
+/**
+ * Asserts the cache key covers a source the caller's compiler-options overlay
+ * admits, which is samchon/ttsc#1316's stated acceptance criterion: "Metro's
+ * walk admits `.js` exactly as the adapter's does, provable through
+ * `getCacheKey` responding to a new `.js` file."
+ *
+ * Widening the policy object is not enough on its own, and getting only half of
+ * it is worse than getting neither. The walk and the recorder are the two
+ * halves of one cache key, and they run in different processes, so they agree
+ * only by deriving from the same declared options. Hand the overlay to the
+ * recorder alone and `isProjectWalkPath` answers that the walk covers an
+ * overlay-admitted `.js`, so the recorder drops it from the out-of-walk
+ * snapshot while the narrower walk never hashes it: the file is covered by
+ * neither half, and Metro serves its dependents' transforms across runs with
+ * nothing to notice the edit by.
+ *
+ * The strict control is what makes the positive case mean anything. Without the
+ * overlay the same `.js` is not a program input at all, so leaving the key
+ * alone is correct there, and an implementation that simply hashed every file
+ * would fail it.
+ */
+export async function assertCacheKeyCoversOverlayAdmittedSources(): Promise<void> {
+  const root = createBareProject();
+  const legacy = path.join(root, "src", "legacy.js");
+  fs.writeFileSync(legacy, "export const legacy = 1;\n", "utf8");
+  await prepareSnapshot(root);
+
+  const overlay = { compilerOptions: { allowJs: true } };
+  const before = await cacheKeyForRun(root, overlay);
+  fs.writeFileSync(legacy, "export const legacy = 2;\n", "utf8");
+  assert.notEqual(
+    before,
+    await cacheKeyForRun(root, overlay),
+    "under allowJs the walk must hash .js sources, so editing one re-keys the run",
+  );
+
+  const strict = await cacheKeyForRun(root);
+  fs.writeFileSync(legacy, "export const legacy = 3;\n", "utf8");
+  assert.equal(
+    strict,
+    await cacheKeyForRun(root),
+    "without the overlay a .js is not a program input, so it must not re-key the run",
   );
 }

--- a/tests/test-metro/src/internal/metro-cache.ts
+++ b/tests/test-metro/src/internal/metro-cache.ts
@@ -865,6 +865,31 @@ export async function assertMetroAsksTheAdaptersPolicy(): Promise<void> {
     second.policy,
     "a file inside a directory occupying an extends candidate must not refresh the policy",
   );
+
+  // The other direction, and the one that makes the first safe to want: the
+  // stamp still has to notice a real config arriving at a candidate path.
+  // `./config` resolves to `config.json` when that file exists, so its
+  // appearance changes the answer and must refresh the memo — a directory
+  // contributing its existence instead of its mtime must not blind the stamp
+  // to that. Widening `exclude` is what makes the refresh observable rather
+  // than merely re-derived.
+  fs.writeFileSync(
+    path.join(root, "config.json"),
+    JSON.stringify({ exclude: ["src/generated"] }),
+    "utf8",
+  );
+  const third = fingerprint.resolveProjectView({ projectRoot: root });
+  assert.notEqual(
+    second.policy,
+    third.policy,
+    "a config appearing at an extends candidate must refresh the policy",
+  );
+  assert.ok(
+    third.policy.excludedDirectories.some((directory: string) =>
+      directory.includes("generated"),
+    ),
+    `the refreshed policy must carry the new config's exclude (got ${JSON.stringify(third.policy.excludedDirectories)})`,
+  );
 }
 
 /**

--- a/tests/test-metro/src/internal/metro-cache.ts
+++ b/tests/test-metro/src/internal/metro-cache.ts
@@ -911,3 +911,57 @@ export async function assertCacheKeyCoversOverlayAdmittedSources(): Promise<void
     "without the overlay a .js is not a program input, so it must not re-key the run",
   );
 }
+
+/**
+ * Asserts output in a directory no configuration names leaves the cache key
+ * alone, while a new source the program could include still moves it.
+ *
+ * The Metro half of samchon/ttsc#1307's sharpest case, required by
+ * samchon/ttsc#1317 and missing when that work merged. Content-hashed output is
+ * not a rewrite in place: every rebuild removes a name and adds another, which
+ * is a directory membership change, and the walk used to record every entry
+ * regardless of whether it could ever enter the program.
+ *
+ * It costs more here than it does for a bundler. Metro folds one static key
+ * into every file's per-content cache key, so a walk that re-keyed on emitted
+ * output would discard the entire per-file transform cache rather than cost one
+ * compile — and `.expo/` is written to constantly by the dominant React Native
+ * toolchain, so the discard would happen on essentially every run.
+ *
+ * `lib` is deliberately neither the project's `outDir` nor one of the three
+ * names the walk still refuses, so nothing but the input-extension rule can
+ * make this pass: the project admits no JavaScript, so a `.js` bundle is not a
+ * membership change wherever it lands. The `src/late.ts` half is the control
+ * that keeps this from passing by never re-keying at all.
+ */
+export async function assertCacheKeyIgnoresOutputInAnUnlistedDirectory(): Promise<void> {
+  const root = createBareProject();
+  await prepareSnapshot(root);
+  const before = await cacheKeyForRun(root);
+
+  const lib = path.join(root, "lib");
+  fs.mkdirSync(lib, { recursive: true });
+  for (let build = 1; build <= 3; build += 1) {
+    fs.writeFileSync(
+      path.join(lib, `bundle.${build.toString(16)}f2a.js`),
+      `export const build = ${build};\n`,
+      "utf8",
+    );
+    assert.equal(
+      await cacheKeyForRun(root),
+      before,
+      "content-hashed output must not re-key the run that produced it",
+    );
+  }
+
+  fs.writeFileSync(
+    path.join(root, "src", "late.ts"),
+    "export const late: number = 1;\n",
+    "utf8",
+  );
+  assert.notEqual(
+    await cacheKeyForRun(root),
+    before,
+    "a new source the program could include must still re-key the run",
+  );
+}

--- a/tests/test-metro/src/internal/metro-cache.ts
+++ b/tests/test-metro/src/internal/metro-cache.ts
@@ -805,3 +805,58 @@ export async function assertCacheKeyChangesWhenTheTsconfigChanges(): Promise<voi
     "a tsconfig edit must re-key every transform in the run",
   );
 }
+
+/**
+ * Asserts Metro asks the membership policy the way the adapter does.
+ *
+ * Three differences the previous cycle left between the two packages
+ * (samchon/ttsc#1316), all of them the same shape: one product answering one
+ * question two ways.
+ *
+ * The overlay is the one with consequences. The adapter builds its policy as
+ * the project config plus the caller's compiler-options overlay, because the
+ * overlay wins for the compile and so must win for the membership rule. Metro
+ * read the project config alone, so `withTtsc(config, { compilerOptions: {
+ * allowJs: true } })` gave its walk a narrower program than the compile has.
+ *
+ * The directory stamp and the per-input lookup are cost rather than
+ * correctness, and both are measured in the issue.
+ */
+export async function assertMetroAsksTheAdaptersPolicy(): Promise<void> {
+  const fingerprint = await TestMetroRuntime.loadFingerprint();
+  const root = createBareProject();
+
+  const strict = fingerprint.resolveMembershipPolicy({ projectRoot: root });
+  assert.ok(
+    !strict.inputExtensions.includes(".js"),
+    `a project without allowJs must not admit .js (got ${strict.inputExtensions.join(" ")})`,
+  );
+
+  const widened = fingerprint.resolveMembershipPolicy({
+    compilerOptions: { allowJs: true },
+    projectRoot: root,
+  });
+  assert.ok(
+    widened.inputExtensions.includes(".js"),
+    "the caller's compiler-options overlay must widen Metro's policy too",
+  );
+
+  // A directory occupying an `extends` candidate can never be the config, so
+  // its children must not churn the memo.
+  const leaf = path.join(root, "tsconfig.json");
+  const declared = JSON.parse(fs.readFileSync(leaf, "utf8")) as object;
+  fs.writeFileSync(
+    leaf,
+    JSON.stringify({ ...declared, extends: "./config" }),
+    "utf8",
+  );
+  fs.mkdirSync(path.join(root, "config"), { recursive: true });
+  const first = fingerprint.resolveMembershipPolicy({ projectRoot: root });
+  fs.writeFileSync(path.join(root, "config", "note.txt"), "one", "utf8");
+  const second = fingerprint.resolveMembershipPolicy({ projectRoot: root });
+  assert.equal(
+    first,
+    second,
+    "a file inside a directory occupying an extends candidate must not refresh the policy",
+  );
+}

--- a/tests/test-metro/src/internal/metro-cache.ts
+++ b/tests/test-metro/src/internal/metro-cache.ts
@@ -890,6 +890,24 @@ export async function assertMetroAsksTheAdaptersPolicy(): Promise<void> {
     ),
     `the refreshed policy must carry the new config's exclude (got ${JSON.stringify(third.policy.excludedDirectories)})`,
   );
+
+  // And disappearing again, which #1316 asks for beside the appearance. A
+  // candidate that stops existing is the same kind of state change as one that
+  // starts, so the stamp has to move both ways or a project that deletes a
+  // shared config keeps compiling under it.
+  fs.rmSync(path.join(root, "config.json"));
+  const fourth = fingerprint.resolveProjectView({ projectRoot: root });
+  assert.notEqual(
+    third.policy,
+    fourth.policy,
+    "a config disappearing from an extends candidate must refresh the policy",
+  );
+  assert.ok(
+    !fourth.policy.excludedDirectories.some((directory: string) =>
+      directory.includes("generated"),
+    ),
+    "the refreshed policy must have dropped the deleted config's exclude",
+  );
 }
 
 /**
@@ -928,12 +946,33 @@ export async function assertCacheKeyCoversOverlayAdmittedSources(): Promise<void
     "under allowJs the walk must hash .js sources, so editing one re-keys the run",
   );
 
+  // The criterion's own wording is a *new* `.js` file rather than an edited
+  // one, and the two are different questions: an edit changes a file the walk
+  // already hashes, while an appearance changes which files the walk hashes at
+  // all. Both must move the key under the overlay.
+  const appeared = await cacheKeyForRun(root, overlay);
+  fs.writeFileSync(
+    path.join(root, "src", "arrived.js"),
+    "export const arrived = 1;\n",
+    "utf8",
+  );
+  assert.notEqual(
+    appeared,
+    await cacheKeyForRun(root, overlay),
+    "under allowJs a .js the program gains must re-key the run",
+  );
+
   const strict = await cacheKeyForRun(root);
   fs.writeFileSync(legacy, "export const legacy = 3;\n", "utf8");
+  fs.writeFileSync(
+    path.join(root, "src", "ignored.js"),
+    "export const ignored = 1;\n",
+    "utf8",
+  );
   assert.equal(
     strict,
     await cacheKeyForRun(root),
-    "without the overlay a .js is not a program input, so it must not re-key the run",
+    "without the overlay a .js is not a program input, so neither editing nor adding one re-keys the run",
   );
 }
 

--- a/tests/test-unplugin/src/features/adapters/test_bun_adapter_passes_through_an_out_of_program_module.ts
+++ b/tests/test-unplugin/src/features/adapters/test_bun_adapter_passes_through_an_out_of_program_module.ts
@@ -1,0 +1,14 @@
+import { assertBunAdapterPassesThroughAnOutOfProgramModule } from "../../internal/adapter-bun";
+
+/**
+ * Verifies the Bun bundler adapter passes an out-of-program module through.
+ *
+ * See {@link assertBunAdapterPassesThroughAnOutOfProgramModule}:
+ * samchon/ttsc#1308 asked for its pass-through contract to be proven per
+ * adapter, and samchon/ttsc#1317 records that only the core and Metro were
+ * pinned.
+ */
+export const test_bun_adapter_passes_through_an_out_of_program_module =
+  async () => {
+    await assertBunAdapterPassesThroughAnOutOfProgramModule();
+  };

--- a/tests/test-unplugin/src/features/adapters/test_next_adapter_does_not_double_register_across_globs.ts
+++ b/tests/test-unplugin/src/features/adapters/test_next_adapter_does_not_double_register_across_globs.ts
@@ -1,0 +1,14 @@
+import { assertNextAdapterDoesNotDoubleRegisterAcrossGlobs } from "../../internal/adapter-next";
+
+/**
+ * Verifies the wrapper does not register its loader twice for one file set.
+ *
+ * See {@link assertNextAdapterDoesNotDoubleRegisterAcrossGlobs}: a caller who
+ * hand-wired `"*.{ts,tsx}"` kept it and received the wrapper's two globs as
+ * well, so every module matched two rules and the loader ran twice
+ * (samchon/ttsc#1314).
+ */
+export const test_next_adapter_does_not_double_register_across_globs =
+  async () => {
+    await assertNextAdapterDoesNotDoubleRegisterAcrossGlobs();
+  };

--- a/tests/test-unplugin/src/features/adapters/test_turbopack_loader_passes_through_an_out_of_program_module.ts
+++ b/tests/test-unplugin/src/features/adapters/test_turbopack_loader_passes_through_an_out_of_program_module.ts
@@ -1,0 +1,14 @@
+import { assertTurbopackLoaderPassesThroughAnOutOfProgramModule } from "../../internal/adapter-turbopack";
+
+/**
+ * Verifies the turbopack loader passes an out-of-program module through.
+ *
+ * See {@link assertTurbopackLoaderPassesThroughAnOutOfProgramModule}:
+ * samchon/ttsc#1308 asked for its pass-through contract to be proven per
+ * adapter, and samchon/ttsc#1317 records that only the core and Metro were
+ * pinned.
+ */
+export const test_turbopack_loader_passes_through_an_out_of_program_module =
+  async () => {
+    await assertTurbopackLoaderPassesThroughAnOutOfProgramModule();
+  };

--- a/tests/test-unplugin/src/features/transform/test_transformttsc_reports_untranslatable_vite_aliases.ts
+++ b/tests/test-unplugin/src/features/transform/test_transformttsc_reports_untranslatable_vite_aliases.ts
@@ -1,0 +1,13 @@
+import { assertUntranslatableAliasesAreReported } from "../../internal/transform-vite-aliases";
+
+/**
+ * Verifies an alias form a tsconfig `paths` map cannot express is reported.
+ *
+ * See {@link assertUntranslatableAliasesAreReported}: Vite's `RegExp` `find` and
+ * a `find` containing `*` were both dropped in silence while both documents
+ * described the forwarding without qualifying it (samchon/ttsc#1315).
+ */
+export const test_transformttsc_reports_untranslatable_vite_aliases =
+  async () => {
+    await assertUntranslatableAliasesAreReported();
+  };

--- a/tests/test-unplugin/src/internal/adapter-bun.ts
+++ b/tests/test-unplugin/src/internal/adapter-bun.ts
@@ -435,10 +435,50 @@ async function assertBunRuntimeDoesNotRehashProjectPerModule(): Promise<void> {
   assert.match(lazy.contents, /secondary = 1/);
 }
 
+/**
+ * Asserts a module the compiled program does not contain falls through the Bun
+ * bundler adapter instead of failing the build.
+ *
+ * The Bun half of what samchon/ttsc#1308 asked to be proven per adapter and
+ * samchon/ttsc#1317 records was never proven. Its pass-through spelling is
+ * Bun's own: the bundler loader returns `undefined` to hand the module to the
+ * next loader, exactly as it does for a transform that changed nothing, so the
+ * source Bun compiles is the source on disk.
+ *
+ * The discriminator is the absence of a throw rather than the `undefined`
+ * itself. This file is a genuine transform target — a real `.ts` under the
+ * project root, outside `node_modules`, matching the adapter's own filter — and
+ * is absent from the program only because the fixture's tsconfig includes `src`
+ * alone. Before #1308 that threw and Bun turned it into a build failure. The
+ * filter is asserted here too, so the case cannot pass by the module never
+ * reaching the loader at all, which is how it would decay into
+ * {@link assertBunAdapterFallsThroughWhenItDoesNotTransform}'s excluded-path
+ * row.
+ */
+async function assertBunAdapterPassesThroughAnOutOfProgramModule(): Promise<void> {
+  const unpluginBun = await TestUnpluginRuntime.loadUnpluginAdapter("bun");
+  const root = TestUnpluginProject.createProject();
+  const stray = path.join(root, "scripts", "tool.ts");
+  fs.mkdirSync(path.dirname(stray), { recursive: true });
+  fs.writeFileSync(stray, "export const tool: string = 'STRAY';\n", "utf8");
+
+  const { loader, options } = await captureBunLoader(unpluginBun(), "bundler");
+  assert.ok(
+    options.filter.test(stray),
+    "the fixture must reach the loader, or the case proves nothing",
+  );
+  assert.equal(
+    await loader({ path: stray }),
+    undefined,
+    "a module outside the program must fall through, not fail the build",
+  );
+}
+
 export {
   assertBunAdapterRevalidatesOnBuildStart,
   assertBunAdapterExcludesNulVirtualIds,
   assertBunAdapterFallsThroughWhenItDoesNotTransform,
+  assertBunAdapterPassesThroughAnOutOfProgramModule,
   assertBunAdapterSurvivesPluginReportedDependencies,
   assertBunAdapterTransformsSource,
   assertBunAdapterYieldsToConfiguredInMemoryFiles,

--- a/tests/test-unplugin/src/internal/adapter-bun.ts
+++ b/tests/test-unplugin/src/internal/adapter-bun.ts
@@ -447,13 +447,18 @@ async function assertBunRuntimeDoesNotRehashProjectPerModule(): Promise<void> {
  *
  * The discriminator is the absence of a throw rather than the `undefined`
  * itself. This file is a genuine transform target — a real `.ts` under the
- * project root, outside `node_modules`, matching the adapter's own filter — and
- * is absent from the program only because the fixture's tsconfig includes `src`
- * alone. Before #1308 that threw and Bun turned it into a build failure. The
- * filter is asserted here too, so the case cannot pass by the module never
- * reaching the loader at all, which is how it would decay into
+ * project root, outside `node_modules` — and is absent from the program only
+ * because the fixture's tsconfig includes `src` alone. Before #1308 that threw
+ * and Bun turned it into a build failure.
+ *
+ * The `undefined` alone would be a weak assertion, because the loader returns
+ * it for an excluded path too: `options.filter` is only the coarse pattern
+ * `onLoad` is registered with, and the real gate is `isTransformTarget` inside
+ * the loader, so a case resting on the return value would keep passing if the
+ * module stopped reaching the transform at all and would decay into
  * {@link assertBunAdapterFallsThroughWhenItDoesNotTransform}'s excluded-path
- * row.
+ * row. The report is what tells the two apart: only a delivery that reached the
+ * compile and found no output for this file can emit it.
  */
 async function assertBunAdapterPassesThroughAnOutOfProgramModule(): Promise<void> {
   const unpluginBun = await TestUnpluginRuntime.loadUnpluginAdapter("bun");
@@ -462,15 +467,29 @@ async function assertBunAdapterPassesThroughAnOutOfProgramModule(): Promise<void
   fs.mkdirSync(path.dirname(stray), { recursive: true });
   fs.writeFileSync(stray, "export const tool: string = 'STRAY';\n", "utf8");
 
-  const { loader, options } = await captureBunLoader(unpluginBun(), "bundler");
-  assert.ok(
-    options.filter.test(stray),
-    "the fixture must reach the loader, or the case proves nothing",
-  );
+  const { loader } = await captureBunLoader(unpluginBun(), "bundler");
+  const original = process.stderr.write.bind(process.stderr);
+  let captured = "";
+  process.stderr.write = ((chunk: unknown) => {
+    captured += String(chunk);
+    return true;
+  }) as typeof process.stderr.write;
+  let result;
+  try {
+    result = await loader({ path: stray });
+  } finally {
+    process.stderr.write = original;
+  }
+
   assert.equal(
-    await loader({ path: stray }),
+    result,
     undefined,
     "a module outside the program must fall through, not fail the build",
+  );
+  assert.ok(
+    captured.includes(stray) &&
+      captured.includes(path.join(root, "tsconfig.json")),
+    `the loader must have reached the program and reported the module (got ${JSON.stringify(captured)})`,
   );
 }
 

--- a/tests/test-unplugin/src/internal/adapter-next.ts
+++ b/tests/test-unplugin/src/internal/adapter-next.ts
@@ -232,11 +232,35 @@ export async function assertNextAdapterDoesNotDoubleRegisterAcrossGlobs(): Promi
     );
   }
 
-  // And the shape the guard does recognise, under a recursive prefix.
+  // And the shapes the guard does recognise. Each names every file with the
+  // extension, so the wrapper's own rules would be a second registration of a
+  // file set the caller already routed. They are one rule rather than a list of
+  // cases: expand the brace group, drop leading `**/` segments, and what is
+  // left must be exactly `*.ts` or `*.tsx`.
+  for (const wide of ["**/*.{ts,tsx}", "**/{*.ts,*.tsx}", "**/**/*.{ts,tsx}"]) {
+    assert.deepEqual(
+      globs({ turbopack: { rules: { [wide]: { loaders: [LOADER] } } } }),
+      [wide],
+      `${wide} names every file of both extensions, so nothing is added`,
+    );
+  }
+
+  // Recognition is per extension, not per rule: a glob naming every `.ts` and
+  // no `.tsx` suppresses only the `*.ts` registration, exactly as the partial
+  // hand wiring above does. Both of these mean every `.ts` in the project.
+  for (const partial of ["{**/,}*.ts", "{src/,}*.ts"]) {
+    assert.deepEqual(
+      globs({ turbopack: { rules: { [partial]: { loaders: [LOADER] } } } }),
+      [partial, "*.tsx"],
+      `${partial} names every .ts, so only the missing .tsx is added`,
+    );
+  }
   assert.deepEqual(
-    globs({ turbopack: { rules: { "**/*.{ts,tsx}": { loaders: [LOADER] } } } }),
-    ["**/*.{ts,tsx}"],
-    "a project-wide brace list under a recursive prefix already covers both",
+    globs({
+      turbopack: { rules: { "{src,lib}/*.{ts,tsx}": { loaders: [LOADER] } } },
+    }),
+    ["{src,lib}/*.{ts,tsx}", "*.ts", "*.tsx"],
+    "a brace group over scopes stays scoped and must not suppress anything",
   );
 }
 

--- a/tests/test-unplugin/src/internal/adapter-next.ts
+++ b/tests/test-unplugin/src/internal/adapter-next.ts
@@ -200,11 +200,15 @@ export async function assertNextAdapterDoesNotDoubleRegisterAcrossGlobs(): Promi
   );
 
   // A partial hand wiring is still completed: `.tsx` is unrouted without us.
-  assert.deepEqual(
-    globs({ turbopack: { rules: { "*.ts": { loaders: [LOADER] } } } }),
-    ["*.ts", "*.tsx"],
-    "a partial hand wiring must still gain the glob it is missing",
-  );
+  // Both spellings of it, since samchon/ttsc#1314 asks for the recursive one by
+  // name and a guard could recognise `*.ts` while missing `**` + `/*.ts`.
+  for (const partial of ["*.ts", "**/*.ts"]) {
+    assert.deepEqual(
+      globs({ turbopack: { rules: { [partial]: { loaders: [LOADER] } } } }),
+      [partial, "*.tsx"],
+      `${partial} must still gain the glob it is missing`,
+    );
+  }
 
   // Somebody else's loader on the same file set is not this loader running
   // twice, so ttsc still has to be wired.

--- a/tests/test-unplugin/src/internal/adapter-next.ts
+++ b/tests/test-unplugin/src/internal/adapter-next.ts
@@ -162,6 +162,61 @@ export async function assertNextAdapterPreservesTurbopackConfig(): Promise<void>
 }
 
 /**
+ * Asserts the wrapper does not register the loader a second time under a glob
+ * the caller spelled differently.
+ *
+ * The dedupe guard read only the rule stored under the exact key the wrapper
+ * writes, so a caller who had wired `"*.{ts,tsx}"` by hand, which is the
+ * natural way to write two identical rules and what the README asked for before
+ * this wrapper existed, kept their rule and received `"*.ts"` and `"*.tsx"` as
+ * well. Every TypeScript module then matched two rules and the loader ran twice
+ * on it, with the second pass receiving the first pass's output
+ * (samchon/ttsc#1314).
+ *
+ * The wrapper still completes a partial hand wiring, since `"*.ts"` alone
+ * leaves `.tsx` unrouted, and still adds its own rules beside a glob carrying
+ * somebody else's loader, because that is not this loader running twice.
+ */
+export async function assertNextAdapterDoesNotDoubleRegisterAcrossGlobs(): Promise<void> {
+  const next = await loadNext();
+  const globs = (config: INextLikeConfig): string[] =>
+    Object.keys(next(config).turbopack?.rules ?? {});
+
+  assert.deepEqual(
+    globs({ turbopack: { rules: { "*.{ts,tsx}": { loaders: [LOADER] } } } }),
+    ["*.{ts,tsx}"],
+    "a brace list already carrying the loader must not gain two more rules",
+  );
+  assert.deepEqual(
+    globs({
+      turbopack: {
+        rules: {
+          "**/*.ts": { loaders: [LOADER] },
+          "**/*.tsx": { loaders: [LOADER] },
+        },
+      },
+    }),
+    ["**/*.ts", "**/*.tsx"],
+    "a recursive prefix already carrying the loader must not gain two more",
+  );
+
+  // A partial hand wiring is still completed: `.tsx` is unrouted without us.
+  assert.deepEqual(
+    globs({ turbopack: { rules: { "*.ts": { loaders: [LOADER] } } } }),
+    ["*.ts", "*.tsx"],
+    "a partial hand wiring must still gain the glob it is missing",
+  );
+
+  // Somebody else's loader on the same file set is not this loader running
+  // twice, so ttsc still has to be wired.
+  assert.deepEqual(
+    globs({ turbopack: { rules: { "*.{ts,tsx}": { loaders: ["other"] } } } }),
+    ["*.{ts,tsx}", "*.ts", "*.tsx"],
+    "another loader's glob must not suppress ttsc's own rules",
+  );
+}
+
+/**
  * Asserts the wrapper says what Next.js can no longer say for it.
  *
  * Next refuses to build on Turbopack when a config carries a `webpack` hook and

--- a/tests/test-unplugin/src/internal/adapter-next.ts
+++ b/tests/test-unplugin/src/internal/adapter-next.ts
@@ -166,12 +166,11 @@ export async function assertNextAdapterPreservesTurbopackConfig(): Promise<void>
  * the caller spelled differently.
  *
  * The dedupe guard read only the rule stored under the exact key the wrapper
- * writes, so a caller who had wired `"*.{ts,tsx}"` by hand, which is the
- * natural way to write two identical rules and what the README asked for before
- * this wrapper existed, kept their rule and received `"*.ts"` and `"*.tsx"` as
- * well. Every TypeScript module then matched two rules and the loader ran twice
- * on it, with the second pass receiving the first pass's output
- * (samchon/ttsc#1314).
+ * writes, so a caller who had wired `"*.{ts,tsx}"` by hand, which is a natural
+ * way to write two identical rules, kept their rule and received `"*.ts"` and
+ * `"*.tsx"` as well. Every TypeScript module then matched two rules and the
+ * loader ran twice on it, with the second pass receiving the first pass's
+ * output (samchon/ttsc#1314).
  *
  * The wrapper still completes a partial hand wiring, since `"*.ts"` alone
  * leaves `.tsx` unrouted, and still adds its own rules beside a glob carrying
@@ -213,6 +212,31 @@ export async function assertNextAdapterDoesNotDoubleRegisterAcrossGlobs(): Promi
     globs({ turbopack: { rules: { "*.{ts,tsx}": { loaders: ["other"] } } } }),
     ["*.{ts,tsx}", "*.ts", "*.tsx"],
     "another loader's glob must not suppress ttsc's own rules",
+  );
+
+  // The direction that matters most, because getting it wrong is
+  // samchon/ttsc#1310 again rather than a double transform: a rule scoped to a
+  // path covers its own subtree and says nothing about the rest of the
+  // project, so the wrapper must still add its own.
+  for (const scoped of [
+    "src/*.{ts,tsx}",
+    "src/**/*.ts",
+    "./src/**/*.{ts,tsx}",
+    "generated.ts",
+    "*.d.ts",
+  ]) {
+    assert.deepEqual(
+      globs({ turbopack: { rules: { [scoped]: { loaders: [LOADER] } } } }),
+      [scoped, "*.ts", "*.tsx"],
+      `a rule scoped by ${scoped} must not suppress the project-wide rules`,
+    );
+  }
+
+  // And the shape the guard does recognise, under a recursive prefix.
+  assert.deepEqual(
+    globs({ turbopack: { rules: { "**/*.{ts,tsx}": { loaders: [LOADER] } } } }),
+    ["**/*.{ts,tsx}"],
+    "a project-wide brace list under a recursive prefix already covers both",
   );
 }
 

--- a/tests/test-unplugin/src/internal/adapter-turbopack.ts
+++ b/tests/test-unplugin/src/internal/adapter-turbopack.ts
@@ -1,5 +1,6 @@
 import { TestUnpluginProject, TestUnpluginRuntime } from "@ttsc/testing";
 import assert from "node:assert/strict";
+import fs from "node:fs";
 import path from "node:path";
 
 /**
@@ -355,9 +356,42 @@ async function assertTurbopackLoaderMarksVolatileModulesUncacheable(): Promise<v
   assert.deepEqual(hermeticRun.cacheableCalls, []);
 }
 
+/**
+ * Asserts a module the compiled program does not contain passes through the
+ * loader instead of failing the Turbopack build.
+ *
+ * Samchon/ttsc#1308 moved that decision into the shared core so every adapter
+ * answers it once, and asked for it to be proven per adapter rather than for
+ * the core alone; samchon/ttsc#1317 records that it never was. The core case
+ * pins the report and the once-per-pass rule, and this pins the outcome at the
+ * boundary that actually reaches a bundler.
+ *
+ * The discriminator is the absence of a throw. This file is a genuine transform
+ * target — a real `.ts` under the project root, outside `node_modules`, not a
+ * declaration — so no filter turns it away; it is simply absent from the
+ * program, because the fixture's tsconfig includes `src` alone. Before #1308
+ * the adapter threw here and Turbopack turned that into a build failure.
+ * Passing through is not silent: the core reports the file and the program on
+ * stderr once per pass.
+ */
+async function assertTurbopackLoaderPassesThroughAnOutOfProgramModule(): Promise<void> {
+  const root = TestUnpluginProject.createProject();
+  const stray = path.join(root, "scripts", "tool.ts");
+  fs.mkdirSync(path.dirname(stray), { recursive: true });
+  const source = "export const tool: string = 'STRAY';\n";
+  fs.writeFileSync(stray, source, "utf8");
+
+  assert.equal(
+    await runTurbopackLoader({ resourcePath: stray, source }),
+    source,
+    "a module outside the program must pass through the loader unchanged",
+  );
+}
+
 export {
   assertTurbopackLoaderForwardsRuleOptions,
   assertTurbopackLoaderMarksVolatileModulesUncacheable,
+  assertTurbopackLoaderPassesThroughAnOutOfProgramModule,
   assertTurbopackLoaderPassesThroughFilteredPaths,
   assertTurbopackLoaderPassesThroughNonSourceIds,
   assertTurbopackLoaderRegistersDependenciesOnCacheHit,

--- a/tests/test-unplugin/src/internal/adapter-turbopack.ts
+++ b/tests/test-unplugin/src/internal/adapter-turbopack.ts
@@ -371,8 +371,15 @@ async function assertTurbopackLoaderMarksVolatileModulesUncacheable(): Promise<v
  * declaration — so no filter turns it away; it is simply absent from the
  * program, because the fixture's tsconfig includes `src` alone. Before #1308
  * the adapter threw here and Turbopack turned that into a build failure.
- * Passing through is not silent: the core reports the file and the program on
- * stderr once per pass.
+ *
+ * Returning the source unchanged is on its own a weak assertion, because it is
+ * also what the loader does for a path its filter rejects — so a case resting
+ * on it alone would keep passing if the module stopped reaching the transform
+ * at all, and would then prove nothing about the program. The report is what
+ * distinguishes them: only a delivery that reached the compile and found no
+ * output for this file can emit it, so asserting it pins that the pass-through
+ * happened for the stated reason. It is also half the contract, since passing
+ * through must not be silent.
  */
 async function assertTurbopackLoaderPassesThroughAnOutOfProgramModule(): Promise<void> {
   const root = TestUnpluginProject.createProject();
@@ -381,10 +388,28 @@ async function assertTurbopackLoaderPassesThroughAnOutOfProgramModule(): Promise
   const source = "export const tool: string = 'STRAY';\n";
   fs.writeFileSync(stray, source, "utf8");
 
+  const original = process.stderr.write.bind(process.stderr);
+  let captured = "";
+  process.stderr.write = ((chunk: unknown) => {
+    captured += String(chunk);
+    return true;
+  }) as typeof process.stderr.write;
+  let content: string;
+  try {
+    content = await runTurbopackLoader({ resourcePath: stray, source });
+  } finally {
+    process.stderr.write = original;
+  }
+
   assert.equal(
-    await runTurbopackLoader({ resourcePath: stray, source }),
+    content,
     source,
     "a module outside the program must pass through the loader unchanged",
+  );
+  assert.ok(
+    captured.includes(stray) &&
+      captured.includes(path.join(root, "tsconfig.json")),
+    `the loader must have reached the program and reported the module (got ${JSON.stringify(captured)})`,
   );
 }
 

--- a/tests/test-unplugin/src/internal/transform-vite-aliases.ts
+++ b/tests/test-unplugin/src/internal/transform-vite-aliases.ts
@@ -120,17 +120,23 @@ async function assertUntranslatableAliasesAreReported() {
     "a reported alias must not stop the forwardable ones reaching the compile",
   );
   assert.ok(
-    captured.includes("/^~/"),
-    `the RegExp alias must be named in the report (got ${JSON.stringify(captured)})`,
-  );
-  assert.ok(
     captured.includes("@glob/*"),
-    "the wildcard alias must be named in the report",
+    `the wildcard alias must be named in the report (got ${JSON.stringify(captured)})`,
   );
   assert.equal(
-    captured.split("/^~/").length - 1,
+    captured.split("@glob/*").length - 1,
     1,
     "the report must appear once per process, not once per delivery",
+  );
+  // The `RegExp` form is documented and deliberately not reported. Vite merges
+  // `/^\/?@vite\/env/` and `/^\/?@vite\/client/` into every resolved config, so
+  // a report on this form fires twice for every Vite user in every build about
+  // aliases they never wrote. This is the assertion that keeps that noise from
+  // coming back, and it is why the fixture's own `RegExp` is shaped like one a
+  // user would write rather than like Vite's.
+  assert.ok(
+    !captured.includes("/^~/"),
+    `the RegExp form must not be reported (got ${JSON.stringify(captured)})`,
   );
 }
 

--- a/tests/test-unplugin/src/internal/transform-vite-aliases.ts
+++ b/tests/test-unplugin/src/internal/transform-vite-aliases.ts
@@ -40,4 +40,101 @@ async function assertTransformPassesBundlerAliases() {
   assert.match(result.code, /"PLUGIN"/);
 }
 
-export { assertTransformPassesBundlerAliases };
+/**
+ * Asserts an alias form a tsconfig `paths` map cannot express is reported
+ * rather than silently dropped, and costs the forwardable aliases nothing.
+ *
+ * Vite's array form accepts a `RegExp` `find`, and `{ find: /^~/ }` is a common
+ * way to spell a prefix alias. `paths` has no regular-expression form, so such
+ * an alias cannot be translated at all; a `find` containing `*` cannot either,
+ * because a `paths` key already reads `*` as its own wildcard. Both used to be
+ * dropped in silence while both documents said the adapter "reads the resolved
+ * `resolve.alias` and layers it onto the generated config" without qualifying
+ * it, so a user whose aliases were ignored had nothing to read that explained
+ * why (samchon/ttsc#1315).
+ *
+ * The consequence was never wrong output — the compile falls back to the
+ * tsconfig's own `paths`, and a specifier that resolves for the bundler but not
+ * the compiler surfaces as the out-of-program report (samchon/ttsc#1308). But
+ * that report names the module, not the alias, so it cannot tell the user that
+ * a configuration they wrote was ignored.
+ *
+ * The string entry sharing the array is the control: a report must not cost the
+ * aliases that do forward, and `assert-paths` fails the compile unless `@lib`
+ * reached the generated config. The second delivery pins the once-per-process
+ * rule, since `resolve.alias` is resolved once and consulted per module, so
+ * reporting per delivery would repeat one statement about the config for every
+ * file in the bundle.
+ */
+async function assertUntranslatableAliasesAreReported() {
+  const { resolveOptions, transformTtsc } =
+    await TestUnpluginRuntime.loadUnpluginApi();
+  const root = TestUnpluginProject.createProject({ plugins: [] });
+  const options = resolveOptions({
+    plugins: [
+      {
+        transform: "./plugin.cjs",
+        name: "fixture",
+        operation: "assert-paths",
+        key: "@lib",
+        target: path.join(root, "src", "modules").replace(/\\/g, "/"),
+      },
+    ],
+  });
+  const aliases = [
+    { find: /^~/, replacement: path.join(root, "src") },
+    { find: "@glob/*", replacement: path.join(root, "src", "glob") },
+    { find: "@lib", replacement: path.join(root, "src", "modules") },
+  ];
+
+  const original = process.stderr.write.bind(process.stderr);
+  let captured = "";
+  process.stderr.write = ((chunk: unknown) => {
+    captured += String(chunk);
+    return true;
+  }) as typeof process.stderr.write;
+  let result;
+  try {
+    result = await transformTtsc(
+      TestUnpluginProject.mainFile(root),
+      TestUnpluginProject.mainSource(root),
+      options,
+      aliases,
+    );
+    // Same process, same aliases: the statement is about the configuration, so
+    // asking again must not repeat it.
+    await transformTtsc(
+      TestUnpluginProject.mainFile(root),
+      TestUnpluginProject.mainSource(root),
+      options,
+      aliases,
+    );
+  } finally {
+    process.stderr.write = original;
+  }
+
+  assert.ok(result);
+  assert.match(
+    result.code,
+    /"PLUGIN"/,
+    "a reported alias must not stop the forwardable ones reaching the compile",
+  );
+  assert.ok(
+    captured.includes("/^~/"),
+    `the RegExp alias must be named in the report (got ${JSON.stringify(captured)})`,
+  );
+  assert.ok(
+    captured.includes("@glob/*"),
+    "the wildcard alias must be named in the report",
+  );
+  assert.equal(
+    captured.split("/^~/").length - 1,
+    1,
+    "the report must appear once per process, not once per delivery",
+  );
+}
+
+export {
+  assertTransformPassesBundlerAliases,
+  assertUntranslatableAliasesAreReported,
+};

--- a/tests/test-unplugin/src/internal/transform-vite-aliases.ts
+++ b/tests/test-unplugin/src/internal/transform-vite-aliases.ts
@@ -38,6 +38,30 @@ async function assertTransformPassesBundlerAliases() {
 
   assert.ok(result);
   assert.match(result.code, /"PLUGIN"/);
+
+  // A `find` written with a trailing slash keeps today's outcome, which
+  // samchon/ttsc#1315 asks for by name: the slash is stripped, so `"@trail/"`
+  // reaches the compile under the key `"@trail"` and its `"@trail/*"` wildcard,
+  // the same pair a slashless `find` produces. Left unpinned, a reader could
+  // reasonably think the two spellings give different keys.
+  const trailing = await transformTtsc(
+    TestUnpluginProject.mainFile(root),
+    TestUnpluginProject.mainSource(root),
+    resolveOptions({
+      plugins: [
+        {
+          transform: "./plugin.cjs",
+          name: "fixture",
+          operation: "assert-paths",
+          key: "@trail",
+          target: path.join(root, "src", "modules").replace(/\\/g, "/"),
+        },
+      ],
+    }),
+    [{ find: "@trail/", replacement: path.join(root, "src", "modules") }],
+  );
+  assert.ok(trailing);
+  assert.match(trailing.code, /"PLUGIN"/);
 }
 
 /**

--- a/website/src/content/docs/setup/metro.mdx
+++ b/website/src/content/docs/setup/metro.mdx
@@ -75,6 +75,22 @@ module.exports = withTtsc(getDefaultConfig(__dirname), {
 
 Options travel from the Metro config process to its worker processes through an environment variable, so they must stay JSON-serialisable: substring patterns, not `RegExp`.
 
+## Files outside the program
+
+Metro resolves its own module graph, and that graph is not the set of files your `tsconfig` describes. A file Metro delivers that the compiled program does not contain is passed to the upstream transformer untransformed, and reported once per pass naming the file and the `tsconfig` it is missing from:
+
+```text
+ttsc: /app/scripts/tool.ts is not part of the program described by /app/tsconfig.json,
+so it was left untransformed. Add it to that project's "include" if ttsc plugins
+should apply to it.
+```
+
+This is not a build error. The file is simply not this project's to transform, and the usual cause is a Metro graph reaching past the `tsconfig`'s `include` — a source beside `src` rather than inside it, or one in a sibling workspace folder. Add it to that project's `include` if `ttsc` plugins should apply to it.
+
+The report matters because passing through is not the same as leaving alone: a file that skips the `ttsc` pass keeps whatever plugin-driven syntax it carries, which fails at runtime rather than at build time. Declaration and JavaScript files never reach the pass at all, so they are not reported; they are filtered before it, as `include` / `exclude` above describes.
+
+This answer belongs to the shared transform core rather than to Metro, so every [`@ttsc/unplugin`](/docs/setup/unplugin) adapter gives the identical one.
+
 ## Cache invalidation
 
 A module-resolution candidate that would outrank a selected target is recorded as a fingerprint input. A missing candidate remains recorded even when it lies under the project root, so creating it changes the next Metro cache key even though the first project walk could not hash a path that did not yet exist. Existing unsuccessful probes are already part of the ordinary project walk or the recorded out-of-walk set.

--- a/website/src/content/docs/setup/metro.mdx
+++ b/website/src/content/docs/setup/metro.mdx
@@ -77,7 +77,7 @@ Options travel from the Metro config process to its worker processes through an 
 
 ## Files outside the program
 
-Metro resolves its own module graph, and that graph is not the set of files your `tsconfig` describes. A file Metro delivers that the compiled program does not contain is passed to the upstream transformer untransformed, and reported once per pass naming the file and the `tsconfig` it is missing from:
+Metro resolves its own module graph, and that graph is not the set of files your `tsconfig` describes. A file Metro delivers that the compiled program does not contain is passed to the upstream transformer untransformed, and reported naming the file and the `tsconfig` it is missing from — once per file per compile in each Metro worker, since a Metro worker has no build boundary to reset the report at:
 
 ```text
 ttsc: /app/scripts/tool.ts is not part of the program described by /app/tsconfig.json,

--- a/website/src/content/docs/setup/unplugin.mdx
+++ b/website/src/content/docs/setup/unplugin.mdx
@@ -241,7 +241,9 @@ Not every Vite alias form can be forwarded, because a tsconfig `paths` map canno
 | array form with a `RegExp` `find`, such as `{ find: /^~/ }` | no — `paths` has no regular-expression form |
 | a string `find` containing `*` | no — a `paths` key already reads `*` as its own wildcard |
 
-An alias that cannot be forwarded is reported once, naming the alias and the reason, and the compile resolves that specifier through the tsconfig's `paths` alone. Declare it there if `ttsc` must resolve through it — a prefix `RegExp` such as `/^~/` is written as a `"~/*"` entry. Reducing simple prefix patterns automatically is deliberately not attempted: distinguishing `/^~/` from `/^@app/`, which also matches `@apple`, needs enough of a regular-expression engine that a wrong reduction becomes likely, and a mistranslated alias resolves imports to the wrong file without saying so.
+In both unforwarded cases the compile resolves that specifier through the tsconfig's `paths` alone, so declare it there if `ttsc` must resolve through it — a prefix `RegExp` such as `/^~/` is written as a `"~/*"` entry. Reducing simple prefix patterns automatically is deliberately not attempted: distinguishing `/^~/` from `/^@app/`, which also matches `@apple`, needs enough of a regular-expression engine that a wrong reduction becomes likely, and a mistranslated alias resolves imports to the wrong file without saying so.
+
+A `find` containing `*` is also reported once on stderr, naming the alias and the reason. A `RegExp` `find` is not, and the asymmetry is deliberate: Vite merges two `RegExp` aliases of its own into every resolved config, for `@vite/env` and `@vite/client`, so a report on that form would fire in every build of every project and name aliases you never wrote.
 
 ## Cache and watch invalidation
 

--- a/website/src/content/docs/setup/unplugin.mdx
+++ b/website/src/content/docs/setup/unplugin.mdx
@@ -233,6 +233,16 @@ ttsc({
 
 Under Vite, the adapter reads the resolved `resolve.alias` and layers it onto the generated config, so an alias declared only in `vite.config.ts` still resolves during the compile. No other host's alias configuration is read: under Rollup, Rolldown, webpack, Rspack, esbuild, Farm, Turbopack and Bun, the compile resolves through the tsconfig's own `paths` alone. Declare an alias in `paths` when a module has to resolve for the compiler as well as for the bundler, which is what those hosts need anyway for `tsc` to type-check the same imports.
 
+Not every Vite alias form can be forwarded, because a tsconfig `paths` map cannot express all of them:
+
+| `resolve.alias` form | Forwarded |
+| --- | --- |
+| `{ "@": "/src" }`, or the array form with a string `find` | yes |
+| array form with a `RegExp` `find`, such as `{ find: /^~/ }` | no — `paths` has no regular-expression form |
+| a string `find` containing `*` | no — a `paths` key already reads `*` as its own wildcard |
+
+An alias that cannot be forwarded is reported once, naming the alias and the reason, and the compile resolves that specifier through the tsconfig's `paths` alone. Declare it there if `ttsc` must resolve through it — a prefix `RegExp` such as `/^~/` is written as a `"~/*"` entry. Reducing simple prefix patterns automatically is deliberately not attempted: distinguishing `/^~/` from `/^@app/`, which also matches `@apple`, needs enough of a regular-expression engine that a wrong reduction becomes likely, and a mistranslated alias resolves imports to the wrong file without saying so.
+
 ## Cache and watch invalidation
 
 The compiler also reports module-resolution candidates that would outrank a selected target. `@ttsc/unplugin` registers candidates belonging to importers in a transformed file's reference closure, so creating or changing a higher-priority probe invalidates the transform even when neither the importer nor its tsconfig changed.


### PR DESCRIPTION
Cycle 3 of the `@ttsc/unplugin` campaign. Four issues, one branch, no residue.

## What this closes

- **#1314** — the Turbopack dedupe guard registered the loader twice for one file set, whenever the caller spelled that set differently from the wrapper.
- **#1316** — `@ttsc/metro` asked the membership policy differently from the adapter that defines it: no compiler-options overlay, a memo keyed without it, a directory stamped by mtime, and a policy re-derived once per watch input.
- **#1317** — four acceptance criteria from the previous cycle's issues that shipped undischarged, all of them documentation or proof rather than behaviour.
- **#1315** — Vite alias forms a tsconfig `paths` map cannot express were dropped in silence, and the membership-policy surface on `@ttsc/unplugin/api` was undocumented.

## The one that mattered

The overlay fix landed wrong the first time. It reached the snapshot **recorder** and not the project **walk**, so an overlay-admitted `.js` was judged in-walk by the recorder — and therefore dropped from the out-of-walk snapshot — while the narrower walk never hashed it. Covered by neither half, its edits moved no cache key, and Metro would serve its dependents' transforms across runs with nothing to notice by. That is the quietest form of the both-sides-disagree hole the policy exists to close, and it was strictly worse than the divergence it replaced.

It was caught because it is #1316's own stated acceptance criterion — "provable through `getCacheKey` responding to a new `.js` file" — and nothing had asked. The case now asks, with the strict control beside it.

Two follow-ons: the recorder's policy now travels bound to the project it describes, so a policy for one project cannot arrive with the root of another; and both new adapter cases now assert the core's report, because resting on the pass-through value alone let them pass in 1.1s without ever reaching a compile.

## Verification

Every new case was run against the behaviour it guards and confirmed to fail:

| Case | Reverted behaviour | Result |
| --- | --- | --- |
| overlay-admitted sources | overlay withheld from the walk | identical keys across the edit |
| unlisted-directory output | input-extension rule widened | key moves on emitted output |
| the same, other half | rule narrowed to nothing | key does not move on a new source |
| both adapter pass-throughs | `isTransformTarget` refuses the fixture | no report emitted |
| both adapter pass-throughs | pass-through reverted to a throw | throws |
| untranslatable aliases | — | report asserted, once per process |

## Bookkeeping

Two contaminations were caught by reading commit stats rather than by any test, and both are recorded rather than quietly dropped: `f0028657c` carries part of #1316's Metro work its message does not mention, and `09a9a6665` swept in 276 whitespace-only lines of a Go file that a timed-out `pnpm format` left half-converted between `gofmt` and its two-space post-processing. The Go file is restored in `2bdbbe71d`; the branch is byte-identical to master outside the surface these issues own. The commits squash on merge, so the misattribution does not reach master history.

One CI gap closed: `test_metro_asks_the_adapters_policy` shipped into a Windows lane whose filter could not select it, though that lane exists precisely to exercise the config reader over Windows path spellings.
