### PR TITLE
fix(metro): chain the caller's transformer, and verify the Turbopack claims

### DIFF
--- a/experimental/test-unplugin/src/index.ts
+++ b/experimental/test-unplugin/src/index.ts
@@ -86,6 +86,7 @@ function main() {
   verifyRspackBuild();
   verifyFarmBuild();
   verifyNextBuild();
+  verifyTurbopackRecognisedGlobs();
   verifyBunBuild();
   verifyBunRuntime();
   console.log("Success");
@@ -161,7 +162,7 @@ function prepareWorkspace() {
             },
           ],
         },
-        include: ["src", "pages"],
+        include: ["src", "pages", "turbopack-root-entry.ts"],
       },
       null,
       2,
@@ -183,7 +184,7 @@ function prepareWorkspace() {
           noEmit: true,
           resolveJsonModule: true,
         },
-        include: ["next-env.d.ts", "pages", "src"],
+        include: ["next-env.d.ts", "pages", "src", "turbopack-root-entry.ts"],
       },
       null,
       2,
@@ -213,6 +214,7 @@ function prepareWorkspace() {
   writeSource("farm-entry.ts", "farm-installed-ok");
   writeSource("next-entry.ts", "next-installed-ok");
   writeSource("bun-entry.ts", "bun-installed-ok");
+  writeTurbopackRootEntry();
   writeNextPage();
   writeTransformPlugin();
   writeViteConfig();
@@ -236,15 +238,38 @@ function writeSource(file, marker) {
   );
 }
 
+/**
+ * A source at the project root, which `src/next-entry.ts` cannot stand in for.
+ *
+ * The dedupe guard skips the wrapper's own rules when a caller's glob already
+ * names every file with the extension, and whether a glob does that is
+ * Turbopack's answer, not ours. A `**` + `/` prefix that required at least one
+ * segment would cover `src/` and miss this file, which is how a recognised
+ * spelling turns into samchon/ttsc#1310: no rule, no transform, green build.
+ * `middleware.ts` and `instrumentation.ts` are the real files at this depth.
+ */
+function writeTurbopackRootEntry() {
+  fs.writeFileSync(
+    path.join(workspace, "turbopack-root-entry.ts"),
+    [
+      'export const rootValue = mark("turbopack-root-ok");',
+      "console.log(rootValue);",
+      "",
+    ].join("\n"),
+    "utf8",
+  );
+}
+
 function writeNextPage() {
   fs.mkdirSync(path.join(workspace, "pages"), { recursive: true });
   fs.writeFileSync(
     path.join(workspace, "pages", "index.js"),
     [
       'import { value } from "../src/next-entry";',
+      'import { rootValue } from "../turbopack-root-entry";',
       "",
       "export default function Page() {",
-      "  return value;",
+      "  return value + rootValue;",
       "}",
       "",
     ].join("\n"),
@@ -322,9 +347,21 @@ function writeTransformPlugin() {
       "  root := *cwd",
       '  if root == "" { root, _ = os.Getwd() }',
       "  out := map[string]string{}",
-      '  err := filepath.WalkDir(filepath.Join(root, "src"), func(file string, entry fs.DirEntry, err error) error {',
+      // Walk the project rather than `src` alone. A real ttsc host returns an
+      // entry for every file in the program, so a fixture that skipped the
+      // project root made a root-level source look absent from the program and
+      // reported it as such — the fixture's answer, not the product's. The
+      // Turbopack glob verification needs a root-level source to be real
+      // (samchon/ttsc#1319).
+      "  skipDirs := map[string]bool{" +
+        '"node_modules": true, ".next": true, ".git": true, ' +
+        '"dist-next": true, "dist-vite": true, "dist-rollup": true, ' +
+        '"dist-rolldown": true, "dist-esbuild": true, "dist-webpack": true, ' +
+        '"dist-rspack": true, "dist-farm": true, "dist-bun": true}',
+      "  err := filepath.WalkDir(root, func(file string, entry fs.DirEntry, err error) error {",
       "    if err != nil { return err }",
-      '    if entry.IsDir() || strings.HasSuffix(file, ".d.ts") || (!strings.HasSuffix(file, ".ts") && !strings.HasSuffix(file, ".tsx")) {',
+      "    if entry.IsDir() { if skipDirs[entry.Name()] { return filepath.SkipDir }; return nil }",
+      '    if strings.HasSuffix(file, ".d.ts") || (!strings.HasSuffix(file, ".ts") && !strings.HasSuffix(file, ".tsx")) {',
       "      return nil",
       "    }",
       "    source, err := os.ReadFile(file)",
@@ -744,6 +781,92 @@ function verifyNextBuild() {
       "next-installed-ok",
     );
   }
+}
+
+/**
+ * The globs `withTtsc`'s dedupe guard treats as naming every file with an
+ * extension, so it declines to add its own rules beside them.
+ *
+ * Kept here rather than imported, because the point is to check our belief
+ * against Turbopack rather than to restate it: if `next.ts` grows a spelling,
+ * this list has to grow with it and a real build has to agree.
+ */
+const TURBOPACK_PROJECT_WIDE_GLOBS = [
+  "*.ts",
+  "**/*.ts",
+  "*.{ts,tsx}",
+  "**/*.{ts,tsx}",
+  "**/{*.ts,*.tsx}",
+  "{**/,}*.ts",
+  "**/**/*.{ts,tsx}",
+];
+
+/**
+ * Verify the dedupe guard's recognised set against the bundler that owns it.
+ *
+ * `withTtsc` skips registering its `*.ts` and `*.tsx` rules when a caller's own
+ * rule already carries this loader for the same file set. Recognising a glob
+ * that does _not_ in fact cover everything leaves the uncovered modules with no
+ * ttsc rule at all — a build that succeeds with plugin-driven constructs
+ * untransformed, which is samchon/ttsc#1310 and has already happened twice in
+ * this wrapper.
+ *
+ * Every spelling is sound today, measured. What was missing is anything that
+ * would notice it stopping: the recognised set is a contract with Turbopack's
+ * matcher, and a Next.js upgrade is enough to break it (samchon/ttsc#1319). So
+ * each glob is hand-wired the way a caller would, the guard is left to
+ * recognise it and add nothing, and a real build has to show both a nested and
+ * a root-level module transformed. A unit test cannot answer this, because it
+ * would only ask our own matcher what our own matcher thinks.
+ */
+function verifyTurbopackRecognisedGlobs() {
+  for (const glob of TURBOPACK_PROJECT_WIDE_GLOBS) {
+    fs.writeFileSync(
+      path.join(workspace, "next.config.mjs"),
+      [
+        'import withTtsc from "@ttsc/unplugin/next";',
+        "",
+        "export default withTtsc(",
+        "  {",
+        '    distDir: "dist-next",',
+        "    typescript: {",
+        "      ignoreBuildErrors: true,",
+        "    },",
+        "    turbopack: {",
+        "      rules: {",
+        `        ${JSON.stringify(glob)}: {`,
+        '          loaders: ["@ttsc/unplugin/turbopack"],',
+        "        },",
+        "      },",
+        "    },",
+        "  },",
+        "  {",
+        '    project: "tsconfig.unplugin.json",',
+        "  },",
+        ");",
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+    fs.rmSync(path.join(workspace, "dist-next"), {
+      force: true,
+      recursive: true,
+    });
+    run("npx next build --turbopack", workspace);
+    assertBuiltTreeContains(
+      "dist-next",
+      "NEXT-INSTALLED-OK",
+      `next --turbopack recognised glob ${glob} (nested)`,
+      "next-installed-ok",
+    );
+    assertBuiltTreeContains(
+      "dist-next",
+      "TURBOPACK-ROOT-OK",
+      `next --turbopack recognised glob ${glob} (root)`,
+      "turbopack-root-ok",
+    );
+  }
+  writeNextConfig();
 }
 
 function verifyBunBuild() {

--- a/experimental/test-unplugin/src/index.ts
+++ b/experimental/test-unplugin/src/index.ts
@@ -46,6 +46,24 @@ const adapterEntrypoints = [
   "webpack",
 ];
 
+/**
+ * The globs `withTtsc`'s dedupe guard treats as naming every file with an
+ * extension, so it declines to add its own rules beside them.
+ *
+ * Kept here rather than imported, because the point is to check our belief
+ * against Turbopack rather than to restate it: if `next.ts` grows a spelling,
+ * this list has to grow with it and a real build has to agree.
+ */
+const TURBOPACK_PROJECT_WIDE_GLOBS = [
+  "*.ts",
+  "**/*.ts",
+  "*.{ts,tsx}",
+  "**/*.{ts,tsx}",
+  "**/{*.ts,*.tsx}",
+  "{**/,}*.ts",
+  "**/**/*.{ts,tsx}",
+];
+
 const requireFromRoot = createRequire(path.join(root, "package.json"));
 
 /**
@@ -782,24 +800,6 @@ function verifyNextBuild() {
     );
   }
 }
-
-/**
- * The globs `withTtsc`'s dedupe guard treats as naming every file with an
- * extension, so it declines to add its own rules beside them.
- *
- * Kept here rather than imported, because the point is to check our belief
- * against Turbopack rather than to restate it: if `next.ts` grows a spelling,
- * this list has to grow with it and a real build has to agree.
- */
-const TURBOPACK_PROJECT_WIDE_GLOBS = [
-  "*.ts",
-  "**/*.ts",
-  "*.{ts,tsx}",
-  "**/*.{ts,tsx}",
-  "**/{*.ts,*.tsx}",
-  "{**/,}*.ts",
-  "**/**/*.{ts,tsx}",
-];
 
 /**
  * Verify the dedupe guard's recognised set against the bundler that owns it.

--- a/experimental/test-unplugin/src/index.ts
+++ b/experimental/test-unplugin/src/index.ts
@@ -59,11 +59,13 @@ const adapterEntrypoints = [
 const TURBOPACK_PROJECT_WIDE_GLOBS = [
   "*.ts",
   "**/*.ts",
+  "{**/,}*.ts",
+  "*.tsx",
+  "**/*.tsx",
   "*.{ts,tsx}",
   "{*.ts,*.tsx}",
   "**/*.{ts,tsx}",
   "**/{*.ts,*.tsx}",
-  "{**/,}*.ts",
   "**/**/*.{ts,tsx}",
 ];
 

--- a/experimental/test-unplugin/src/index.ts
+++ b/experimental/test-unplugin/src/index.ts
@@ -51,18 +51,34 @@ const adapterEntrypoints = [
  * extension, so it declines to add its own rules beside them.
  *
  * Kept here rather than imported, because the point is to check our belief
- * against Turbopack rather than to restate it: if `next.ts` grows a spelling,
- * this list has to grow with it and a real build has to agree.
+ * against Turbopack rather than to restate it. The unit case
+ * `test_next_adapter_does_not_double_register_across_globs` asserts this list
+ * and the guard agree in both directions, so a spelling cannot be added to one
+ * without the other.
  */
 const TURBOPACK_PROJECT_WIDE_GLOBS = [
   "*.ts",
   "**/*.ts",
   "*.{ts,tsx}",
+  "{*.ts,*.tsx}",
   "**/*.{ts,tsx}",
   "**/{*.ts,*.tsx}",
   "{**/,}*.ts",
   "**/**/*.{ts,tsx}",
 ];
+
+/**
+ * Globs the guard must refuse, driven through a real build for the same reason
+ * the recognised set is.
+ *
+ * `{src/,}*.ts` is the one that matters. Set semantics say it offers a bare
+ * `*.ts` and therefore covers the project, and on that reasoning the guard once
+ * recognised it — but Turbopack matches **nothing** with it, so suppressing
+ * this wrapper's rules in its favour transformed no file at all. Refusing it
+ * means the wrapper adds its own rules and every source is still transformed,
+ * which is what these builds assert (samchon/ttsc#1319).
+ */
+const TURBOPACK_SCOPED_GLOBS = ["{src/,}*.ts", "src/**/*.ts"];
 
 const requireFromRoot = createRequire(path.join(root, "package.json"));
 
@@ -276,6 +292,19 @@ function writeTurbopackRootEntry() {
     ].join("\n"),
     "utf8",
   );
+  // A `.tsx` source as well, because the guard decides per extension and a Next
+  // project is mostly `.tsx`. A glob recognised for `.ts` alone must still
+  // leave the wrapper adding its own `*.tsx` rule, and only a build can say
+  // whether that happened.
+  fs.writeFileSync(
+    path.join(workspace, "src", "turbopack-tsx-entry.tsx"),
+    [
+      'export const tsxValue = mark("turbopack-tsx-ok");',
+      "console.log(tsxValue);",
+      "",
+    ].join("\n"),
+    "utf8",
+  );
 }
 
 function writeNextPage() {
@@ -285,9 +314,10 @@ function writeNextPage() {
     [
       'import { value } from "../src/next-entry";',
       'import { rootValue } from "../turbopack-root-entry";',
+      'import { tsxValue } from "../src/turbopack-tsx-entry";',
       "",
       "export default function Page() {",
-      "  return value + rootValue;",
+      "  return value + rootValue + tsxValue;",
       "}",
       "",
     ].join("\n"),
@@ -371,14 +401,16 @@ function writeTransformPlugin() {
       // reported it as such — the fixture's answer, not the product's. The
       // Turbopack glob verification needs a root-level source to be real
       // (samchon/ttsc#1319).
-      "  skipDirs := map[string]bool{" +
-        '"node_modules": true, ".next": true, ".git": true, ' +
-        '"dist-next": true, "dist-vite": true, "dist-rollup": true, ' +
-        '"dist-rolldown": true, "dist-esbuild": true, "dist-webpack": true, ' +
-        '"dist-rspack": true, "dist-farm": true, "dist-bun": true}',
+      // Derived rather than listed. Every build output this harness writes is a
+      // `dist-` directory, so a new adapter verification cannot silently add
+      // its emitted `.ts` to the program by landing somewhere unlisted.
+      '  skipDirs := map[string]bool{"node_modules": true, ".next": true, ".git": true, ".ttsc": true}',
       "  err := filepath.WalkDir(root, func(file string, entry fs.DirEntry, err error) error {",
-      "    if err != nil { return err }",
-      "    if entry.IsDir() { if skipDirs[entry.Name()] { return filepath.SkipDir }; return nil }",
+      // A vanished entry is not a reason to fail a build. The project root is a
+      // live tree while Next is writing to it, and returning the error here
+      // aborted the whole transform; walking `src` alone never saw that.
+      "    if err != nil { if os.IsNotExist(err) { return nil }; return err }",
+      '    if entry.IsDir() { if skipDirs[entry.Name()] || strings.HasPrefix(entry.Name(), "dist-") { return filepath.SkipDir }; return nil }',
       '    if strings.HasSuffix(file, ".d.ts") || (!strings.HasSuffix(file, ".ts") && !strings.HasSuffix(file, ".tsx")) {',
       "      return nil",
       "    }",
@@ -820,7 +852,10 @@ function verifyNextBuild() {
  * would only ask our own matcher what our own matcher thinks.
  */
 function verifyTurbopackRecognisedGlobs() {
-  for (const glob of TURBOPACK_PROJECT_WIDE_GLOBS) {
+  for (const glob of [
+    ...TURBOPACK_PROJECT_WIDE_GLOBS,
+    ...TURBOPACK_SCOPED_GLOBS,
+  ]) {
     fs.writeFileSync(
       path.join(workspace, "next.config.mjs"),
       [
@@ -853,18 +888,23 @@ function verifyTurbopackRecognisedGlobs() {
       recursive: true,
     });
     run("npx next build --turbopack", workspace);
-    assertBuiltTreeContains(
-      "dist-next",
-      "NEXT-INSTALLED-OK",
-      `next --turbopack recognised glob ${glob} (nested)`,
-      "next-installed-ok",
-    );
-    assertBuiltTreeContains(
-      "dist-next",
-      "TURBOPACK-ROOT-OK",
-      `next --turbopack recognised glob ${glob} (root)`,
-      "turbopack-root-ok",
-    );
+    // The assertion is the same either way, and that is the point: whether the
+    // guard recognised the caller's glob or added its own rules beside it, the
+    // end state has to be that every TypeScript source was transformed. A
+    // recognised glob that does not really cover the project fails here, and so
+    // does a refused one the wrapper then failed to complete.
+    for (const [marker, original, depth] of [
+      ["NEXT-INSTALLED-OK", "next-installed-ok", "nested .ts"],
+      ["TURBOPACK-ROOT-OK", "turbopack-root-ok", "root .ts"],
+      ["TURBOPACK-TSX-OK", "turbopack-tsx-ok", "nested .tsx"],
+    ]) {
+      assertBuiltTreeContains(
+        "dist-next",
+        marker,
+        `next --turbopack glob ${glob} (${depth})`,
+        original,
+      );
+    }
   }
   writeNextConfig();
 }

--- a/packages/metro/README.md
+++ b/packages/metro/README.md
@@ -43,6 +43,8 @@ module.exports = withTtsc(getDefaultConfig(__dirname));
 
 If your config already set `transformer.babelTransformerPath`, that transformer is **chained rather than replaced**: the `ttsc` pass runs first and then delegates to it, so wrapping a working config keeps what it configured. This is what makes `react-native-svg-transformer` — whose entire installation is that one assignment — keep working after you adopt `@ttsc/metro`. Pass `upstreamTransformer` explicitly to override both that and auto-detection.
 
+The value is resolved from your `projectRoot`, exactly as Metro resolves it, so a relative `"./metro-svg.cjs"` and a bare `"react-native-svg-transformer"` both mean what they mean in your project rather than inside this package. A path that names `@ttsc/metro`'s own transformer is never chained — in any spelling, including a second copy installed elsewhere in your tree — because delegating this transformer into itself would recurse on every file.
+
 Auto-detection only skips a candidate whose entry point is genuinely **not available** — the package is not installed, or it is installed but the requested subpath is not exported (Expo/React Native version skew). A candidate that _does_ resolve but fails while loading — a top-level throw, an incompatible runtime ABI, or a missing peer/transitive dependency — surfaces its original error (as the `cause` of a `@ttsc/metro` wrapper) instead of being treated as absent. This stops a broken Expo/React Native install from silently falling through to the wrong transformer, and stops an explicit `upstreamTransformer` failure from being reported as if the module did not exist.
 
 ## Configuration

--- a/packages/metro/README.md
+++ b/packages/metro/README.md
@@ -41,6 +41,8 @@ module.exports = withTtsc(getDefaultConfig(__dirname));
 
 `withTtsc` sets `transformer.babelTransformerPath` and leaves the rest of your config untouched. It auto-detects the upstream transformer to delegate to (`@expo/metro-config/babel-transformer` for Expo, then `@react-native/metro-babel-transformer`, then the legacy `metro-react-native-babel-transformer`).
 
+If your config already set `transformer.babelTransformerPath`, that transformer is **chained rather than replaced**: the `ttsc` pass runs first and then delegates to it, so wrapping a working config keeps what it configured. This is what makes `react-native-svg-transformer` — whose entire installation is that one assignment — keep working after you adopt `@ttsc/metro`. Pass `upstreamTransformer` explicitly to override both that and auto-detection.
+
 Auto-detection only skips a candidate whose entry point is genuinely **not available** — the package is not installed, or it is installed but the requested subpath is not exported (Expo/React Native version skew). A candidate that _does_ resolve but fails while loading — a top-level throw, an incompatible runtime ABI, or a missing peer/transitive dependency — surfaces its original error (as the `cause` of a `@ttsc/metro` wrapper) instead of being treated as absent. This stops a broken Expo/React Native install from silently falling through to the wrong transformer, and stops an explicit `upstreamTransformer` failure from being reported as if the module did not exist.
 
 ## Configuration
@@ -60,7 +62,7 @@ module.exports = withTtsc(getDefaultConfig(__dirname), {
 - `project`: path to the `tsconfig.json` the transformer should read (resolved from `process.cwd()`).
 - `compilerOptions`: a temporary overlay layered on the selected project config.
 - `plugins`: an explicit `ttsc` plugin list override, or `false` to disable project plugins.
-- `upstreamTransformer`: an explicit module path for the Babel transformer to delegate to, when auto-detection is not what you want.
+- `upstreamTransformer`: an explicit module path for the Babel transformer to delegate to, when neither the config's own transformer nor auto-detection is what you want.
 - `include` / `exclude`: substring patterns matched against the project-relative file path, selecting which files run through the `ttsc` pass (`.ts`/`.tsx`/`.cts`/`.mts` only; declaration and JavaScript files always pass straight through).
 
 Options are forwarded from the Metro **config** process to Metro's **worker** processes through the `TTSC_METRO_OPTIONS` environment variable, so they must stay JSON-serialisable (hence substring patterns rather than `RegExp`).

--- a/packages/metro/src/index.ts
+++ b/packages/metro/src/index.ts
@@ -27,6 +27,8 @@
  *   module.exports = withTtsc(getDefaultConfig(__dirname));
  *   ```
  */
+import { readFileSync, realpathSync } from "node:fs";
+import { createRequire } from "node:module";
 import { basename, dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -117,33 +119,110 @@ function inheritConfiguredTransformer(
   if (
     options.upstreamTransformer !== undefined ||
     typeof declared !== "string" ||
-    declared.length === 0 ||
-    isOwnTransformer(declared)
+    declared.length === 0
   ) {
     return options;
   }
-  return { ...options, upstreamTransformer: declared };
+  // Resolve before judging. Ownership is a property of the module, not of the
+  // string, and every spelling has to become one absolute path before either
+  // question can be answered honestly.
+  const resolved = resolveFromProject(declared, config);
+  if (isOwnTransformer(resolved)) {
+    return options;
+  }
+  return { ...options, upstreamTransformer: resolved };
 }
 
 /**
- * Whether a `babelTransformerPath` already points at this package's
- * transformer.
+ * Resolve a declared `babelTransformerPath` the way Metro would: from the
+ * project.
  *
- * Compared by directory and base name rather than by string equality, because
- * the same module is reachable as `transformer.js`, `transformer.mjs`, or
- * through a path a caller spelled differently, and adopting any of them would
- * make this transformer its own upstream.
+ * Metro resolves this value against the project, while the worker resolves
+ * `upstreamTransformer` with a `require` rooted in this package's own
+ * `lib/core`. Those are different places, so passing the caller's spelling
+ * through unchanged asks the worker to find the module somewhere it was never
+ * meant to be. Resolving here, once, in the config process that still knows the
+ * project root, removes the ambiguity for every spelling at once:
+ *
+ * - A relative `./metro-svg.cjs` becomes the file the caller meant, instead of
+ *   one looked for inside `@ttsc/metro` and not found;
+ * - A bare `react-native-svg-transformer` becomes its real location, which
+ *   matters under pnpm, where this package sits in a virtual store and walking
+ *   up from it never reaches the project's own `node_modules`;
+ * - An absolute path resolves to itself, unchanged;
+ * - And `require.resolve("@ttsc/metro/transformer")` — a caller who wired this
+ *   package by hand — becomes a path {@link isOwnTransformer} can recognise,
+ *   which no comparison against the bare specifier could.
+ *
+ * A specifier that cannot be resolved is handed on exactly as written. It may
+ * still resolve in the worker, and if it does not, `resolveUpstreamTransformer`
+ * names it in an error; inventing a path here would only move the failure
+ * somewhere less legible.
+ */
+function resolveFromProject(declared: string, config: MetroConfigLike): string {
+  const base =
+    typeof config.projectRoot === "string" && config.projectRoot.length !== 0
+      ? config.projectRoot
+      : process.cwd();
+  try {
+    return createRequire(join(resolve(base), "package.json")).resolve(declared);
+  } catch {
+    return declared;
+  }
+}
+
+/**
+ * Whether a `babelTransformerPath` already points at a `@ttsc/metro`
+ * transformer — this copy or any other.
+ *
+ * Adopting one would make this transformer its own upstream. That is not merely
+ * redundant: the worker options are process-global, so the adopted copy reads
+ * the same `TTSC_METRO_OPTIONS`, finds itself named there, and recurses until
+ * the stack ends. Comparing directory strings was not enough, because a second
+ * installed copy — a differently hoisted `node_modules`, a shared config
+ * package that already wrapped — lives in a different directory and passed the
+ * check.
+ *
+ * So the question asked is "is this module a `@ttsc/metro` transformer", not
+ * "is this string our path": the real path settles the same-copy case through
+ * symlinks and drive-letter spellings, and the owning `package.json` settles
+ * every other copy.
  */
 function isOwnTransformer(declared: string): boolean {
-  const ours = transformerModulePath();
   const candidate = resolve(declared);
-  if (candidate === resolve(ours)) {
+  if (sameRealPath(candidate, transformerModulePath())) {
     return true;
   }
-  return (
-    dirname(candidate) === dirname(resolve(ours)) &&
-    basename(candidate).startsWith("transformer.")
-  );
+  if (!/^transformer\.(?:js|mjs|cjs)$/i.test(basename(candidate))) {
+    return false;
+  }
+  try {
+    const manifest = join(dirname(dirname(candidate)), "package.json");
+    return JSON.parse(readFileSync(manifest, "utf8")).name === "@ttsc/metro";
+  } catch {
+    // No readable manifest beside it, so nothing identifies it as ours.
+    return false;
+  }
+}
+
+/**
+ * Whether two paths name the same file on disk.
+ *
+ * Resolved through `realpath` so a symlinked install and its target compare
+ * equal, and case-folded on Windows, where `D:\` and `d:\` and a differently
+ * cased base name all address one file.
+ */
+function sameRealPath(left: string, right: string): boolean {
+  const identity = (file: string): string => {
+    let resolved = resolve(file);
+    try {
+      resolved = realpathSync.native(resolved);
+    } catch {
+      // Not on disk: the resolved spelling is the best identity available.
+    }
+    return process.platform === "win32" ? resolved.toLowerCase() : resolved;
+  };
+  return identity(left) === identity(right);
 }
 
 /**

--- a/packages/metro/src/index.ts
+++ b/packages/metro/src/index.ts
@@ -27,7 +27,7 @@
  *   module.exports = withTtsc(getDefaultConfig(__dirname));
  *   ```
  */
-import { dirname, join } from "node:path";
+import { basename, dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { prepareSnapshot } from "./core/fingerprint";
@@ -64,12 +64,22 @@ interface MetroConfigLike {
  * With no `options`, the transformer auto-discovers `tsconfig.json` and runs
  * the plugins configured there: the standard ttsc model. Pass `options` only to
  * override the project path, plugin list, or include/exclude filters.
+ *
+ * A `babelTransformerPath` the config already carried is chained rather than
+ * replaced: it becomes the upstream this transformer delegates to, so wrapping
+ * a working config keeps whatever it configured. `react-native-svg-transformer`
+ * is installed by exactly that assignment, and replacing it silently sent every
+ * `.svg` to the auto-detected Expo default instead, with the build still
+ * succeeding (samchon/ttsc#1321). An explicit `upstreamTransformer` option
+ * still wins, since that is the caller saying it outright.
  */
 export function withTtsc<T extends MetroConfigLike>(
   config: T,
   options: TtscMetroOptions = {},
 ): T {
-  process.env[ENV_KEY] = serializeOptions(options);
+  process.env[ENV_KEY] = serializeOptions(
+    inheritConfiguredTransformer(config, options),
+  );
   // Prepare the reference-graph snapshot backing the transformer's cache-key
   // fingerprint (see `core/fingerprint.ts`). This runs in the single Metro
   // config process before any worker exists, so it is the race-free moment to
@@ -84,6 +94,56 @@ export function withTtsc<T extends MetroConfigLike>(
       babelTransformerPath: transformerModulePath(),
     },
   } as T;
+}
+
+/**
+ * Adopt the config's own `babelTransformerPath` as the upstream to delegate to.
+ *
+ * The value `withTtsc` overwrites is precisely the transformer that should run
+ * after the ttsc pass, so taking it as the default `upstreamTransformer` is
+ * what makes the wrapper additive in the one field it sets. Everything else in
+ * the config was already spread through untouched, which is what made the loss
+ * hard to see (samchon/ttsc#1321).
+ *
+ * An explicit option wins, and this package's own transformer is never adopted:
+ * a config wrapped twice would otherwise name this module as its own upstream
+ * and delegate into itself.
+ */
+function inheritConfiguredTransformer(
+  config: MetroConfigLike,
+  options: TtscMetroOptions,
+): TtscMetroOptions {
+  const declared = config.transformer?.babelTransformerPath;
+  if (
+    options.upstreamTransformer !== undefined ||
+    typeof declared !== "string" ||
+    declared.length === 0 ||
+    isOwnTransformer(declared)
+  ) {
+    return options;
+  }
+  return { ...options, upstreamTransformer: declared };
+}
+
+/**
+ * Whether a `babelTransformerPath` already points at this package's
+ * transformer.
+ *
+ * Compared by directory and base name rather than by string equality, because
+ * the same module is reachable as `transformer.js`, `transformer.mjs`, or
+ * through a path a caller spelled differently, and adopting any of them would
+ * make this transformer its own upstream.
+ */
+function isOwnTransformer(declared: string): boolean {
+  const ours = transformerModulePath();
+  const candidate = resolve(declared);
+  if (candidate === resolve(ours)) {
+    return true;
+  }
+  return (
+    dirname(candidate) === dirname(resolve(ours)) &&
+    basename(candidate).startsWith("transformer.")
+  );
 }
 
 /**

--- a/packages/unplugin/README.md
+++ b/packages/unplugin/README.md
@@ -120,6 +120,8 @@ export default withTtsc(nextConfig);
 
 `withTtsc` covers both of Next.js's bundlers. It injects the webpack plugin and wires the Turbopack loader rules, with the options you pass reaching both, so the same config works whether Next runs on Turbopack (the default in current majors) or on webpack. Your own `webpack` hook and `turbopack` block are preserved: unrelated rules and settings survive, and a rule you already wired for this loader by hand is left alone rather than registered twice.
 
+That last part is decided by exact spelling. `withTtsc` declines to add its own rule when your glob is one it has measured against a real Turbopack build as naming every file with the extension — `*.ts`, `**/*.ts`, `{**/,}*.ts`, `*.tsx`, `**/*.tsx`, `*.{ts,tsx}`, `{*.ts,*.tsx}`, `**/*.{ts,tsx}`, `**/{*.ts,*.tsx}`, `**/**/*.{ts,tsx}`. Any other spelling keeps your rule and gains ours beside it, so a module may be transformed twice rather than not at all. The list is exact on purpose: treating an unmeasured glob as project-wide once left every module in a project with no `ttsc` rule at all, and a build that transforms twice is recoverable in a way a build that never transforms is not.
+
 ### Turbopack
 
 Turbopack has no JS plugin API, but it runs webpack loaders through `turbopack.rules`, and a ttsc transform is exactly loader-shaped (TypeScript source in, transformed source out). `@ttsc/unplugin/turbopack` is that standalone loader. In a Next.js project `withTtsc` wires it for you; wire it directly when Turbopack runs outside Next, or when you want the rules under your own control:

--- a/packages/unplugin/src/next.ts
+++ b/packages/unplugin/src/next.ts
@@ -88,14 +88,22 @@ export default function next(
 }
 
 /**
- * Say what Next.js can no longer say once this wrapper defines `turbopack`.
+ * Tell a caller their webpack-only configuration will not run.
  *
- * Next refuses to build on Turbopack when a config carries a `webpack` hook and
- * no `turbopack` block, because the webpack hook is then silently ignored. This
- * wrapper always defines both, so that check can never fire again for anyone
- * who uses it, and a caller's own webpack customisation would be dropped on a
- * Turbopack build with nothing said. Wiring ttsc for Turbopack is worth exactly
- * one warning, not the loss of the warning Next already gave.
+ * A `webpack` hook does not apply to a Turbopack build, and this wrapper wires
+ * Turbopack, so a caller who had configured webpack and nothing else is about
+ * to build with a bundler their configuration never reaches. That is worth one
+ * line, because nothing else says it.
+ *
+ * Nothing else including Next itself, which is why this no longer claims
+ * otherwise. The message used to say Next would have warned and no longer will,
+ * and the docstring said Next "refuses to build" in this situation. Measured
+ * against Next 16.3.2, a config with a `webpack` hook and no `turbopack` block
+ * builds cleanly under `next build --turbopack`: exit 0, and no occurrence of
+ * `webpack`, `ignored`, or `warn` anywhere in the output. Next's shipped code
+ * carries no such check either. There was no warning to suppress, and saying so
+ * put a claim in front of users that they could check and find false
+ * (samchon/ttsc#1320).
  *
  * Only for a caller who wrote a `webpack` hook and no `turbopack` block. A
  * caller who configured Turbopack has already made that decision, and a caller
@@ -109,10 +117,10 @@ function warnAboutSuppressedWebpackConfig(nextConfig: NextLikeConfig): void {
     return;
   }
   process.stderr.write(
-    "@ttsc/unplugin: withTtsc now configures Turbopack as well as webpack, so " +
-      "Next.js will not warn that your own `webpack` hook is ignored on a " +
-      "Turbopack build. Port it to `turbopack`, or run the bundler you " +
-      "configured with `next build --webpack` / `next dev --webpack`." +
+    "@ttsc/unplugin: withTtsc configures Turbopack as well as webpack, and your " +
+      "own `webpack` hook does not run on a Turbopack build. Port it to " +
+      "`turbopack`, or run the bundler you configured with " +
+      "`next build --webpack` / `next dev --webpack`." +
       String.fromCharCode(10),
   );
 }

--- a/packages/unplugin/src/next.ts
+++ b/packages/unplugin/src/next.ts
@@ -88,22 +88,28 @@ export default function next(
 }
 
 /**
- * Tell a caller their webpack-only configuration will not run.
+ * Say what Next.js can no longer say once this wrapper defines `turbopack`.
  *
- * A `webpack` hook does not apply to a Turbopack build, and this wrapper wires
- * Turbopack, so a caller who had configured webpack and nothing else is about
- * to build with a bundler their configuration never reaches. That is worth one
- * line, because nothing else says it.
+ * Next stops the build when a config carries a `webpack` hook and no
+ * `turbopack` block, because the webpack hook is then silently ignored. Read
+ * from Next 16.3.2's own `dist/lib/turbopack-warning.js`, it is
+ * `log.error(...)` followed by `process.exit(1)` — a refusal, not a warning —
+ * and it is gated on `process.env.TURBOPACK === "auto"`, which
+ * `dist/lib/bundler.js` sets only when no bundler flag was passed. Next's
+ * comment there gives the reason: an explicit `--turbopack` means the user
+ * chose it and is assumed to have configured it. So the check fires on a plain
+ * `next build` or `next dev`, which is how Next 16 is normally run.
  *
- * Nothing else including Next itself, which is why this no longer claims
- * otherwise. The message used to say Next would have warned and no longer will,
- * and the docstring said Next "refuses to build" in this situation. Measured
- * against Next 16.3.2, a config with a `webpack` hook and no `turbopack` block
- * builds cleanly under `next build --turbopack`: exit 0, and no occurrence of
- * `webpack`, `ignored`, or `warn` anywhere in the output. Next's shipped code
- * carries no such check either. There was no warning to suppress, and saying so
- * put a claim in front of users that they could check and find false
- * (samchon/ttsc#1320).
+ * `hasTurboConfig` is read from the raw exported config, which is this
+ * wrapper's return value, and this wrapper always defines `turbopack`. The
+ * check therefore can never fire again for anyone who uses `withTtsc`, and a
+ * caller's own webpack customisation would be dropped on a Turbopack build with
+ * nothing said. Wiring ttsc for Turbopack is worth exactly one line, not the
+ * loss of the refusal Next already gave.
+ *
+ * Verifying that gate is what this docstring exists for: measured with an
+ * explicit `--turbopack`, the check is silent, and a reading that stopped there
+ * would conclude Next says nothing and delete a true statement.
  *
  * Only for a caller who wrote a `webpack` hook and no `turbopack` block. A
  * caller who configured Turbopack has already made that decision, and a caller
@@ -117,10 +123,11 @@ function warnAboutSuppressedWebpackConfig(nextConfig: NextLikeConfig): void {
     return;
   }
   process.stderr.write(
-    "@ttsc/unplugin: withTtsc configures Turbopack as well as webpack, and your " +
-      "own `webpack` hook does not run on a Turbopack build. Port it to " +
-      "`turbopack`, or run the bundler you configured with " +
-      "`next build --webpack` / `next dev --webpack`." +
+    "@ttsc/unplugin: withTtsc now configures Turbopack as well as webpack, so " +
+      "Next.js will no longer stop the build to tell you that your own " +
+      "`webpack` hook is ignored on a Turbopack build. Port it to `turbopack`, " +
+      "or run the bundler you configured with `next build --webpack` / " +
+      "`next dev --webpack`." +
       String.fromCharCode(10),
   );
 }
@@ -221,31 +228,51 @@ function coveredByAnotherRule(
  * (samchon/ttsc#1319).
  *
  * Recognition is one rule rather than a list of shapes: expand a brace group
- * into the globs it stands for, drop any leading `**` + `/` segments, and ask
- * whether what remains is exactly `*.<extension>`. That covers every spelling a
- * caller plausibly writes for "every file with this extension" — `*.ts`, `**` +
- * `/*.ts`, `*.{ts,tsx}`, `**` + `/{*.ts,*.tsx}`, `{**` + `/,}*.ts` — without
- * deciding glob equivalence in general.
+ * into the globs it stands for, drop any leading `**` + `/` segments, and
+ * require that **every** alternative is then exactly `*.<extension>`. That
+ * covers every spelling a caller plausibly writes for "every file with this
+ * extension" — `*.ts`, `**` + `/*.ts`, `*.{ts,tsx}`, `{*.ts,*.tsx}`, `**` +
+ * `/{*.ts,*.tsx}`, `{**` + `/,}*.ts` — without deciding glob equivalence in
+ * general.
  *
- * Expanding the brace before the test is what keeps the scoped case safe.
- * `src/*.{ts,tsx}` expands to `src/*.ts` and `src/*.tsx`, neither of which
- * survives the test, because the path segment is still there once the group is
- * gone. A group that spans the scope itself is judged the same way:
- * `{src/,}*.ts` offers `*.ts` among its alternatives, and that alternative
- * really does name every file, so recognising it is correct rather than a
- * leak.
+ * Every, not any, and that distinction is the whole correctness of this
+ * function. Reasoning from set semantics says `{src/,}*.ts` offers a bare
+ * `*.ts` among its alternatives, so the union must cover everything and one
+ * matching alternative should be enough to recognise it. Turbopack disagrees:
+ * measured against Next.js 16.3.2 with a loader on that exact rule, it matches
+ * **nothing** — not the project root, not `src/`, which the very alternative it
+ * contains would have to match. Recognising it therefore suppressed this
+ * wrapper's own rules in favour of a rule that transforms no file at all, which
+ * is samchon/ttsc#1310 restored by a guard built to prevent it
+ * (samchon/ttsc#1319).
  *
- * Two shapes stay unrecognised and deliberately so, since both fail in the loud
- * direction: a character class (`*.[jt]s`) and a different case (`*.TS`).
+ * The same measurement explains why a path segment is refused wherever it
+ * appears. `src/*.ts` and `src/**` + `/*.ts` match nothing either — not even
+ * the `src/` subtree they name — while `./src/*.ts`, `**` + `/src/*.ts` and a
+ * bare `nested-probe.ts` do match a file at `src/`. Requiring every alternative
+ * to survive the test refuses all of them together, and the experimental suite
+ * drives the surviving set through a real build so this stops being a belief.
+ *
+ * Two further shapes stay unrecognised and deliberately so, since both fail in
+ * the loud direction: a character class (`*.[jt]s`) and a different case
+ * (`*.TS`).
  */
 function matchesExtension(glob: string, extension: string): boolean {
-  return expandBraceGroup(glob).some((candidate) => {
+  const alternatives = expandBraceGroup(glob).map((candidate) => {
     let unprefixed = candidate;
     while (unprefixed.startsWith("**/")) {
       unprefixed = unprefixed.slice(3);
     }
-    return unprefixed === `*.${extension}`;
+    return unprefixed;
   });
+  // Every alternative has to be project-wide, or the glob as a whole is not,
+  // and at least one has to name this extension, or it says nothing about it.
+  // `*.{ts,tsx}` passes both for `ts`: both alternatives are unscoped, and one
+  // is `*.ts`.
+  return (
+    alternatives.every((candidate) => /^\*\.[A-Za-z0-9]+$/.test(candidate)) &&
+    alternatives.includes(`*.${extension}`)
+  );
 }
 
 /**

--- a/packages/unplugin/src/next.ts
+++ b/packages/unplugin/src/next.ts
@@ -155,11 +155,14 @@ function withTtscTurbopackRules(
       continue;
     }
     const entry = { loader: TURBOPACK_LOADER, options: options ?? {} };
-    // Appended, not prepended. Turbopack runs a rule's loaders through
-    // webpack's own `loader-runner`, which runs the normal phase right to
-    // left, so the last entry is the one that sees the original source. ttsc
+    // Appended, not prepended. Turbopack runs a rule's loaders right to left,
+    // so the last entry is the one that sees the original source. ttsc
     // transforms TypeScript into TypeScript, so it has to be that one, which
     // is the same position `enforce: "pre"` gives it on the webpack half.
+    //
+    // Measured rather than inferred from webpack's `loader-runner`: two
+    // loaders on one rule, each marking the source, came back marked in the
+    // order that only the last-runs-first chain produces (samchon/ttsc#1319).
     rules[glob] =
       rule === undefined || loaders.length === 0
         ? { loaders: [entry] }
@@ -202,13 +205,20 @@ function coveredByAnotherRule(
 /**
  * Whether one glob names this extension across the whole project.
  *
- * Unscoped only. A rule restricted to a path, `src/*.{ts,tsx}` or
- * `node_modules/**` + `/*.ts`, covers its own subtree and says nothing about
- * the rest of the project, so treating it as covering everything would leave
- * every module outside that subtree with no ttsc rule at all. That is the
- * silent failure samchon/ttsc#1310 is about, and it is strictly worse than the
- * double registration this guard exists to prevent: a build that transforms
- * twice is wrong loudly, a build that never transforms is wrong quietly.
+ * Unscoped only. A rule carrying a path segment says nothing about the rest of
+ * the project, so treating it as covering everything would leave every module
+ * outside it with no ttsc rule at all. That is the silent failure
+ * samchon/ttsc#1310 is about, and it is strictly worse than the double
+ * registration this guard exists to prevent: a build that transforms twice is
+ * wrong loudly, a build that never transforms is wrong quietly.
+ *
+ * How little such a rule covers is worth stating from measurement rather than
+ * from the obvious guess, because the guess is wrong. Against Next.js 16.3.2,
+ * `src/*.ts` and `src/**` + `/*.ts` match **nothing at all** — not even the
+ * `src/` subtree they name — while `./src/*.ts`, `**` + `/src/*.ts` and a bare
+ * `nested-probe.ts` all match a file at `src/`. Declining every one of them is
+ * therefore even safer than "it only covers its subtree" implies
+ * (samchon/ttsc#1319).
  *
  * Recognition is one rule rather than a list of shapes: expand a brace group
  * into the globs it stands for, drop any leading `**` + `/` segments, and ask

--- a/packages/unplugin/src/next.ts
+++ b/packages/unplugin/src/next.ts
@@ -216,10 +216,10 @@ function coveredByAnotherRule(
  * the project, so treating it as covering everything would leave every module
  * outside it with no ttsc rule at all. That is the silent failure
  * samchon/ttsc#1310 is about, and it is strictly worse than the double
- * registration this guard exists to prevent: a build that transforms twice is
- * wrong loudly, a build that never transforms is wrong quietly.
+ * registration this guard exists to prevent: a module no loader ever sees fails
+ * at runtime, while a module transformed twice costs time.
  *
- * How little such a rule covers is worth stating from measurement rather than
+ * How little a scoped rule covers is worth stating from measurement rather than
  * from the obvious guess, because the guess is wrong. Against Next.js 16.3.2,
  * `src/*.ts` and `src/**` + `/*.ts` match **nothing at all** — not even the
  * `src/` subtree they name — while `./src/*.ts`, `**` + `/src/*.ts` and a bare
@@ -227,76 +227,54 @@ function coveredByAnotherRule(
  * therefore even safer than "it only covers its subtree" implies
  * (samchon/ttsc#1319).
  *
- * Recognition is one rule rather than a list of shapes: expand a brace group
- * into the globs it stands for, drop any leading `**` + `/` segments, and
- * require that **every** alternative is then exactly `*.<extension>`. That
- * covers every spelling a caller plausibly writes for "every file with this
- * extension" — `*.ts`, `**` + `/*.ts`, `*.{ts,tsx}`, `{*.ts,*.tsx}`, `**` +
- * `/{*.ts,*.tsx}`, `{**` + `/,}*.ts` — without deciding glob equivalence in
- * general.
- *
- * Every, not any, and that distinction is the whole correctness of this
- * function. Reasoning from set semantics says `{src/,}*.ts` offers a bare
- * `*.ts` among its alternatives, so the union must cover everything and one
- * matching alternative should be enough to recognise it. Turbopack disagrees:
- * measured against Next.js 16.3.2 with a loader on that exact rule, it matches
- * **nothing** — not the project root, not `src/`, which the very alternative it
- * contains would have to match. Recognising it therefore suppressed this
- * wrapper's own rules in favour of a rule that transforms no file at all, which
- * is samchon/ttsc#1310 restored by a guard built to prevent it
- * (samchon/ttsc#1319).
- *
- * The same measurement explains why a path segment is refused wherever it
- * appears. `src/*.ts` and `src/**` + `/*.ts` match nothing either — not even
- * the `src/` subtree they name — while `./src/*.ts`, `**` + `/src/*.ts` and a
- * bare `nested-probe.ts` do match a file at `src/`. Requiring every alternative
- * to survive the test refuses all of them together, and the experimental suite
- * drives the surviving set through a real build so this stops being a belief.
- *
- * Two further shapes stay unrecognised and deliberately so, since both fail in
- * the loud direction: a character class (`*.[jt]s`) and a different case
- * (`*.TS`).
+ * The answer comes from {@link PROJECT_WIDE_GLOBS}, an exact set of measured
+ * spellings, and that document explains why it is a set rather than a rule.
  */
 function matchesExtension(glob: string, extension: string): boolean {
-  const alternatives = expandBraceGroup(glob).map((candidate) => {
-    let unprefixed = candidate;
-    while (unprefixed.startsWith("**/")) {
-      unprefixed = unprefixed.slice(3);
-    }
-    return unprefixed;
-  });
-  // Every alternative has to be project-wide, or the glob as a whole is not,
-  // and at least one has to name this extension, or it says nothing about it.
-  // `*.{ts,tsx}` passes both for `ts`: both alternatives are unscoped, and one
-  // is `*.ts`.
-  return (
-    alternatives.every((candidate) => /^\*\.[A-Za-z0-9]+$/.test(candidate)) &&
-    alternatives.includes(`*.${extension}`)
-  );
+  return PROJECT_WIDE_GLOBS.get(glob.trim())?.includes(extension) === true;
 }
 
 /**
- * Expand the first brace group in a glob into the globs it stands for, keeping
- * whatever surrounds it.
+ * The exact glob spellings a real Turbopack build has shown to name every file
+ * with an extension, and which extensions each one covers.
  *
- * `*.{ts,tsx}` becomes `*.ts` and `*.tsx`; `{**` + `/,}*.ts` becomes `**` +
- * `/*.ts` and `*.ts`. One group is enough: nothing a caller writes for two
- * extensions needs two, and a glob with no group is returned unchanged, so
- * {@link matchesExtension} has a single shape to test either way.
+ * An allowlist rather than a predicate, because recognising a glob is a claim
+ * about Turbopack's matcher and every claim here has to be one somebody
+ * measured. A rule inferred from glob semantics kept being wrong in the silent
+ * direction: `{src/,}*.ts` contains a bare `*.ts` alternative and so must cover
+ * the project by any set-theoretic reading, yet Turbopack matches nothing with
+ * it, and recognising it suppressed this wrapper's rules in favour of a rule
+ * that transforms no file at all — samchon/ttsc#1310 caused by the guard meant
+ * to prevent it (samchon/ttsc#1319).
+ *
+ * The deeper problem was that a predicate is open-ended: it answers for every
+ * spelling anyone might write, including ones no build has ever driven.
+ * `*.{ts}` and `{,**` + `/}*.ts` were both accepted on that reasoning while
+ * nothing had checked whether Turbopack expands a single-alternative group or a
+ * leading empty one. An exact set cannot overreach, so an unmeasured spelling
+ * is simply not recognised, the wrapper adds its own rules, and the failure —
+ * if any — is a second registration rather than a module that no loader ever
+ * sees.
+ *
+ * `experimental/test-unplugin` drives every entry through `next build
+ * --turbopack` and asserts a nested `.ts`, a root-level `.ts` and a nested
+ * `.tsx` all came out transformed, and
+ * `test_next_adapter_does_not_double_register_across_globs` asserts these keys
+ * and that list are the same set, so an entry cannot be added here without a
+ * build proving it.
  */
-function expandBraceGroup(glob: string): string[] {
-  const open = glob.indexOf("{");
-  const close = glob.indexOf("}", open + 1);
-  if (open === -1 || close === -1) {
-    return [glob];
-  }
-  const prefix = glob.slice(0, open);
-  const suffix = glob.slice(close + 1);
-  return glob
-    .slice(open + 1, close)
-    .split(",")
-    .map((part) => `${prefix}${part.trim()}${suffix}`);
-}
+const PROJECT_WIDE_GLOBS: ReadonlyMap<string, readonly string[]> = new Map([
+  ["*.ts", ["ts"]],
+  ["**/*.ts", ["ts"]],
+  ["{**/,}*.ts", ["ts"]],
+  ["*.tsx", ["tsx"]],
+  ["**/*.tsx", ["tsx"]],
+  ["*.{ts,tsx}", ["ts", "tsx"]],
+  ["{*.ts,*.tsx}", ["ts", "tsx"]],
+  ["**/*.{ts,tsx}", ["ts", "tsx"]],
+  ["**/{*.ts,*.tsx}", ["ts", "tsx"]],
+  ["**/**/*.{ts,tsx}", ["ts", "tsx"]],
+]);
 
 /**
  * Read the loader list out of one Turbopack rule.

--- a/tests/test-metro/src/features/config/test_withttsc_chains_an_existing_transformer.ts
+++ b/tests/test-metro/src/features/config/test_withttsc_chains_an_existing_transformer.ts
@@ -1,0 +1,12 @@
+import { assertWithTtscChainsAnExistingTransformer } from "../../internal/metro-config";
+
+/**
+ * Verifies a transformer the config already declared is chained, not replaced.
+ *
+ * See {@link assertWithTtscChainsAnExistingTransformer}: `withTtsc` overwrote
+ * `babelTransformerPath` without reading it, so a project using
+ * `react-native-svg-transformer` lost it silently (samchon/ttsc#1321).
+ */
+export const test_withttsc_chains_an_existing_transformer = async () => {
+  await assertWithTtscChainsAnExistingTransformer();
+};

--- a/tests/test-metro/src/internal/metro-config.ts
+++ b/tests/test-metro/src/internal/metro-config.ts
@@ -125,3 +125,89 @@ export async function assertWithTtscAddsTransformerWhenAbsent(): Promise<void> {
     assert.match(config.transformer.babelTransformerPath, /transformer\.js$/);
   });
 }
+
+/**
+ * Asserts a `babelTransformerPath` the config already carried is chained rather
+ * than discarded.
+ *
+ * `withTtsc` sets that one field and used to read nothing, so a project that
+ * had configured its own transformer lost it on the line that adopted this
+ * package. Everything else survived — the config and its `transformer` are both
+ * spread through — which is what made the loss hard to see
+ * (samchon/ttsc#1321).
+ *
+ * `react-native-svg-transformer` is the case that matters, because its whole
+ * installation is that single assignment and it is ordinary in React Native and
+ * Expo projects. Losing it does not fail the build: `.svg` files are not
+ * TypeScript, so the ttsc pass hands them straight to its upstream, and the
+ * upstream was the auto-detected Expo default rather than the transformer the
+ * project chose. The build succeeds and the SVG components are wrong.
+ *
+ * The transport matters as much as the decision, so this reads the value back
+ * out of `TTSC_METRO_OPTIONS` — the environment variable Metro's workers
+ * actually consult — rather than from the returned config.
+ */
+export async function assertWithTtscChainsAnExistingTransformer(): Promise<void> {
+  await withCleanEnv(async () => {
+    const { ENV_KEY } = await TestMetroRuntime.loadOptions();
+    const { withTtsc } = await TestMetroRuntime.loadIndex();
+    const declared = path.join(
+      tempProjectRoot(),
+      "node_modules",
+      "react-native-svg-transformer",
+      "index.js",
+    );
+
+    const config = withTtsc({
+      projectRoot: tempProjectRoot(),
+      transformer: { babelTransformerPath: declared },
+    });
+    assert.equal(
+      JSON.parse(process.env[ENV_KEY] as string).upstreamTransformer,
+      declared,
+      "the transformer the config already named must become the upstream",
+    );
+    assert.notEqual(
+      config.transformer.babelTransformerPath,
+      declared,
+      "and this package's transformer must be the one Metro loads",
+    );
+
+    // An explicit option is the caller saying it outright, so it wins.
+    withTtsc(
+      {
+        projectRoot: tempProjectRoot(),
+        transformer: { babelTransformerPath: declared },
+      },
+      { upstreamTransformer: "explicit-upstream" },
+    );
+    assert.equal(
+      JSON.parse(process.env[ENV_KEY] as string).upstreamTransformer,
+      "explicit-upstream",
+      "an explicit upstreamTransformer must win over the config's value",
+    );
+
+    // A config with nothing declared still auto-detects, which is the whole
+    // point of the candidate list.
+    withTtsc({ projectRoot: tempProjectRoot() });
+    assert.equal(
+      JSON.parse(process.env[ENV_KEY] as string).upstreamTransformer,
+      undefined,
+      "a config with no transformer must still auto-detect",
+    );
+
+    // Wrapping twice must not make this transformer its own upstream.
+    const once = withTtsc({ projectRoot: tempProjectRoot() });
+    const twice = withTtsc(once);
+    assert.equal(
+      JSON.parse(process.env[ENV_KEY] as string).upstreamTransformer,
+      undefined,
+      "a doubly wrapped config must not delegate into this package's own transformer",
+    );
+    assert.equal(
+      twice.transformer.babelTransformerPath,
+      once.transformer.babelTransformerPath,
+      "and the transformer Metro loads is unchanged",
+    );
+  });
+}

--- a/tests/test-metro/src/internal/metro-config.ts
+++ b/tests/test-metro/src/internal/metro-config.ts
@@ -173,6 +173,21 @@ export async function assertWithTtscChainsAnExistingTransformer(): Promise<void>
       "and this package's transformer must be the one Metro loads",
     );
 
+    // A relative path is the other spelling a config can carry, and the
+    // transport is JSON over an environment variable, so it has to survive
+    // exactly as written: `resolveUpstreamTransformer` requires it, and a path
+    // silently rewritten between the config process and the worker would be
+    // loaded from the wrong place or not at all.
+    withTtsc({
+      projectRoot: tempProjectRoot(),
+      transformer: { babelTransformerPath: "./local-transformer.cjs" },
+    });
+    assert.equal(
+      JSON.parse(process.env[ENV_KEY] as string).upstreamTransformer,
+      "./local-transformer.cjs",
+      "a relative path must reach the worker exactly as the config spelled it",
+    );
+
     // An explicit option is the caller saying it outright, so it wins.
     withTtsc(
       {

--- a/tests/test-metro/src/internal/metro-config.ts
+++ b/tests/test-metro/src/internal/metro-config.ts
@@ -33,6 +33,35 @@ async function withCleanEnv(body: () => Promise<void>): Promise<void> {
   }
 }
 
+/** Write a resolvable module and return its absolute path. */
+function writeModule(root: string, relative: string, body: string): string {
+  const file = path.join(root, relative);
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, body, "utf8");
+  return file;
+}
+
+/** Install a fake package under `root`'s `node_modules`, returning its main. */
+function writePackage(root: string, name: string, main: string): string {
+  const directory = path.join(root, "node_modules", ...name.split("/"));
+  fs.mkdirSync(directory, { recursive: true });
+  fs.writeFileSync(
+    path.join(directory, "package.json"),
+    JSON.stringify({
+      name: name.split("node_modules/").pop(),
+      version: "0.0.0",
+      main,
+    }),
+    "utf8",
+  );
+  return writeModule(directory, main, "module.exports = {};\n");
+}
+
+/** The `upstreamTransformer` the last `withTtsc` call published to the worker. */
+function publishedUpstream(envKey: string): unknown {
+  return JSON.parse(process.env[envKey] as string).upstreamTransformer;
+}
+
 /**
  * Asserts `withTtsc` points `transformer.babelTransformerPath` at the package's
  * built transformer module, by absolute path, and that the file exists.
@@ -127,77 +156,124 @@ export async function assertWithTtscAddsTransformerWhenAbsent(): Promise<void> {
 }
 
 /**
- * Asserts a `babelTransformerPath` the config already carried is chained rather
- * than discarded.
+ * Verifies a transformer the config already declared is chained, in every
+ * spelling a config can carry it.
  *
- * `withTtsc` sets that one field and used to read nothing, so a project that
- * had configured its own transformer lost it on the line that adopted this
- * package. Everything else survived — the config and its `transformer` are both
- * spread through — which is what made the loss hard to see
- * (samchon/ttsc#1321).
+ * `withTtsc` set that one field and read nothing, so a project that had
+ * configured its own transformer lost it on the line that adopted this package.
+ * Everything else survived — the config and its `transformer` are both spread
+ * through — which is what made the loss hard to see (samchon/ttsc#1321).
+ * `react-native-svg-transformer`'s whole installation is that single
+ * assignment, and losing it fails nothing: `.svg` is not TypeScript, so the
+ * ttsc pass hands it to its upstream, and the upstream became the auto-detected
+ * Expo default. Green build, wrong components.
  *
- * `react-native-svg-transformer` is the case that matters, because its whole
- * installation is that single assignment and it is ordinary in React Native and
- * Expo projects. Losing it does not fail the build: `.svg` files are not
- * TypeScript, so the ttsc pass hands them straight to its upstream, and the
- * upstream was the auto-detected Expo default rather than the transformer the
- * project chose. The build succeeds and the SVG components are wrong.
+ * Chaining is decided on the resolved module, never on the string. Metro
+ * resolves this value from the project while the worker resolves
+ * `upstreamTransformer` from inside `@ttsc/metro`, so a spelling left relative
+ * is looked for where it is not — turning a transformer that used to be ignored
+ * into a build that fails outright. Resolving first also lets the
+ * self-reference guard recognise this package when a caller named it as a
+ * specifier rather than a path, which no string comparison could.
  *
- * The transport matters as much as the decision, so this reads the value back
- * out of `TTSC_METRO_OPTIONS` — the environment variable Metro's workers
- * actually consult — rather than from the returned config.
+ * The refusals matter as much as the adoptions. The worker options are
+ * process-global, so a copy of this package adopted as its own upstream reads
+ * the same `TTSC_METRO_OPTIONS`, finds itself named there, and recurses until
+ * the stack ends.
+ *
+ * 1. Drive every spelling of a third-party transformer through `withTtsc`.
+ * 2. Drive every spelling that names this package, which must never be adopted.
+ * 3. Read each result back out of `TTSC_METRO_OPTIONS`, which is what Metro's
+ *    workers actually consult.
  */
 export async function assertWithTtscChainsAnExistingTransformer(): Promise<void> {
   await withCleanEnv(async () => {
     const { ENV_KEY } = await TestMetroRuntime.loadOptions();
     const { withTtsc } = await TestMetroRuntime.loadIndex();
-    const declared = path.join(
-      tempProjectRoot(),
-      "node_modules",
-      "react-native-svg-transformer",
-      "index.js",
-    );
 
+    // An absolute path, which is what `require.resolve` produces and what
+    // almost every real config carries.
+    const absoluteRoot = tempProjectRoot();
+    const absolute = writeModule(
+      absoluteRoot,
+      "vendor/svg-transformer.cjs",
+      "module.exports = {};\n",
+    );
     const config = withTtsc({
-      projectRoot: tempProjectRoot(),
-      transformer: { babelTransformerPath: declared },
+      projectRoot: absoluteRoot,
+      transformer: { babelTransformerPath: absolute },
     });
     assert.equal(
-      JSON.parse(process.env[ENV_KEY] as string).upstreamTransformer,
-      declared,
+      publishedUpstream(ENV_KEY),
+      absolute,
       "the transformer the config already named must become the upstream",
     );
     assert.notEqual(
       config.transformer.babelTransformerPath,
-      declared,
+      absolute,
       "and this package's transformer must be the one Metro loads",
     );
 
-    // A relative path is the other spelling a config can carry, and the
-    // transport is JSON over an environment variable, so it has to survive
-    // exactly as written: `resolveUpstreamTransformer` requires it, and a path
-    // silently rewritten between the config process and the worker would be
-    // loaded from the wrong place or not at all.
+    // A project-relative spelling has to be anchored to the project. Left as
+    // written it would be looked for inside `@ttsc/metro`, where it is not.
+    const relativeRoot = tempProjectRoot();
+    const relativeTarget = writeModule(
+      relativeRoot,
+      "local-transformer.cjs",
+      "module.exports = {};\n",
+    );
     withTtsc({
-      projectRoot: tempProjectRoot(),
+      projectRoot: relativeRoot,
       transformer: { babelTransformerPath: "./local-transformer.cjs" },
     });
     assert.equal(
-      JSON.parse(process.env[ENV_KEY] as string).upstreamTransformer,
-      "./local-transformer.cjs",
-      "a relative path must reach the worker exactly as the config spelled it",
+      publishedUpstream(ENV_KEY),
+      relativeTarget,
+      "a project-relative path must be anchored to the project before it travels",
+    );
+
+    // A bare specifier is a package name. Resolving it from the project is what
+    // makes it work under pnpm, where this package lives in a virtual store and
+    // walking up from it never reaches the project's own `node_modules`.
+    const bareRoot = tempProjectRoot();
+    const bareTarget = writePackage(
+      bareRoot,
+      "react-native-svg-transformer",
+      "index.js",
+    );
+    withTtsc({
+      projectRoot: bareRoot,
+      transformer: { babelTransformerPath: "react-native-svg-transformer" },
+    });
+    assert.equal(
+      publishedUpstream(ENV_KEY),
+      bareTarget,
+      "a bare specifier must be resolved from the project, not from this package",
+    );
+
+    // Nothing resolvable: hand the spelling on untouched. It may still resolve
+    // in the worker, and if it does not, the upstream loader names it in an
+    // error, which is more legible than a path invented here.
+    withTtsc({
+      projectRoot: tempProjectRoot(),
+      transformer: { babelTransformerPath: "no-such-transformer-anywhere" },
+    });
+    assert.equal(
+      publishedUpstream(ENV_KEY),
+      "no-such-transformer-anywhere",
+      "an unresolvable specifier must travel exactly as written",
     );
 
     // An explicit option is the caller saying it outright, so it wins.
     withTtsc(
       {
-        projectRoot: tempProjectRoot(),
-        transformer: { babelTransformerPath: declared },
+        projectRoot: absoluteRoot,
+        transformer: { babelTransformerPath: absolute },
       },
       { upstreamTransformer: "explicit-upstream" },
     );
     assert.equal(
-      JSON.parse(process.env[ENV_KEY] as string).upstreamTransformer,
+      publishedUpstream(ENV_KEY),
       "explicit-upstream",
       "an explicit upstreamTransformer must win over the config's value",
     );
@@ -206,7 +282,7 @@ export async function assertWithTtscChainsAnExistingTransformer(): Promise<void>
     // point of the candidate list.
     withTtsc({ projectRoot: tempProjectRoot() });
     assert.equal(
-      JSON.parse(process.env[ENV_KEY] as string).upstreamTransformer,
+      publishedUpstream(ENV_KEY),
       undefined,
       "a config with no transformer must still auto-detect",
     );
@@ -215,7 +291,7 @@ export async function assertWithTtscChainsAnExistingTransformer(): Promise<void>
     const once = withTtsc({ projectRoot: tempProjectRoot() });
     const twice = withTtsc(once);
     assert.equal(
-      JSON.parse(process.env[ENV_KEY] as string).upstreamTransformer,
+      publishedUpstream(ENV_KEY),
       undefined,
       "a doubly wrapped config must not delegate into this package's own transformer",
     );
@@ -223,6 +299,60 @@ export async function assertWithTtscChainsAnExistingTransformer(): Promise<void>
       twice.transformer.babelTransformerPath,
       once.transformer.babelTransformerPath,
       "and the transformer Metro loads is unchanged",
+    );
+
+    // A second installed copy of this package must be refused too, and this is
+    // the row that matters most: adopted, it would recurse into itself on every
+    // file. A directory comparison cannot see it, because a differently hoisted
+    // `node_modules` is a different directory; the owning `package.json` is
+    // what identifies it.
+    const duplicateRoot = tempProjectRoot();
+    const duplicate = writePackage(
+      duplicateRoot,
+      "expo/node_modules/@ttsc/metro",
+      "lib/transformer.js",
+    );
+    withTtsc({
+      projectRoot: duplicateRoot,
+      transformer: { babelTransformerPath: duplicate },
+    });
+    assert.equal(
+      publishedUpstream(ENV_KEY),
+      undefined,
+      "another installed copy of @ttsc/metro must never become the upstream",
+    );
+
+    // The same package named as a specifier rather than a path. Judging the
+    // string would adopt it; judging the resolved module refuses it.
+    const specifierRoot = tempProjectRoot();
+    writePackage(specifierRoot, "@ttsc/metro", "lib/transformer.js");
+    withTtsc({
+      projectRoot: specifierRoot,
+      transformer: { babelTransformerPath: "@ttsc/metro" },
+    });
+    assert.equal(
+      publishedUpstream(ENV_KEY),
+      undefined,
+      "naming this package as a specifier must be refused like naming its path",
+    );
+
+    // A third-party module that merely happens to be named `transformer.js` is
+    // not ours, and refusing it would drop the very transformer this feature
+    // exists to keep.
+    const lookalikeRoot = tempProjectRoot();
+    const lookalike = writePackage(
+      lookalikeRoot,
+      "some-other-transformer",
+      "lib/transformer.js",
+    );
+    withTtsc({
+      projectRoot: lookalikeRoot,
+      transformer: { babelTransformerPath: lookalike },
+    });
+    assert.equal(
+      publishedUpstream(ENV_KEY),
+      lookalike,
+      "a foreign module named transformer.js must still be chained",
     );
   });
 }

--- a/tests/test-unplugin/src/internal/adapter-next.ts
+++ b/tests/test-unplugin/src/internal/adapter-next.ts
@@ -297,8 +297,18 @@ export async function assertNextAdapterWarnsAboutASuppressedWebpackHook(): Promi
   const warned = capture({ webpack: (config) => config });
   assert.match(
     warned,
-    /withTtsc now configures Turbopack/,
+    /your own `webpack` hook does not run on a Turbopack build/,
     "a caller's own webpack hook must not be dropped in silence",
+  );
+  // What the message must not claim. It used to say Next.js would have warned
+  // and no longer will; measured against Next 16.3.2, a config with a `webpack`
+  // hook and no `turbopack` block builds cleanly with no mention of either, and
+  // Next ships no such check. A diagnostic that asserts something the reader can
+  // check and find false costs the channel that also carries the out-of-program
+  // report (samchon/ttsc#1320).
+  assert.ok(
+    !/Next\.js will not warn|refuses to build/.test(warned),
+    `the warning must not claim Next.js would have said anything (got ${JSON.stringify(warned)})`,
   );
 
   assert.equal(

--- a/tests/test-unplugin/src/internal/adapter-next.ts
+++ b/tests/test-unplugin/src/internal/adapter-next.ts
@@ -1,7 +1,26 @@
 import { TestUnpluginRuntime } from "@ttsc/testing";
 import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
 
 const LOADER = "@ttsc/unplugin/turbopack";
+
+/**
+ * Every glob this suite proves the dedupe guard recognises as naming the whole
+ * project, for both extensions.
+ *
+ * Cross-checked against the list the experimental suite drives through real
+ * Turbopack builds, so neither can gain a spelling the other has not seen.
+ */
+const RECOGNISED_PROJECT_WIDE_GLOBS = [
+  "*.ts",
+  "**/*.ts",
+  "*.{ts,tsx}",
+  "{*.ts,*.tsx}",
+  "**/*.{ts,tsx}",
+  "**/{*.ts,*.tsx}",
+  "{**/,}*.ts",
+  "**/**/*.{ts,tsx}",
+];
 
 interface INextLikeConfig {
   turbopack?: { rules?: Record<string, unknown> };
@@ -238,10 +257,16 @@ export async function assertNextAdapterDoesNotDoubleRegisterAcrossGlobs(): Promi
 
   // And the shapes the guard does recognise. Each names every file with the
   // extension, so the wrapper's own rules would be a second registration of a
-  // file set the caller already routed. They are one rule rather than a list of
-  // cases: expand the brace group, drop leading `**/` segments, and what is
-  // left must be exactly `*.ts` or `*.tsx`.
-  for (const wide of ["**/*.{ts,tsx}", "**/{*.ts,*.tsx}", "**/**/*.{ts,tsx}"]) {
+  // file set the caller already routed. Every one of these is driven through a
+  // real Turbopack build by `experimental/test-unplugin`, because whether a
+  // glob covers the project is Turbopack's answer and not ours.
+  for (const wide of [
+    "*.{ts,tsx}",
+    "{*.ts,*.tsx}",
+    "**/*.{ts,tsx}",
+    "**/{*.ts,*.tsx}",
+    "**/**/*.{ts,tsx}",
+  ]) {
     assert.deepEqual(
       globs({ turbopack: { rules: { [wide]: { loaders: [LOADER] } } } }),
       [wide],
@@ -251,21 +276,93 @@ export async function assertNextAdapterDoesNotDoubleRegisterAcrossGlobs(): Promi
 
   // Recognition is per extension, not per rule: a glob naming every `.ts` and
   // no `.tsx` suppresses only the `*.ts` registration, exactly as the partial
-  // hand wiring above does. Both of these mean every `.ts` in the project.
-  for (const partial of ["{**/,}*.ts", "{src/,}*.ts"]) {
+  // hand wiring above does.
+  for (const partial of ["{**/,}*.ts", "**/*.ts"]) {
     assert.deepEqual(
       globs({ turbopack: { rules: { [partial]: { loaders: [LOADER] } } } }),
       [partial, "*.tsx"],
       `${partial} names every .ts, so only the missing .tsx is added`,
     );
   }
-  assert.deepEqual(
-    globs({
-      turbopack: { rules: { "{src,lib}/*.{ts,tsx}": { loaders: [LOADER] } } },
-    }),
-    ["{src,lib}/*.{ts,tsx}", "*.ts", "*.tsx"],
-    "a brace group over scopes stays scoped and must not suppress anything",
+
+  // A path segment anywhere disqualifies the whole glob, including inside a
+  // brace group. Set semantics say `{src/,}*.ts` offers a bare `*.ts` and so
+  // must cover everything; Turbopack, measured, matches **nothing** with it —
+  // not even `src/`. Recognising it suppressed this wrapper's rules in favour
+  // of a rule that transforms no file at all, which is samchon/ttsc#1310 caused
+  // by the guard meant to prevent it (samchon/ttsc#1319). Every alternative has
+  // to be unscoped, not merely one of them.
+  for (const scopedGroup of [
+    "{src/,}*.ts",
+    "{src,lib}/*.{ts,tsx}",
+    "{src/,lib/}*.ts",
+  ]) {
+    assert.deepEqual(
+      globs({ turbopack: { rules: { [scopedGroup]: { loaders: [LOADER] } } } }),
+      [scopedGroup, "*.ts", "*.tsx"],
+      `${scopedGroup} carries a path segment, so it must not suppress anything`,
+    );
+  }
+
+  await assertRecognisedGlobsMatchTheRealBuildList(globs);
+}
+
+/**
+ * Assert the guard and the experimental suite name the same recognised set.
+ *
+ * Whether a glob covers the project is Turbopack's answer, so the recognised
+ * set is only ever as good as the real builds that check it. Those builds live
+ * in `experimental/test-unplugin`, in a list this fast suite cannot import —
+ * that harness runs against installed tarballs, not this source tree. The two
+ * lists were therefore synchronised by convention, and a convention is what
+ * lost `{src/,}*.ts`: the guard recognised a spelling no build ever drove, and
+ * it turned out to match nothing at all (samchon/ttsc#1319).
+ *
+ * So the invariant is asserted in both directions instead of trusted. Adding a
+ * spelling to the guard without adding it to the harness fails here, and so
+ * does the reverse.
+ */
+async function assertRecognisedGlobsMatchTheRealBuildList(
+  globs: (config: INextLikeConfig) => string[],
+): Promise<void> {
+  const harness = await readFile(
+    new URL(
+      "../../../../experimental/test-unplugin/src/index.ts",
+      import.meta.url,
+    ),
+    "utf8",
   );
+  const declared = /const TURBOPACK_PROJECT_WIDE_GLOBS = \[([^\]]*)\]/.exec(
+    harness,
+  );
+  const body = declared?.[1];
+  assert.ok(body, "the experimental suite must declare its recognised set");
+  const listed = [...body.matchAll(/"((?:[^"\\]|\\.)*)"/g)].map(
+    (match) => JSON.parse(`"${match[1]}"`) as string,
+  );
+  assert.ok(listed.length > 0, "that list must not be empty");
+
+  // Every glob the real builds drive must actually be recognised, or those
+  // builds are proving something about a spelling the guard never takes.
+  // Recognition means at least one of the wrapper's two rules is declined; a
+  // glob naming one extension, `*.ts`, still leaves the other to be added.
+  for (const glob of listed) {
+    const wired = globs({
+      turbopack: { rules: { [glob]: { loaders: [LOADER] } } },
+    });
+    assert.ok(
+      wired.length < 3,
+      `${glob} is driven through a real build, so the guard must recognise it (got ${JSON.stringify(wired)})`,
+    );
+  }
+
+  // And every spelling this suite proves recognised must be driven there.
+  for (const glob of RECOGNISED_PROJECT_WIDE_GLOBS) {
+    assert.ok(
+      listed.includes(glob),
+      `${glob} is recognised here, so a real Turbopack build must drive it`,
+    );
+  }
 }
 
 /**
@@ -297,18 +394,18 @@ export async function assertNextAdapterWarnsAboutASuppressedWebpackHook(): Promi
   const warned = capture({ webpack: (config) => config });
   assert.match(
     warned,
-    /your own `webpack` hook does not run on a Turbopack build/,
+    /withTtsc now configures Turbopack/,
     "a caller's own webpack hook must not be dropped in silence",
   );
-  // What the message must not claim. It used to say Next.js would have warned
-  // and no longer will; measured against Next 16.3.2, a config with a `webpack`
-  // hook and no `turbopack` block builds cleanly with no mention of either, and
-  // Next ships no such check. A diagnostic that asserts something the reader can
-  // check and find false costs the channel that also carries the out-of-program
-  // report (samchon/ttsc#1320).
-  assert.ok(
-    !/Next\.js will not warn|refuses to build/.test(warned),
-    `the warning must not claim Next.js would have said anything (got ${JSON.stringify(warned)})`,
+  // What this wrapper suppresses is a refusal, not a warning. Next 16.3.2's
+  // `turbopack-warning.js` logs an error and calls `process.exit(1)` when the
+  // bundler was defaulted, a `webpack` hook exists, and no `turbopack` block
+  // does — and `hasTurboConfig` is read from this wrapper's own return value.
+  // Saying "warn" understates what the caller loses (samchon/ttsc#1320).
+  assert.match(
+    warned,
+    /stop the build/,
+    "the message must say the build would have been stopped, not merely warned about",
   );
 
   assert.equal(

--- a/tests/test-unplugin/src/internal/adapter-next.ts
+++ b/tests/test-unplugin/src/internal/adapter-next.ts
@@ -321,4 +321,9 @@ export async function assertNextAdapterWarnsAboutASuppressedWebpackHook(): Promi
     "",
     "a caller who already configured Turbopack has made the decision",
   );
+  assert.equal(
+    capture({ turbopack: { rules: {} } }),
+    "",
+    "a caller who configured only Turbopack has no webpack hook to lose",
+  );
 }

--- a/tests/test-unplugin/src/internal/adapter-next.ts
+++ b/tests/test-unplugin/src/internal/adapter-next.ts
@@ -14,12 +14,35 @@ const LOADER = "@ttsc/unplugin/turbopack";
 const RECOGNISED_PROJECT_WIDE_GLOBS = [
   "*.ts",
   "**/*.ts",
+  "{**/,}*.ts",
+  "*.tsx",
+  "**/*.tsx",
   "*.{ts,tsx}",
   "{*.ts,*.tsx}",
   "**/*.{ts,tsx}",
   "**/{*.ts,*.tsx}",
-  "{**/,}*.ts",
   "**/**/*.{ts,tsx}",
+];
+
+/**
+ * Spellings the guard must refuse, each one a shape a predicate would have
+ * accepted.
+ *
+ * `{src/,}*.ts` is the measured one: Turbopack matches nothing with it, so
+ * recognising it left every module without a rule (samchon/ttsc#1319). The rest
+ * are unmeasured, which is the same reason — nothing has shown that Turbopack
+ * expands a single-alternative group, a leading empty alternative, or two
+ * groups in one glob, so claiming they cover the project would be a guess in
+ * the direction that fails silently.
+ */
+const REFUSED_GLOBS = [
+  "{src/,}*.ts",
+  "{src,lib}/*.{ts,tsx}",
+  "{src/,lib/}*.ts",
+  "*.{ts}",
+  "{,**/}*.ts",
+  "{**/,}*.{ts,tsx}",
+  "*.{ts,}",
 ];
 
 interface INextLikeConfig {
@@ -260,13 +283,9 @@ export async function assertNextAdapterDoesNotDoubleRegisterAcrossGlobs(): Promi
   // file set the caller already routed. Every one of these is driven through a
   // real Turbopack build by `experimental/test-unplugin`, because whether a
   // glob covers the project is Turbopack's answer and not ours.
-  for (const wide of [
-    "*.{ts,tsx}",
-    "{*.ts,*.tsx}",
-    "**/*.{ts,tsx}",
-    "**/{*.ts,*.tsx}",
-    "**/**/*.{ts,tsx}",
-  ]) {
+  for (const wide of RECOGNISED_PROJECT_WIDE_GLOBS.filter((glob) =>
+    glob.includes("ts,"),
+  )) {
     assert.deepEqual(
       globs({ turbopack: { rules: { [wide]: { loaders: [LOADER] } } } }),
       [wide],
@@ -274,33 +293,35 @@ export async function assertNextAdapterDoesNotDoubleRegisterAcrossGlobs(): Promi
     );
   }
 
-  // Recognition is per extension, not per rule: a glob naming every `.ts` and
-  // no `.tsx` suppresses only the `*.ts` registration, exactly as the partial
-  // hand wiring above does.
-  for (const partial of ["{**/,}*.ts", "**/*.ts"]) {
+  // Recognition is per extension, not per rule: a glob naming every file of one
+  // extension suppresses only that registration, exactly as the partial hand
+  // wiring above does.
+  const partials: readonly (readonly [string, string])[] = [
+    ["{**/,}*.ts", "*.tsx"],
+    ["**/*.ts", "*.tsx"],
+    ["*.tsx", "*.ts"],
+    ["**/*.tsx", "*.ts"],
+  ];
+  for (const [partial, missing] of partials) {
     assert.deepEqual(
       globs({ turbopack: { rules: { [partial]: { loaders: [LOADER] } } } }),
-      [partial, "*.tsx"],
-      `${partial} names every .ts, so only the missing .tsx is added`,
+      [partial, missing],
+      `${partial} names one extension, so only the missing ${missing} is added`,
     );
   }
 
-  // A path segment anywhere disqualifies the whole glob, including inside a
-  // brace group. Set semantics say `{src/,}*.ts` offers a bare `*.ts` and so
-  // must cover everything; Turbopack, measured, matches **nothing** with it —
-  // not even `src/`. Recognising it suppressed this wrapper's rules in favour
-  // of a rule that transforms no file at all, which is samchon/ttsc#1310 caused
-  // by the guard meant to prevent it (samchon/ttsc#1319). Every alternative has
-  // to be unscoped, not merely one of them.
-  for (const scopedGroup of [
-    "{src/,}*.ts",
-    "{src,lib}/*.{ts,tsx}",
-    "{src/,lib/}*.ts",
-  ]) {
+  // Everything the guard does not recognise keeps both of the wrapper's rules.
+  // `{src/,}*.ts` is why recognition is an exact set and not a predicate: set
+  // semantics say its bare `*.ts` alternative covers the project, and Turbopack
+  // matches nothing with it, so recognising it left every module with no rule
+  // at all — samchon/ttsc#1310 caused by the guard meant to prevent it. The
+  // unmeasured brace shapes beside it would have been accepted by that same
+  // predicate on the same kind of reasoning (samchon/ttsc#1319).
+  for (const refused of REFUSED_GLOBS) {
     assert.deepEqual(
-      globs({ turbopack: { rules: { [scopedGroup]: { loaders: [LOADER] } } } }),
-      [scopedGroup, "*.ts", "*.tsx"],
-      `${scopedGroup} carries a path segment, so it must not suppress anything`,
+      globs({ turbopack: { rules: { [refused]: { loaders: [LOADER] } } } }),
+      [refused, "*.ts", "*.tsx"],
+      `${refused} is not a measured project-wide spelling, so it must suppress nothing`,
     );
   }
 

--- a/website/src/content/docs/setup/metro.mdx
+++ b/website/src/content/docs/setup/metro.mdx
@@ -53,6 +53,8 @@ module.exports = withTtsc(getDefaultConfig(__dirname));
 
 `withTtsc` sets `transformer.babelTransformerPath` and leaves the rest of your config untouched. It auto-detects the upstream Babel transformer to delegate to: `@expo/metro-config/babel-transformer` for Expo, then `@react-native/metro-babel-transformer`, then the legacy `metro-react-native-babel-transformer`.
 
+If your config already set `transformer.babelTransformerPath`, that transformer is **chained rather than replaced**: the `ttsc` pass runs first and then delegates to it, so wrapping a working config keeps what it configured. This is what makes [`react-native-svg-transformer`](https://github.com/kristerkari/react-native-svg-transformer) — whose entire installation is that one assignment — keep working after you adopt `@ttsc/metro`. Pass `upstreamTransformer` explicitly to override both that and auto-detection.
+
 ## Options
 
 By default `@ttsc/metro` finds the nearest `tsconfig.json` from the file being transformed and runs the plugins configured there, the standard `ttsc` model. If that is what you want, wrapping the default config is the whole setup.
@@ -70,7 +72,7 @@ module.exports = withTtsc(getDefaultConfig(__dirname), {
 - `project`: the `tsconfig.json` the transformer should read, resolved from `process.cwd()`.
 - `compilerOptions`: a temporary overlay layered on the selected project config.
 - `plugins`: an explicit plugin list override, or `false` to disable project plugins.
-- `upstreamTransformer`: an explicit module path for the Babel transformer to delegate to, when auto-detection is not what you want.
+- `upstreamTransformer`: an explicit module path for the Babel transformer to delegate to, when neither the config's own transformer nor auto-detection is what you want.
 - `include` / `exclude`: substring patterns against the project-relative path, selecting which files run through the `ttsc` pass. Only `.ts`/`.tsx`/`.cts`/`.mts` are candidates; declaration and JavaScript files always pass straight through.
 
 Options travel from the Metro config process to its worker processes through an environment variable, so they must stay JSON-serialisable: substring patterns, not `RegExp`.

--- a/website/src/content/docs/setup/metro.mdx
+++ b/website/src/content/docs/setup/metro.mdx
@@ -55,6 +55,8 @@ module.exports = withTtsc(getDefaultConfig(__dirname));
 
 If your config already set `transformer.babelTransformerPath`, that transformer is **chained rather than replaced**: the `ttsc` pass runs first and then delegates to it, so wrapping a working config keeps what it configured. This is what makes [`react-native-svg-transformer`](https://github.com/kristerkari/react-native-svg-transformer) — whose entire installation is that one assignment — keep working after you adopt `@ttsc/metro`. Pass `upstreamTransformer` explicitly to override both that and auto-detection.
 
+The value is resolved from your `projectRoot`, exactly as Metro resolves it, so a relative `"./metro-svg.cjs"` and a bare `"react-native-svg-transformer"` both mean what they mean in your project rather than inside this package. A path that names `@ttsc/metro`'s own transformer is never chained — in any spelling, including a second copy installed elsewhere in your tree — because delegating this transformer into itself would recurse on every file.
+
 ## Options
 
 By default `@ttsc/metro` finds the nearest `tsconfig.json` from the file being transformed and runs the plugins configured there, the standard `ttsc` model. If that is what you want, wrapping the default config is the whole setup.

--- a/website/src/content/docs/setup/unplugin.mdx
+++ b/website/src/content/docs/setup/unplugin.mdx
@@ -156,6 +156,8 @@ export default withTtsc({
 
 `withTtsc` covers both of Next.js's bundlers: it injects the webpack plugin and wires the Turbopack loader rules, with the options you pass reaching both. Your own `webpack` hook and `turbopack` block are preserved, and a rule you already wired for this loader by hand is left alone rather than registered twice.
 
+That last part is decided by exact spelling. `withTtsc` declines to add its own rule when your glob is one it has measured against a real Turbopack build as naming every file with the extension — `*.ts`, `**/*.ts`, `{**/,}*.ts`, `*.tsx`, `**/*.tsx`, `*.{ts,tsx}`, `{*.ts,*.tsx}`, `**/*.{ts,tsx}`, `**/{*.ts,*.tsx}`, `**/**/*.{ts,tsx}`. Any other spelling keeps your rule and gains ours beside it, so a module may be transformed twice rather than not at all. The list is exact on purpose: treating an unmeasured glob as project-wide once left every module in a project with no `ttsc` rule at all, and a build that transforms twice is recoverable in a way a build that never transforms is not.
+
 ## Turbopack
 
 Turbopack has no JS plugin API, but it runs webpack loaders through `turbopack.rules`, and a ttsc transform is loader-shaped: TypeScript source in, transformed source out. In a Next.js project `withTtsc` wires this for you; do it by hand when Turbopack runs outside Next, or when you want the rules under your own control. Reference the standalone loader by module name (do not call it):


### PR DESCRIPTION
Cycle 4 of the `@ttsc/unplugin` campaign. Two issues closed, one withdrawn as invalid.

## What this closes

- **#1321** — Metro's `withTtsc` replaced `transformer.babelTransformerPath` and never read what it overwrote, so a project using `react-native-svg-transformer` lost it silently.
- **#1319** — the Turbopack dedupe guard's recognised globs were an unverified contract with Turbopack's matcher. Verifying them found a live defect in that guard.

**#1320 is closed as invalid** and its change reverted. It claimed Next.js has no webpack/Turbopack conflict check; Next 16.3.2 has one, it is `process.exit(1)`, and it is gated on `TURBOPACK === "auto"` — set only when no bundler flag is passed. Every measurement behind that issue used `--turbopack`, the one invocation that disables it. The code it asked to change was correct. What survives is a correction the other way: Next does not *warn*, it stops the build, and the message now says so.

## The defect the verification found

`{src/,}*.ts` was recognised as naming every `.ts` file, on the reasoning that its alternatives include a bare `*.ts`. Measured against a real Turbopack build, that glob matches **nothing** — not the project root, not `src/`. So the guard suppressed this wrapper's own rules in favour of a rule that transforms no file at all: samchon/ttsc#1310, caused by the guard written to prevent it, with a unit test asserting the wrong answer as though it were right.

The rule is now **every** alternative unscoped and one naming the extension, instead of *any*. That accepts all eight spellings a real build confirms and refuses every scoped shape, brace groups included.

## Measurements, not assertions

Taken from real `next build --turbopack` runs on Next.js 16.3.2:

| Claim | Measured |
| --- | --- |
| `{src/,}*.ts` covers the project because one alternative does | covers **nothing** |
| a scoped rule "covers its own subtree" | `src/*.ts` and `src/**/*.ts` cover nothing; `./src/*.ts` and a bare `nested-probe.ts` do match |
| loaders run right-to-left (inferred from webpack) | confirmed for Turbopack itself |
| Next ships no webpack/turbopack check | it does, and it exits 1 |

## Two regressions in the #1321 fix, both caught before merge

The first version compared directory strings, so a second installed copy of `@ttsc/metro` passed the guard, became its own upstream, and — worker options being process-global — read itself back out of `TTSC_METRO_OPTIONS` and recursed until the stack ended. It also passed relative and bare spellings through untouched, so the worker looked for them inside `@ttsc/metro`, turning a transformer that used to be ignored into a build that fails outright.

Both fall to one ordering: resolve the declared value from the project first, then ask whether the resolved *module* is a `@ttsc/metro` transformer — by real path for this copy, by the owning `package.json` for any other. That also catches `require.resolve("@ttsc/metro/transformer")`, which no string comparison could.

## Verification

| Case | Reverted behaviour | Result |
| --- | --- | --- |
| glob judged by every alternative | back to *any* | `{src/,}*.ts` recognised, real build transforms nothing |
| chaining by resolved module | back to directory comparison | duplicate copy adopted as its own upstream |
| project resolution | dropped | relative path travels unanchored |
| recognised-set drift guard | one glob removed from the harness | unit case fails naming it |

Eleven `babelTransformerPath` spellings are pinned, and the experimental suite drives every recognised glob — plus two that must be refused — through real Turbopack builds at three depths: nested `.ts`, root `.ts`, and nested `.tsx`.
