### PR TITLE
fix(lint): stop print-width oscillation in binary expressions

### DIFF
--- a/packages/lint/linthost/rules_format_print_width.go
+++ b/packages/lint/linthost/rules_format_print_width.go
@@ -187,6 +187,18 @@ func (formatPrintWidth) Check(ctx *Context, node *shimast.Node) {
     return
   }
 
+  // Abstain on any uncontrolled reflow target nested below a binary
+  // expression. The structured printer does not own BinaryExpression, so
+  // independently flattening or breaking its child calls and value literals
+  // can change whether the complete binary line fits. The next cascade pass
+  // then reverses those child decisions and `ttsc format` oscillates to the
+  // 10-pass cap. Destructuring assignment targets are the exception: their
+  // literal printer owns the complete left-hand list and already charges the
+  // `= value` suffix against its width budget.
+  if hasUncontrolledBinaryExpressionAncestor(node) {
+    return
+  }
+
   // Abstain on any node nested inside a template-literal substitution.
   // Prettier renders `${…}` expressions at printWidth:Infinity, it
   // never breaks an interpolation the source wrote on one line, so
@@ -499,6 +511,21 @@ func hasReflowAncestor(node *shimast.Node) bool {
   }
   for parent := node.Parent; parent != nil; parent = parent.Parent {
     if isReflowKind(parent.Kind) {
+      return true
+    }
+  }
+  return false
+}
+
+// hasUncontrolledBinaryExpressionAncestor reports whether `node` is a fragment
+// of a binary expression whose layout it cannot own. A destructuring assignment
+// target is safe because the literal printer owns that complete left-hand list.
+func hasUncontrolledBinaryExpressionAncestor(node *shimast.Node) bool {
+  if node == nil || isDestructuringAssignmentTarget(node) {
+    return false
+  }
+  for parent := node.Parent; parent != nil; parent = parent.Parent {
+    if parent.Kind == shimast.KindBinaryExpression {
       return true
     }
   }

--- a/packages/lint/linthost/rules_format_print_width.go
+++ b/packages/lint/linthost/rules_format_print_width.go
@@ -519,15 +519,25 @@ func hasReflowAncestor(node *shimast.Node) bool {
 
 // hasUncontrolledBinaryExpressionAncestor reports whether `node` is a fragment
 // of a binary expression whose layout it cannot own. A destructuring assignment
-// target is safe because the literal printer owns that complete left-hand list.
+// target may skip its owning `=` because the literal printer owns that complete
+// left-hand list, but an enclosing binary expression remains uncontrolled.
 func hasUncontrolledBinaryExpressionAncestor(node *shimast.Node) bool {
-  if node == nil || isDestructuringAssignmentTarget(node) {
+  if node == nil {
     return false
   }
+  skipOwningAssignment := isDestructuringAssignmentTarget(node)
+  child := node
   for parent := node.Parent; parent != nil; parent = parent.Parent {
     if parent.Kind == shimast.KindBinaryExpression {
-      return true
+      expression := parent.AsBinaryExpression()
+      if skipOwningAssignment && expression != nil && expression.OperatorToken != nil &&
+        expression.OperatorToken.Kind == shimast.KindEqualsToken && expression.Left == child {
+        skipOwningAssignment = false
+      } else {
+        return true
+      }
     }
+    child = parent
   }
   return false
 }

--- a/packages/lint/linthost/rules_format_print_width.go
+++ b/packages/lint/linthost/rules_format_print_width.go
@@ -192,9 +192,10 @@ func (formatPrintWidth) Check(ctx *Context, node *shimast.Node) {
   // independently flattening or breaking its child calls and value literals
   // can change whether the complete binary line fits. The next cascade pass
   // then reverses those child decisions and `ttsc format` oscillates to the
-  // 10-pass cap. Destructuring assignment targets are the exception: their
-  // literal printer owns the complete left-hand list and already charges the
-  // `= value` suffix against its width budget.
+  // 10-pass cap. A destructuring assignment target may skip only its directly
+  // owning `=` because the literal printer owns the complete left-hand list and
+  // charges the `= value` suffix. Any binary ancestor above that assignment
+  // remains uncontrolled.
   if hasUncontrolledBinaryExpressionAncestor(node) {
     return
   }

--- a/packages/lint/test/format/command_format_print_width_abstains_inside_binary_expression_test.go
+++ b/packages/lint/test/format/command_format_print_width_abstains_inside_binary_expression_test.go
@@ -7,14 +7,16 @@ import (
 )
 
 // TestCommandFormatPrintWidthAbstainsInsideBinaryExpression verifies
-// print-width preserves nested calls when it cannot own their binary line.
+// print-width preserves nested reflow targets when it cannot own their binary
+// line.
 //
 // A supported call below an unsupported BinaryExpression otherwise makes its
 // width decision in isolation. Broken calls flatten on one pass, the combined
 // binary line overflows on the next, and `ttsc format` reaches its 10-pass cap.
 // The standalone call is the negative twin: it must still reflow normally.
 //
-//  1. Seed broken calls below `||`, `??`, and `&&` plus one long standalone call.
+//  1. Seed broken calls below `||`, `??`, and `&&`, a destructuring assignment
+//     target below `||`, and one long standalone call.
 //  2. Run `ttsc format` twice and require both commands to exit cleanly.
 //  3. Assert the binary fragments stay intact and the standalone call reflows.
 func TestCommandFormatPrintWidthAbstainsInsideBinaryExpression(t *testing.T) {
@@ -36,7 +38,8 @@ func TestCommandFormatPrintWidthAbstainsInsideBinaryExpression(t *testing.T) {
     "  value,\n" +
     ") && isAllowed(\n" +
     "  value,\n" +
-    ");\n"
+    ");\n" +
+    "([alphaValue, ...remainingValues] = sourceValues) || fallbackValue;\n"
   source := binaryFragments +
     "const formatted = standalone(\"alpha\", \"bravo\", \"charlie\");\n"
   want := binaryFragments +

--- a/packages/lint/test/format/command_format_print_width_abstains_inside_binary_expression_test.go
+++ b/packages/lint/test/format/command_format_print_width_abstains_inside_binary_expression_test.go
@@ -1,0 +1,76 @@
+package linthost
+
+import (
+  "os"
+  "path/filepath"
+  "testing"
+)
+
+// TestCommandFormatPrintWidthAbstainsInsideBinaryExpression verifies
+// print-width preserves nested calls when it cannot own their binary line.
+//
+// A supported call below an unsupported BinaryExpression otherwise makes its
+// width decision in isolation. Broken calls flatten on one pass, the combined
+// binary line overflows on the next, and `ttsc format` reaches its 10-pass cap.
+// The standalone call is the negative twin: it must still reflow normally.
+//
+//  1. Seed broken calls below `||`, `??`, and `&&` plus one long standalone call.
+//  2. Run `ttsc format` twice and require both commands to exit cleanly.
+//  3. Assert the binary fragments stay intact and the standalone call reflows.
+func TestCommandFormatPrintWidthAbstainsInsideBinaryExpression(t *testing.T) {
+  binaryFragments := "export function isStrategy(value: unknown): boolean {\n" +
+    "  return isSync(\n" +
+    "    value,\n" +
+    "  ) || isLazy(\n" +
+    "    value,\n" +
+    "  ) || isStatic(\n" +
+    "    value,\n" +
+    "  );\n" +
+    "}\n" +
+    "const nullable = primary(\n" +
+    "  value,\n" +
+    ") ?? fallback(\n" +
+    "  value,\n" +
+    ");\n" +
+    "const enabled = isReady(\n" +
+    "  value,\n" +
+    ") && isAllowed(\n" +
+    "  value,\n" +
+    ");\n"
+  source := binaryFragments +
+    "const formatted = standalone(\"alpha\", \"bravo\", \"charlie\");\n"
+  want := binaryFragments +
+    "const formatted = standalone(\n" +
+    "  \"alpha\",\n" +
+    "  \"bravo\",\n" +
+    "  \"charlie\",\n" +
+    ");\n"
+  root := seedLintProject(t, source)
+  seedLintConfig(t, root, map[string]any{
+    "format": map[string]any{"printWidth": 40},
+  })
+  main := filepath.Join(root, "src", "main.ts")
+
+  for pass := 1; pass <= 2; pass++ {
+    code, stdout, stderr := captureCommandOutput(t, func() int {
+      return run([]string{
+        "format",
+        "--cwd", root,
+        "--plugins-json", lintManifest(t),
+        "--single-threaded",
+      })
+    })
+    if code != 0 || stdout != "" || stderr != "" {
+      t.Fatalf("pass %d: format command mismatch: code=%d stdout=%q stderr=%q",
+        pass, code, stdout, stderr)
+    }
+    got, err := os.ReadFile(main)
+    if err != nil {
+      t.Fatalf("pass %d: ReadFile: %v", pass, err)
+    }
+    if string(got) != want {
+      t.Fatalf("pass %d: reformatted source mismatch:\nwant %q\ngot  %q",
+        pass, want, string(got))
+    }
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -55,6 +55,7 @@ catalogs:
 
 overrides:
   mocha>serialize-javascript: 7.0.3
+  browserslist: 4.28.8
 
 importers:
 
@@ -3245,6 +3246,11 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
+  baseline-browser-mapping@2.11.20:
+    resolution: {integrity: sha512-H0ulySigv6icDJ1F7SjtdCD6PrhTpdYCmP0CactWy1+ekh0AFd0o1Wn5T8b+hnTmdBx19u9yhL6wvCylXMY7zw==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
   basic-ftp@5.3.1:
     resolution: {integrity: sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw==}
     engines: {node: '>=10.0.0'}
@@ -3302,8 +3308,8 @@ packages:
   browser-stdout@1.3.1:
     resolution: {integrity: sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==}
 
-  browserslist@4.28.2:
-    resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
+  browserslist@4.28.8:
+    resolution: {integrity: sha512-V2NpofLblG64mfOtSgDhOJESZEGogzDMBv/q+W6oc4LXWP/q75eOXoOaaOu1EOadB9U4Bwx/e0yzbvwKH8zalA==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
@@ -3362,6 +3368,9 @@ packages:
 
   caniuse-lite@1.0.30001793:
     resolution: {integrity: sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA==}
+
+  caniuse-lite@1.0.30001810:
+    resolution: {integrity: sha512-TITQPUkaz+aVk5GL6NhOdwk1aEaNTSDPsGFWrTuhKGtjTF70jL/Oht2W4c6rXUe5fu7Ie19VIahAXHIIiWWNeg==}
 
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
@@ -3904,8 +3913,8 @@ packages:
   ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
 
-  electron-to-chromium@1.5.361:
-    resolution: {integrity: sha512-Q6Hts7N9FnJc5LeGRINFvLhCI9xZmNtTDe5ZbcVezQz7cU4a8Aua3GH1b8J2XY8Al9PF+OCwYqhgsOOheMdvkA==}
+  electron-to-chromium@1.5.420:
+    resolution: {integrity: sha512-2yD6XreGusOfNV+dUcvipJEXc3n/n7fgr7996aszTG+YY5E4mqM4tOq/3uhP129cazL9YHbVWSpc79ePotWtPA==}
 
   email-addresses@5.0.0:
     resolution: {integrity: sha512-4OIPYlA6JXqtVn8zpHpGiI7vE6EQOAg16aGnDMIAlZVinnoZ8208tW1hAbjWydgN/4PLTT9q+O1K6AH/vALJGw==}
@@ -5326,8 +5335,8 @@ packages:
     resolution: {integrity: sha512-LarFH0+6VfriEhqMMcLX2F7SwSXeWwnEAJEsYm5QKWchiVYVvJyV9v7UDvUv+w5HO23ZpQTXDv/GxdDdMyOuoQ==}
     engines: {node: '>= 6.13.0'}
 
-  node-releases@2.0.46:
-    resolution: {integrity: sha512-GYVXHE2KnrzAfsAjl4uP++evGFCrAU1jta4ubEjIG7YWt/64Gqv66a30yKwWczVjA6j3bM4nBwH7Pk1JmDHaxQ==}
+  node-releases@2.0.54:
+    resolution: {integrity: sha512-YHs7BmmcsdAI5Ozuf8JZo6PT0mv2GIWC9vMfvUC3dp65M8hn7Ux8CPL+2oBI7juNuj9d0ndhTcznq2ODBps9cQ==}
     engines: {node: '>=18'}
 
   node-sarif-builder@3.4.0:
@@ -6492,11 +6501,11 @@ packages:
     resolution: {integrity: sha512-5uKD0nqiYVzlmCRs01Fhs2BdkEgBS3SAVP6ndrBsuK42iC2+JHyxM05Rm9G8+5mkmRtzMZGY8Ct5+mliZxU/Ww==}
     engines: {node: '>=18.12.0'}
 
-  update-browserslist-db@1.2.3:
-    resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
+  update-browserslist-db@1.3.2:
+    resolution: {integrity: sha512-UQ+MSxlhRm1bzjhU+DcuXfjFO1FzNtqhK5+9Yvlp90ItDLk5vT932A0rFu619nf7RVS+Y/VeaUW1jaRDqZ8VJw==}
     hasBin: true
     peerDependencies:
-      browserslist: '>= 4.21.0'
+      browserslist: 4.28.8
 
   url-join@4.0.1:
     resolution: {integrity: sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==}
@@ -9019,6 +9028,8 @@ snapshots:
 
   baseline-browser-mapping@2.10.32: {}
 
+  baseline-browser-mapping@2.11.20: {}
+
   basic-ftp@5.3.1: {}
 
   batch@0.6.1: {}
@@ -9097,13 +9108,13 @@ snapshots:
 
   browser-stdout@1.3.1: {}
 
-  browserslist@4.28.2:
+  browserslist@4.28.8:
     dependencies:
-      baseline-browser-mapping: 2.10.32
-      caniuse-lite: 1.0.30001793
-      electron-to-chromium: 1.5.361
-      node-releases: 2.0.46
-      update-browserslist-db: 1.2.3(browserslist@4.28.2)
+      baseline-browser-mapping: 2.11.20
+      caniuse-lite: 1.0.30001810
+      electron-to-chromium: 1.5.420
+      node-releases: 2.0.54
+      update-browserslist-db: 1.3.2(browserslist@4.28.8)
 
   buffer-crc32@0.2.13: {}
 
@@ -9171,6 +9182,8 @@ snapshots:
   camelcase@6.3.0: {}
 
   caniuse-lite@1.0.30001793: {}
+
+  caniuse-lite@1.0.30001810: {}
 
   ccount@2.0.1: {}
 
@@ -9708,7 +9721,7 @@ snapshots:
 
   ee-first@1.1.1: {}
 
-  electron-to-chromium@1.5.361: {}
+  electron-to-chromium@1.5.420: {}
 
   email-addresses@5.0.0: {}
 
@@ -11656,7 +11669,7 @@ snapshots:
 
   node-forge@1.4.0: {}
 
-  node-releases@2.0.46: {}
+  node-releases@2.0.54: {}
 
   node-sarif-builder@3.4.0:
     dependencies:
@@ -13157,9 +13170,9 @@ snapshots:
       picomatch: 4.0.4
       webpack-virtual-modules: 0.6.2
 
-  update-browserslist-db@1.2.3(browserslist@4.28.2):
+  update-browserslist-db@1.3.2(browserslist@4.28.8):
     dependencies:
-      browserslist: 4.28.2
+      browserslist: 4.28.8
       escalade: 3.2.0
       picocolors: 1.1.1
 
@@ -13332,7 +13345,7 @@ snapshots:
       '@webassemblyjs/wasm-parser': 1.14.1
       acorn: 8.16.0
       acorn-import-phases: 1.0.4(acorn@8.16.0)
-      browserslist: 4.28.2
+      browserslist: 4.28.8
       chrome-trace-event: 1.0.4
       enhanced-resolve: 5.22.0
       es-module-lexer: 2.1.0
@@ -13371,7 +13384,7 @@ snapshots:
       '@webassemblyjs/wasm-parser': 1.14.1
       acorn: 8.16.0
       acorn-import-phases: 1.0.4(acorn@8.16.0)
-      browserslist: 4.28.2
+      browserslist: 4.28.8
       chrome-trace-event: 1.0.4
       enhanced-resolve: 5.22.0
       es-module-lexer: 2.1.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -14,6 +14,9 @@ autoInstallPeers: false
 # release, so keep the real Mocha register defense without accepting that edge.
 overrides:
   "mocha>serialize-javascript": 7.0.3
+  # Browserslist before 4.28.7 has two data-processing advisories. Pin the
+  # patched release until every transitive consumer raises its own range.
+  browserslist: 4.28.8
 catalogs:
   typescript:
     typescript: ^7.0.2

--- a/website/src/content/docs/lint/format.mdx
+++ b/website/src/content/docs/lint/format.mdx
@@ -226,8 +226,8 @@ Width is measured in **display columns** (Prettier's `getStringWidth`), not UTF-
 This list is the reflow's own, scoped to node shapes. The boundary that applies to the whole format set is [Scope](#scope).
 
 - JSX elements and fragments.
-- Binary expressions.
-- Destructuring patterns.
+- Binary expressions, including otherwise supported calls and value literals nested inside them. The rule preserves those fragments until it can render the complete binary chain. Destructuring assignment targets remain covered because their literal printer owns the complete left-hand list.
+- Binding destructuring patterns.
 - Decorators (their call arguments still hug per the rules above).
 - Multi-line string and template literals.
 - Lists with comments interleaved between members (the rule detects this and abstains).

--- a/website/src/content/docs/lint/format.mdx
+++ b/website/src/content/docs/lint/format.mdx
@@ -226,7 +226,7 @@ Width is measured in **display columns** (Prettier's `getStringWidth`), not UTF-
 This list is the reflow's own, scoped to node shapes. The boundary that applies to the whole format set is [Scope](#scope).
 
 - JSX elements and fragments.
-- Binary expressions, including otherwise supported calls and value literals nested inside them. The rule preserves those fragments until it can render the complete binary chain. Destructuring assignment targets remain covered because their literal printer owns the complete left-hand list.
+- Binary expressions, including otherwise supported calls and value literals nested inside them. The rule preserves those fragments until it can render the complete binary chain. A direct destructuring assignment target remains covered because its literal printer owns the complete left-hand list; when that assignment is nested in another binary expression, the rule preserves it with the outer expression.
 - Binding destructuring patterns.
 - Decorators (their call arguments still hug per the rules above).
 - Multi-line string and template literals.


### PR DESCRIPTION
## Intent

Issue #1323 demonstrates a two-state `format/print-width` cascade when a supported call or value literal is nested below a binary expression that the structured printer does not own. This pull request restores the formatter's conservative ownership invariant so the cascade converges.

## Change

- Abstain from print-width reflow when any uncontrolled `BinaryExpression` is an ancestor of the visited node.
- Keep the existing direct destructuring assignment behavior by skipping only the target's directly owning `=`, then resume scanning for outer binary expressions.
- Add a command-level regression covering `||`, `??`, `&&`, a destructuring assignment below `||`, a standalone-call negative twin, and byte-identical second-run output.
- Document the binary-expression ownership boundary and distinguish binding destructuring patterns from direct assignment targets.
- Pin Browserslist 4.28.8 after the required dependency-audit lane exposed two advisories with released fixes.

## Boundary

Full `BinaryExpression` printer coverage and binary-chain reflow remain outside this change. Unsupported binary subtrees stay byte-identical until the structured printer can own the complete chain.

## Verification

- Before the local-test restriction, the baseline native reproduction reached the ten-pass cap with exit 2; the corrected reproduction exited 0 twice with identical output.
- Before the local-test restriction, the focused command regression and relevant print-width group passed, including a repeated run. A full lint run reached its ten-minute limit in unrelated corpus work after exposing two direct-assignment regressions; those regressions were corrected and covered, but the full run was not repeated.
- Before the local-test restriction, `pnpm run check:dependencies` passed with `low=9`, `moderate=23`, `high=1`, `critical=0`, and `waived=1` after the Browserslist override.
- The required final `pnpm format` completed successfully. `git diff --check` and the tracked worktree are clean.
- No local test or suite was run after the restriction.
- All 29 ordinary CI checks passed on exact head `c822e5fb2862b0f8caae0cc54d030abaf9f515d2`.

## Self-Review

- Individual Self-Review on the implementation found the overbroad destructuring-target exemption, and the correction review plus the first Overall round found its source and guide explanation mismatch. Both findings were corrected.
- Individual Self-Review of exact commit `c822e5fb2862b0f8caae0cc54d030abaf9f515d2` is clean.
- Final Overall Self-Review of exact diff `36c8488c347917e807cba88a9f9b9df47a54c6cc..c822e5fb2862b0f8caae0cc54d030abaf9f515d2` is clean.
