### PR TITLE
feat(evidence): support claim and reference severity overrides

### DIFF
--- a/packages/evidence/native/checklist_defers_the_unhosted_report_test.go
+++ b/packages/evidence/native/checklist_defers_the_unhosted_report_test.go
@@ -234,8 +234,8 @@ func TestChecklistWithholdsTheUnhostedReportWhenALoaderFailureHidesConsumption(t
   }
 
   failed := evaluateEvidenceGraph(build(false), nil)
-  if strings.Contains(strings.Join(failed, "\n"), "Unhosted") {
-    t.Fatalf("an unknowable consumption was reported as none:\n%s", strings.Join(failed, "\n"))
+  if strings.Contains(strings.Join(problemMessages(failed), "\n"), "Unhosted") {
+    t.Fatalf("an unknowable consumption was reported as none:\n%s", strings.Join(problemMessages(failed), "\n"))
   }
   assertProblemContains(t, failed, "has not acknowledged 1 of 1 checklist item(s): 'docs/rules.md#only-rule'")
 

--- a/packages/evidence/native/config.go
+++ b/packages/evidence/native/config.go
@@ -8,6 +8,8 @@ import (
   "path"
   "sort"
   "strings"
+
+  "github.com/samchon/ttsc/packages/lint/rule"
 )
 
 func decodeGraphConfig(raw json.RawMessage) (graphConfig, []string) {
@@ -54,7 +56,7 @@ func decodeClaim(raw json.RawMessage, index int) (claimSpec, []string) {
   }
   problems := rejectUnknownFields(
     object,
-    []string{"type", "name", "disabled", "root", "files", "evidenceExcludeCarriers", "symbol", "reference"},
+    []string{"type", "name", "severity", "disabled", "root", "files", "evidenceExcludeCarriers", "symbol", "reference"},
     graphRuleName,
     path,
   )
@@ -78,6 +80,8 @@ func decodeClaim(raw json.RawMessage, index int) (claimSpec, []string) {
       problems = append(problems, "Invalid evidence/graph configuration at "+path+".disabled: expected a boolean.")
     }
   }
+  severity, severityProblems := decodeGraphSeverity(object["severity"], path+".severity")
+  problems = append(problems, severityProblems...)
   root, rootProblems := decodeClaimRoot(object["root"], kind, path+".root")
   problems = append(problems, rootProblems...)
   files, fileProblems := decodeFiles(object["files"], path+".files")
@@ -98,6 +102,7 @@ func decodeClaim(raw json.RawMessage, index int) (claimSpec, []string) {
   }
   return claimSpec{
     Index:             index,
+    Severity:          severity,
     Type:              kind,
     Name:              name,
     Disabled:          disabled,
@@ -109,16 +114,26 @@ func decodeClaim(raw json.RawMessage, index int) (claimSpec, []string) {
   }, nil
 }
 
-// enabledGraphConfig removes explicitly staged claims after their public
+// enabledGraphConfig removes disabled claims and references after their public
 // configuration has been validated. Keeping the filter separate from decoding
-// preserves original claim indexes and prevents disabled entries from hiding a
+// preserves original indexes and prevents disabled entries from hiding a
 // malformed shape.
 func enabledGraphConfig(config graphConfig) graphConfig {
   claims := make([]claimSpec, 0, len(config.Claims))
   for _, claim := range config.Claims {
-    if claim.Disabled {
+    if claim.Disabled || claim.Severity != nil && *claim.Severity == rule.SeverityOff {
       continue
     }
+    references := make([]referenceSpec, 0, len(claim.References))
+    for _, reference := range claim.References {
+      if reference.Severity == nil || *reference.Severity != rule.SeverityOff {
+        references = append(references, reference)
+      }
+    }
+    if len(references) == 0 {
+      continue
+    }
+    claim.References = references
     claims = append(claims, claim)
   }
   config.Claims = claims
@@ -183,6 +198,7 @@ func decodeReference(
     object,
     []string{
       "type",
+      "severity",
       "noEvidenceExclude",
       "uniqueEvidence",
       "singleEvidencePerSymbol",
@@ -204,6 +220,8 @@ func decodeReference(
   if problem := rejectForeignTypeScriptReference(claimKind, kind, path); problem != "" {
     problems = append(problems, problem)
   }
+  severity, severityProblems := decodeGraphSeverity(object["severity"], path+".severity")
+  problems = append(problems, severityProblems...)
   root, rootProblems := decodeRoot(object["root"], kind, path+".root")
   problems = append(problems, rootProblems...)
   policy, policyProblems := decodeReferencePolicy(object, kind, path)
@@ -265,14 +283,15 @@ func decodeReference(
     return referenceSpec{}, problems
   }
   return referenceSpec{
-    Index:   index,
-    Type:    kind,
-    Policy:  policy,
-    Root:    root,
-    Files:   files,
-    Source:  source,
-    Package: packageName,
-    Symbols: symbols,
+    Severity: severity,
+    Index:    index,
+    Type:     kind,
+    Policy:   policy,
+    Root:     root,
+    Files:    files,
+    Source:   source,
+    Package:  packageName,
+    Symbols:  symbols,
   }, nil
 }
 

--- a/packages/evidence/native/configuration_defaults_follow_public_contract_test.go
+++ b/packages/evidence/native/configuration_defaults_follow_public_contract_test.go
@@ -91,12 +91,11 @@ func TestConfigurationKeepsSymbolUnionAndReferencesDistinct(t *testing.T) {
 }
 
 /**
- * Verifies invalid configuration diagnostics: obsolete nested severity and
+ * Verifies invalid configuration diagnostics: invalid nested severity and
  * empty obligation arrays fail before graph evaluation.
  *
- * The public contract leaves severity to the outer lint tuple and requires a
- * real evidence population. Accepting old fields or vacuous arrays would
- * preserve the superseded model as a silent compatibility path.
+ * The public contract validates nested severity and requires a real evidence
+ * population. Invalid levels and vacuous arrays must fail at configuration.
  *
  *  1. Decode a claim with nested severity and an empty reference array.
  *  2. Decode an empty claim array separately.
@@ -107,13 +106,13 @@ func TestConfigurationRejectsObsoleteAndVacuousShapes(t *testing.T) {
     "claims": [{
       "type": "typescript",
       "files": ["src/**"],
-      "severity": "error",
+      "severity": "fatal",
       "reference": []
     }]
   }`))
   joined := strings.Join(problems, "\n")
-  if !strings.Contains(joined, "severity belongs only in the outer") {
-    t.Fatalf("nested severity was not rejected: %s", joined)
+  if !strings.Contains(joined, "claims[0].severity") {
+    t.Fatalf("invalid severity was not rejected: %s", joined)
   }
   if !strings.Contains(joined, "empty reference array") {
     t.Fatalf("empty references were not rejected: %s", joined)

--- a/packages/evidence/native/configuration_severity_matches_lint_values_test.go
+++ b/packages/evidence/native/configuration_severity_matches_lint_values_test.go
@@ -1,0 +1,40 @@
+package evidence
+
+import (
+  "encoding/json"
+  "testing"
+
+  "github.com/samchon/ttsc/packages/lint/rule"
+)
+
+/**
+ * Verifies nested severity accepts the public lint values and preserves absence.
+ *
+ * Off and inheritance cannot share a zero value. Null is an invalid level;
+ * JavaScript undefined is omitted when options are serialized.
+ *
+ * 1. Decode the omitted value and every named or numeric severity.
+ * 2. Reject null, booleans, objects, and unknown levels.
+ * 3. Assert decoding distinguishes omission from explicit off.
+ */
+func TestConfigurationSeverityMatchesLintValues(t *testing.T) {
+  absent, problems := decodeGraphSeverity(nil, "severity")
+  if absent != nil || len(problems) != 0 {
+    t.Fatalf("omission must inherit: %v %v", absent, problems)
+  }
+  for raw, want := range map[string]rule.Severity{
+    `"off"`: rule.SeverityOff, `0`: rule.SeverityOff,
+    `"warning"`: rule.SeverityWarn, `"warn"`: rule.SeverityWarn, `1`: rule.SeverityWarn,
+    `"error"`: rule.SeverityError, `2`: rule.SeverityError, `2.0`: rule.SeverityError, `"err\u006fr"`: rule.SeverityError,
+  } {
+    got, problems := decodeGraphSeverity(json.RawMessage(raw), "severity")
+    if len(problems) != 0 || got == nil || *got != want {
+      t.Fatalf("%s: got %v %v", raw, got, problems)
+    }
+  }
+  for _, raw := range []string{`null`, `true`, `{}`, `[]`, `"fatal"`, `""`, `3`, `-1`, `1.5`} {
+    if _, problems := decodeGraphSeverity(json.RawMessage(raw), "severity"); len(problems) != 1 {
+      t.Fatalf("accepted invalid level %s", raw)
+    }
+  }
+}

--- a/packages/evidence/native/graph.go
+++ b/packages/evidence/native/graph.go
@@ -31,6 +31,7 @@ func (graphRule) Check(ctx *rule.ProjectContext) {
     reportProblems(ctx, problems)
     return
   }
+  resolveGraphSeverities(&config, ctx.Severity)
   config = enabledGraphConfig(config)
   if len(config.Claims) == 0 {
     cycle.Corpus = graphCorpus{Config: config}
@@ -46,6 +47,7 @@ func (graphRule) Check(ctx *rule.ProjectContext) {
     ctx.Report("Evidence graph project root '" + root + "' is not a readable directory. Fix the ttsc project identity before evaluating evidence globs.")
     return
   }
+  diagnostics := graphDiagnostics{}
   // Every population is anchored before anything is read, so a loader, a
   // diagnostic, and the corpus the editor receives all speak of one resolved
   // base rather than each re-deriving it from the author's spelling.
@@ -68,15 +70,15 @@ func (graphRule) Check(ctx *rule.ProjectContext) {
     root,
     claimPopulationConfig(config, artifactPrisma),
   )
-  problems = append(
-    problems,
+  diagnostics = append(
+    diagnostics,
     typeScriptBaseProblems(
       claimPopulationConfig(config, artifactTypeScript),
       typescript,
     )...,
   )
-  problems = append(problems, markdownClaimProblems...)
-  problems = append(problems, prismaClaimProblems...)
+  diagnostics = append(diagnostics, markdownClaimProblems...)
+  diagnostics = append(diagnostics, prismaClaimProblems...)
   // Governance is judged against the configuration as declared, before
   // activation drops a claim whose population materialized no unit of its
   // symbol kind. The question is whether an author put this file in a
@@ -91,10 +93,10 @@ func (graphRule) Check(ctx *rule.ProjectContext) {
   markdown, markdownProblems := loadMarkdownInventories(root, config)
   prisma, prismaProblems := loadPrismaInventories(root, config)
   swagger, swaggerProblems := loadSwaggerInventories(root, config)
-  problems = append(problems, markdownProblems...)
-  problems = append(problems, prismaProblems...)
-  problems = append(problems, swaggerProblems...)
-  problems = append(problems, unreadableTypeScriptTags(typescript, governed)...)
+  diagnostics = append(diagnostics, markdownProblems...)
+  diagnostics = append(diagnostics, prismaProblems...)
+  diagnostics = append(diagnostics, swaggerProblems...)
+  diagnostics = append(diagnostics, unreadableTypeScriptTags(typescript, governed, declared)...)
   loader := newTypeScriptLoader(root, typescript)
   states, stateProblems := materializeClaimStates(
     config,
@@ -104,10 +106,10 @@ func (graphRule) Check(ctx *rule.ProjectContext) {
     typescript,
     loader,
   )
-  problems = append(problems, stateProblems...)
-  problems = append(problems, evaluateEvidenceGraph(states, loader)...)
-  reportProblems(ctx, problems)
-  if len(problems) == 0 {
+  diagnostics = append(diagnostics, stateProblems...)
+  diagnostics = append(diagnostics, evaluateEvidenceGraph(states, loader)...)
+  diagnostics.report(ctx)
+  if len(diagnostics) == 0 {
     // Published only on a clean evaluation, because the host reads state
     // from a rule that passed and reporting anything marks this one failed
     // (`linthost/hints.go:147-149`, `linthost/project_engine.go:68-77`).
@@ -238,10 +240,11 @@ func materializeClaimStates(
   swagger map[string]*artifactInventory,
   typescript map[string]*artifactInventory,
   loader *typeScriptLoader,
-) ([]claimState, []string) {
+) ([]claimState, graphDiagnostics) {
   states := make([]claimState, 0, len(config.Claims))
-  problems := []string{}
+  problems := graphDiagnostics{}
   for _, claim := range config.Claims {
+    severity := claim.Level
     inventories := inventoriesOf(claim.Type, markdown, prisma, swagger, typescript)
     paths := matchingInventoryPaths(inventories, claim.Base, claim.Files)
     state := claimState{
@@ -268,8 +271,8 @@ func materializeClaimStates(
       // exclusion the claim writes, so the misspelling is reported where
       // it was made rather than as a placement finding on each tag.
       if len(carrierPaths) == 0 && len(paths) != 0 {
-        problems = append(
-          problems,
+        problems = problems.add(
+          severity,
           claimLabel(claim)+" declares evidenceExcludeCarriers "+describePopulation(claim.Base, claim.ExclusionCarriers)+", which selects none of its "+decimal(len(paths))+" claim file(s). Point the patterns at a file this claim already selects, or drop the property to accept an exclusion anywhere in the population.",
         )
       }
@@ -346,6 +349,7 @@ func materializeClaimStates(
     }
     sortUnits(state.Hosts)
     for _, reference := range claim.References {
+      severity := reference.Level
       referenceInventories := inventoriesOf(
         reference.Type,
         markdown,
@@ -359,7 +363,7 @@ func materializeClaimStates(
           reference,
           loader,
         )
-        problems = append(problems, entryProblems...)
+        problems = problems.add(severity, entryProblems...)
         state.References = append(state.References, entryState)
         continue
       }
@@ -369,7 +373,7 @@ func materializeClaimStates(
           reference,
           loader,
         )
-        problems = append(problems, packageProblems...)
+        problems = problems.add(severity, packageProblems...)
         state.References = append(state.References, packageState)
         continue
       }
@@ -380,7 +384,7 @@ func materializeClaimStates(
           referenceInventories,
           loader,
         )
-        problems = append(problems, localProblems...)
+        problems = problems.add(severity, localProblems...)
         state.References = append(state.References, localState)
         continue
       }
@@ -396,13 +400,13 @@ func materializeClaimStates(
       }
       if len(referencePaths) == 0 && referenceState.Healthy {
         if reference.Type == artifactSwagger {
-          problems = append(
-            problems,
+          problems = problems.add(
+            severity,
             claimLabel(claim)+" "+referenceLabel(reference)+" matched no swagger source for "+describeReferenceSources(reference)+". Fix the reference location; this obligation cannot materialize evidence units without a source.",
           )
         } else {
-          problems = append(
-            problems,
+          problems = problems.add(
+            severity,
             claimLabel(claim)+" "+referenceLabel(reference)+" matched no "+string(reference.Type)+" files for "+describePopulation(reference.Base, reference.Files)+". Fix the reference globs or the root they resolve against; this obligation cannot materialize evidence units without files.",
           )
         }
@@ -477,8 +481,8 @@ func materializeClaimStates(
         len(referenceState.Units) == 0 &&
         referenceState.Healthy &&
         !selectedInventoryProblem {
-        problems = append(
-          problems,
+        problems = problems.add(
+          severity,
           claimLabel(claim)+" "+referenceLabel(reference)+" matched "+decimal(len(referencePaths))+" file(s) but found no selected evidence units ("+reference.Symbols.names()+"). Select symbol kinds present in those files or correct the reference globs.",
         )
       }
@@ -492,8 +496,8 @@ func materializeClaimStates(
 func evaluateEvidenceGraph(
   states []claimState,
   loader *typeScriptLoader,
-) []string {
-  problems := []string{}
+) graphDiagnostics {
+  problems := graphDiagnostics{}
   targets := map[string]map[string]*evidenceUnit{}
   markdownTargets := map[string]map[string]*evidenceUnit{}
   // Scoped targets are keyed by owning file as well as name, which is what
@@ -604,11 +608,12 @@ func evaluateEvidenceGraph(
 
   resolved := map[string]string{}
   for _, id := range declarationIDs {
+    severity := ownerSeverity(owners[id])
     declaration := declarations[id]
     context := declarationObligationContext(owners[id])
     if !declaration.valid() {
-      problems = append(
-        problems,
+      problems = problems.add(
+        severity,
         "Malformed @"+string(declaration.Tag)+" declaration at "+declaration.location()+" for "+context+": target and non-empty reason are mandatory. Write '@"+string(declaration.Tag)+" <target> <reason>'."+untrueTagWarning,
       )
       continue
@@ -622,7 +627,7 @@ func evaluateEvidenceGraph(
         context,
       )
       if problem != "" {
-        problems = append(problems, problem)
+        problems = problems.add(severity, problem)
         continue
       }
       resolved[id] = unitID
@@ -630,8 +635,8 @@ func evaluateEvidenceGraph(
     }
     if declaration.Type == artifactTypeScript &&
       looksLikeTypeScriptTarget(declaration.Target, targets, markdownTargets) {
-      problems = append(
-        problems,
+      problems = problems.add(
+        severity,
         "Unbraced TypeScript evidence target '"+declaration.Target+"' at "+declaration.location()+" for "+context+": a target naming a symbol is now written as an inline link, so the citing module's import is what resolves it. Write '@"+string(declaration.Tag)+" {@link "+declaration.Target+"} <reason>' and import the symbol; 'import type' is enough.",
       )
       continue
@@ -648,8 +653,8 @@ func evaluateEvidenceGraph(
     if declaration.Type != artifactTypeScript {
       addressable, code := splitCodeCandidates(candidates)
       if len(addressable) == 0 && len(code) != 0 {
-        problems = append(
-          problems,
+        problems = problems.add(
+          severity,
           "Code evidence target '"+declaration.Target+"' at "+declaration.location()+" for "+context+": a "+string(declaration.Type)+" claim cannot cite a TypeScript symbol, because a symbol citation resolves through the citing module's imports and this artifact has none. Invert the obligation so the code cites this artifact, or move the citation into TypeScript.",
         )
         continue
@@ -667,14 +672,11 @@ func evaluateEvidenceGraph(
         continue
       }
       if hidden := hiddenTargets[declaration.Target]; hidden != nil {
-        problems = append(
-          problems,
-          hiddenTargetProblem(declaration, hidden, context),
-        )
+        problems = problems.add(severity, hiddenTargetProblem(declaration, hidden, context))
         continue
       }
-      problems = append(
-        problems,
+      problems = problems.add(
+        severity,
         "Unresolved evidence target '"+declaration.Target+"' at "+declaration.location()+" for "+context+": no configured source materializes that evidence unit. Correct the target, make one of the named references select the source unit this claim actually uses, or remove the tag when this host does not answer for that target."+untrueTagWarning,
       )
     case 1:
@@ -687,8 +689,8 @@ func evaluateEvidenceGraph(
         descriptions = append(descriptions, unit.Readable+" at "+unit.location())
       }
       sort.Strings(descriptions)
-      problems = append(
-        problems,
+      problems = problems.add(
+        severity,
         "Ambiguous evidence target '"+declaration.Target+"' at "+declaration.location()+" for "+context+": it matches "+strings.Join(descriptions, "; ")+". Rename or qualify the source symbols so the target has exactly one meaning.",
       )
     }
@@ -697,11 +699,13 @@ func evaluateEvidenceGraph(
   participates := map[string]bool{}
   uncertain := map[string]bool{}
   outOfScope := map[string][]string{}
+  outOfScopeLevels := map[string]rule.Severity{}
   outOfScopeSelections := map[string]symbolSet{}
   // An exclusion outside its claim's declared carriers is a placement
   // finding, not a host-kind one, so it carries its own obligations and the
   // carrier globs its message must name.
   outsideCarrier := map[string][]string{}
+  outsideCarrierLevels := map[string]rule.Severity{}
   outsideCarrierGlobs := map[string]string{}
   // A checklist tag speaking for no selected host is a non-participation
   // finding: within its reference it answers nothing, and whether that earns a
@@ -711,6 +715,7 @@ func evaluateEvidenceGraph(
   // elsewhere — so the finding is recorded here and judged after the walk,
   // when `answers` can say whether anything consumed the tag.
   unhosted := map[string][]string{}
+  unhostedLevels := map[string]rule.Severity{}
   unhostedSelections := map[string]symbolSet{}
   // answers marks a declaration that wrote at least one acknowledgement
   // ledger, or was refused as an aggregate, which is that citation's own
@@ -732,6 +737,7 @@ func evaluateEvidenceGraph(
     // reviewing reference pays nothing.
     var reviewLedgerForClaim *reviewLedger
     for _, reference := range state.References {
+      severity := reference.Spec.Level
       if !reference.Healthy {
         for _, declaration := range state.Declarations {
           uncertain[declaration.ID] = true
@@ -819,6 +825,7 @@ func evaluateEvidenceGraph(
           continue
         }
         if declaration.Tag == tagExclude && state.OutsideCarrier[declaration.ID] {
+          outsideCarrierLevels[declaration.ID] = max(outsideCarrierLevels[declaration.ID], severity)
           outsideCarrier[declaration.ID] = appendUniqueString(
             outsideCarrier[declaration.ID],
             claimLabel(state.Spec)+" "+referenceLabel(reference.Spec),
@@ -827,6 +834,7 @@ func evaluateEvidenceGraph(
           continue
         }
         if !declarationEligibleForClaim(declaration, state.Spec) {
+          outOfScopeLevels[declaration.ID] = max(outOfScopeLevels[declaration.ID], severity)
           outOfScope[declaration.ID] = appendUniqueString(
             outOfScope[declaration.ID],
             claimLabel(state.Spec)+" "+referenceLabel(reference.Spec),
@@ -849,8 +857,8 @@ func evaluateEvidenceGraph(
           continue
         }
         if declaration.Tag == tagExclude && reference.Spec.Policy.NoExclude {
-          problems = append(
-            problems,
+          problems = problems.add(
+            severity,
             "Forbidden @evidenceExclude for '"+scopesByID[scopeID].Target+"' at "+declaration.location()+" in "+claimLabel(state.Spec)+" "+referenceLabel(reference.Spec)+": noEvidenceExclude requires positive @evidence for this reference. Remove the exclusion and cite the target from a selected "+string(state.Spec.Type)+" host that answers for it."+untrueTagWarning,
           )
           continue
@@ -889,6 +897,7 @@ func evaluateEvidenceGraph(
             // answer, and a hard diagnostic here left that valid configuration
             // no placement to exist in. The end-of-run block reports the tag
             // once nothing has consumed it.
+            unhostedLevels[declaration.ID] = max(unhostedLevels[declaration.ID], severity)
             unhosted[declaration.ID] = appendUniqueString(
               unhosted[declaration.ID],
               claimLabel(state.Spec)+" "+referenceLabel(reference.Spec),
@@ -910,8 +919,8 @@ func evaluateEvidenceGraph(
           for _, unit := range covered {
             targets = append(targets, "'"+unit.Target+"'")
           }
-          problems = append(
-            problems,
+          problems = problems.add(
+            severity,
             "Aggregate @evidence target '"+scopesByID[scopeID].Target+"' at "+declaration.location()+" in "+claimLabel(state.Spec)+" "+referenceLabel(reference.Spec)+": this reference is a checklist, so a citation answers for the item it names, and this target names a scope containing "+decimal(len(covered))+" item(s) ("+strings.Join(targets, ", ")+") rather than one of them. Cite each item this host answers for, or write @evidenceExclude on this scope when none of it applies here."+untrueTagWarning,
           )
           for _, unit := range covered {
@@ -936,7 +945,7 @@ func evaluateEvidenceGraph(
           if reviewLedgerForClaim == nil {
             reviewLedgerForClaim = newReviewLedger(state.Reviews)
           }
-          problems = append(problems, reviewProblems(
+          problems = problems.add(severity, reviewProblems(
             declaration,
             scopesByID[scopeID],
             reference,
@@ -952,8 +961,8 @@ func evaluateEvidenceGraph(
             evidenceByHostAndScope[declaration.HostID] = byScope
           }
           if first := byScope[scopeID]; first != nil {
-            problems = append(
-              problems,
+            problems = problems.add(
+              severity,
               "Duplicate @evidence for '"+scopesByID[scopeID].Target+"' on the same host at "+declaration.location()+"; first declared at "+first.location()+".",
             )
           } else {
@@ -1060,14 +1069,14 @@ func evaluateEvidenceGraph(
             evidence = conflictingDeclaration
             exclusion = declaration
           }
-          problems = append(
-            problems,
+          problems = problems.add(
+            severity,
             "Conflicting acknowledgements for '"+conflictingUnit.Target+"' in "+claimLabel(state.Spec)+" "+referenceLabel(reference.Spec)+": @evidence at "+evidence.location()+" overlaps @evidenceExclude at "+exclusion.location()+". Delete whichever is untrue of this host."+untrueTagWarning,
           )
         }
         if duplicateExclusionUnit != nil {
-          problems = append(
-            problems,
+          problems = problems.add(
+            severity,
             "Duplicate @evidenceExclude for '"+duplicateExclusionUnit.Target+"' in "+claimLabel(state.Spec)+" "+referenceLabel(reference.Spec)+": exclusion at "+declaration.location()+" overlaps exclusion at "+firstExclusion.location()+".",
           )
         }
@@ -1084,8 +1093,8 @@ func evaluateEvidenceGraph(
           if count == 1 {
             continue
           }
-          problems = append(
-            problems,
+          problems = problems.add(
+            severity,
             "Evidence host "+host.Readable+" at "+host.location()+" in "+claimLabel(state.Spec)+" "+referenceLabel(reference.Spec)+" cites "+decimal(count)+" distinct selected evidence unit(s); singleEvidencePerSymbol requires exactly 1. Split this host so each unit has one that owns it, or keep positive @evidence citations on this semantic host to exactly one distinct unit.",
           )
         }
@@ -1116,8 +1125,8 @@ func evaluateEvidenceGraph(
           if reference.Spec.Policy.NoExclude {
             repair = "Do what each item requires and cite it with @evidence on this host; this reference forbids @evidenceExclude." + untrueTagWarning
           }
-          problems = append(
-            problems,
+          problems = problems.add(
+            severity,
             "Evidence host "+host.Readable+" at "+host.location()+" in "+claimLabel(state.Spec)+" "+referenceLabel(reference.Spec)+" has not acknowledged "+decimal(len(missing))+" of "+decimal(len(reference.Units))+" checklist item(s): "+strings.Join(missing, ", ")+". "+repair,
           )
         }
@@ -1131,8 +1140,8 @@ func evaluateEvidenceGraph(
           if reference.Spec.Policy.NoExclude {
             repair = "Cite the artifact that answers for this unit with @evidence on a selected " + string(state.Spec.Type) + " host, building that artifact first when none does; this reference forbids @evidenceExclude." + untrueTagWarning
           }
-          problems = append(
-            problems,
+          problems = problems.add(
+            severity,
             "Missing acknowledgement for '"+unit.Target+"' ("+unit.Readable+" at "+unit.location()+") in "+claimLabel(state.Spec)+" "+referenceLabel(reference.Spec)+". "+repair,
           )
         }
@@ -1140,14 +1149,15 @@ func evaluateEvidenceGraph(
         if !unique || hostCount <= 1 {
           continue
         }
-        problems = append(
-          problems,
+        problems = problems.add(
+          severity,
           "Evidence unit '"+unit.Target+"' ("+unit.Readable+" at "+unit.location()+") in "+claimLabel(state.Spec)+" "+referenceLabel(reference.Spec)+" has "+decimal(hostCount)+" distinct positive evidence host(s); uniqueEvidence allows at most 1. Keep the one selected "+string(state.Spec.Type)+" host that owns this unit and remove the other citation(s).",
         )
       }
     }
   }
   for _, id := range declarationIDs {
+    severity := ownerSeverity(owners[id])
     if resolved[id] == "" {
       continue
     }
@@ -1161,8 +1171,8 @@ func evaluateEvidenceGraph(
     // withholds its own.
     if obligations := unhosted[id]; len(obligations) != 0 &&
       !answers[id] && !uncertain[id] {
-      problems = append(
-        problems,
+      problems = problems.add(
+        unhostedLevels[id],
         "Unhosted @"+string(declaration.Tag)+" at "+declaration.location()+" for "+strings.Join(obligations, "; ")+", target '"+displayTarget(declaration.Target)+"': a checklist acknowledgement answers for one selected host of its claim, and this declaration sits on no selected host and discharges no other obligation. Move the tag onto a host of a selected kind ("+unhostedSelections[id].names()+") in a claim that owes it."+untrueTagWarning,
       )
     }
@@ -1171,8 +1181,8 @@ func evaluateEvidenceGraph(
     }
     context := declarationObligationContext(owners[id])
     if obligations := outsideCarrier[id]; len(obligations) != 0 {
-      problems = append(
-        problems,
+      problems = problems.add(
+        outsideCarrierLevels[id],
         "Misplaced @evidenceExclude at "+declaration.location()+" for "+strings.Join(obligations, "; ")+", target '"+displayTarget(declaration.Target)+"': evidenceExcludeCarriers confines this claim's exclusions to "+outsideCarrierGlobs[id]+". Move the tag there, or delete it and build what the target requires of this claim."+untrueTagWarning,
       )
       continue
@@ -1183,14 +1193,14 @@ func evaluateEvidenceGraph(
         host = "unsupported or non-exported declaration"
       }
       if declaration.Tag == tagExclude {
-        problems = append(
-          problems,
+        problems = problems.add(
+          outOfScopeLevels[id],
           "Out-of-scope @evidenceExclude carrier at "+declaration.location()+" for "+strings.Join(obligations, "; ")+", target '"+displayTarget(declaration.Target)+"': '"+host+"' is not an eligible exclusion carrier in these matching claim files. Move the exclusion to a supported public export or selected declaration host, or use a top-level unattached Prisma documentation comment.",
         )
         continue
       }
-      problems = append(
-        problems,
+      problems = problems.add(
+        outOfScopeLevels[id],
         "Out-of-scope @"+string(declaration.Tag)+" host at "+declaration.location()+" for "+strings.Join(obligations, "; ")+", target '"+displayTarget(declaration.Target)+"': host kind '"+host+"' is not selected ("+outOfScopeSelections[id].names()+") by any of these claim obligations. Move the declaration to a selected host, or widen the claim symbol selector only when it genuinely owns this target."+untrueTagWarning,
       )
       continue
@@ -1201,8 +1211,8 @@ func evaluateEvidenceGraph(
       // derive a second claim from an incomplete graph.
       continue
     }
-    problems = append(
-      problems,
+    problems = problems.add(
+      severity,
       "Non-participating @"+string(declaration.Tag)+" target '"+displayTarget(declaration.Target)+"' at "+declaration.location()+" for "+context+": the target resolves, but none of this declaration's configured references selects it. Correct the target or reference, or move the tag to an eligible host or exclusion carrier in the claim that owes it; a resolving tag must discharge at least one obligation."+untrueTagWarning,
     )
   }

--- a/packages/evidence/native/graph_distinguishes_repeated_evidence_from_exclusion_conflicts_test.go
+++ b/packages/evidence/native/graph_distinguishes_repeated_evidence_from_exclusion_conflicts_test.go
@@ -455,6 +455,7 @@ func runPrismaAcknowledgementGraph(
     scan.Comments,
     hosts,
     prismaInventoriesByDisplay(inventories),
+    nil,
   ); len(problems) != 0 {
     t.Fatalf("Prisma declaration scan failed: %v", problems)
   }
@@ -483,5 +484,5 @@ func runPrismaAcknowledgementGraph(
     map[string]*artifactInventory{},
     loader,
   )
-  return append(problems, evaluateEvidenceGraph(states, loader)...)
+  return problemMessages(append(problems, evaluateEvidenceGraph(states, loader)...))
 }

--- a/packages/evidence/native/graph_enforces_reference_policy_test.go
+++ b/packages/evidence/native/graph_enforces_reference_policy_test.go
@@ -39,11 +39,11 @@ export function testContract(): void {}
     ]
   }]}`)
   if count := countProblemsContaining(messages, "Forbidden @evidenceExclude"); count != 1 {
-    t.Fatalf("expected one strict-reference exclusion diagnostic, got %d:\n%s", count, strings.Join(messages, "\n"))
+    t.Fatalf("expected one strict-reference exclusion diagnostic, got %d:\n%s", count, strings.Join(problemMessages(messages), "\n"))
   }
   assertProblemContains(t, messages, "reference 1 (markdown, symbols: h2): noEvidenceExclude")
   if count := countProblemsContaining(messages, "Missing acknowledgement"); count != 1 {
-    t.Fatalf("the ordinary reference must remain acknowledged, got %d missing diagnostics:\n%s", count, strings.Join(messages, "\n"))
+    t.Fatalf("the ordinary reference must remain acknowledged, got %d missing diagnostics:\n%s", count, strings.Join(problemMessages(messages), "\n"))
   }
   assertProblemContains(t, messages, "Missing acknowledgement for 'docs/spec.md#contract'")
   assertProblemContains(t, messages, "this reference forbids @evidenceExclude")
@@ -87,14 +87,14 @@ export function broad(): void {}
     }
   }]}`)
   if count := countProblemsContaining(messages, "singleEvidencePerSymbol requires exactly 1"); count != 2 {
-    t.Fatalf("expected zero and broad hosts to fail cardinality, got %d:\n%s", count, strings.Join(messages, "\n"))
+    t.Fatalf("expected zero and broad hosts to fail cardinality, got %d:\n%s", count, strings.Join(problemMessages(messages), "\n"))
   }
   assertProblemContains(t, messages, "TypeScript function 'empty'")
   assertProblemContains(t, messages, "cites 0 distinct selected evidence unit(s)")
   assertProblemContains(t, messages, "TypeScript function 'broad'")
   assertProblemContains(t, messages, "cites 2 distinct selected evidence unit(s)")
-  if strings.Contains(strings.Join(messages, "\n"), "TypeScript function 'duplicate'") {
-    t.Fatalf("duplicate tags inflated the semantic host count:\n%s", strings.Join(messages, "\n"))
+  if strings.Contains(strings.Join(problemMessages(messages), "\n"), "TypeScript function 'duplicate'") {
+    t.Fatalf("duplicate tags inflated the semantic host count:\n%s", strings.Join(problemMessages(messages), "\n"))
   }
   assertProblemContains(t, messages, "Duplicate @evidence")
 }
@@ -226,7 +226,7 @@ export function two(): void {}
     ]
   }]}`)
   if count := countProblemsContaining(messages, "uniqueEvidence allows at most 1"); count != 1 {
-    t.Fatalf("expected exactly one independent policy failure, got %d:\n%s", count, strings.Join(messages, "\n"))
+    t.Fatalf("expected exactly one independent policy failure, got %d:\n%s", count, strings.Join(problemMessages(messages), "\n"))
   }
   assertProblemContains(t, messages, "Claim 1 reference 2")
 }
@@ -266,7 +266,7 @@ export function testContract(): void {}
     ]
   }]}`)
   if count := countProblemsContaining(messages, "singleEvidencePerSymbol"); count != 1 {
-    t.Fatalf("expected one hierarchical-reference failure, got %d:\n%s", count, strings.Join(messages, "\n"))
+    t.Fatalf("expected one hierarchical-reference failure, got %d:\n%s", count, strings.Join(problemMessages(messages), "\n"))
   }
   assertProblemContains(t, messages, "Claim 1 reference 2")
 }
@@ -326,7 +326,7 @@ func TestReferencePolicyDerivesNothingFromAnUnhealthyReference(t *testing.T) {
     }},
   }}, nil)
   if len(messages) != 0 {
-    t.Fatalf("partial reference produced derived diagnostics instead of deferring to its loader failure:\n%s", strings.Join(messages, "\n"))
+    t.Fatalf("partial reference produced derived diagnostics instead of deferring to its loader failure:\n%s", strings.Join(problemMessages(messages), "\n"))
   }
 }
 
@@ -432,15 +432,15 @@ func TestStrictSwaggerAndOrdinaryMarkdownExclusionsCoexist(t *testing.T) {
     },
   }}, nil)
   if count := countProblemsContaining(messages, "Forbidden @evidenceExclude"); count != 1 {
-    t.Fatalf("expected only the Swagger exclusion to be forbidden, got %d:\n%s", count, strings.Join(messages, "\n"))
+    t.Fatalf("expected only the Swagger exclusion to be forbidden, got %d:\n%s", count, strings.Join(problemMessages(messages), "\n"))
   }
   assertProblemContains(t, messages, "Forbidden @evidenceExclude for 'POST:/orders'")
   if count := countProblemsContaining(messages, "Missing acknowledgement"); count != 1 {
-    t.Fatalf("ordinary Markdown exclusion did not retain coverage, got %d missing diagnostics:\n%s", count, strings.Join(messages, "\n"))
+    t.Fatalf("ordinary Markdown exclusion did not retain coverage, got %d missing diagnostics:\n%s", count, strings.Join(problemMessages(messages), "\n"))
   }
   assertProblemContains(t, messages, "Missing acknowledgement for 'POST:/orders'")
-  if strings.Contains(strings.Join(messages, "\n"), "Missing acknowledgement for 'docs/requirement.md#requirement'") {
-    t.Fatalf("strict Swagger policy leaked into the Markdown reference:\n%s", strings.Join(messages, "\n"))
+  if strings.Contains(strings.Join(problemMessages(messages), "\n"), "Missing acknowledgement for 'docs/requirement.md#requirement'") {
+    t.Fatalf("strict Swagger policy leaked into the Markdown reference:\n%s", strings.Join(problemMessages(messages), "\n"))
   }
 }
 
@@ -509,7 +509,7 @@ func TestSingleEvidencePerSymbolDerivesNothingFromAHealthyEmptyReference(t *test
   if countProblemsContaining(messages, "singleEvidencePerSymbol requires exactly 1") != 0 {
     t.Fatalf(
       "an empty population must not be re-reported per host:\n%s",
-      strings.Join(messages, "\n"),
+      strings.Join(problemMessages(messages), "\n"),
     )
   }
 }
@@ -545,7 +545,7 @@ func TestSingleEvidencePerSymbolAnswersAnUnmatchedGlobTheSameWay(t *testing.T) {
   if countProblemsContaining(messages, "singleEvidencePerSymbol requires exactly 1") != 0 {
     t.Fatalf(
       "an unmatched glob must not be re-reported per host:\n%s",
-      strings.Join(messages, "\n"),
+      strings.Join(problemMessages(messages), "\n"),
     )
   }
 }

--- a/packages/evidence/native/graph_severity_inherits_and_overrides_test.go
+++ b/packages/evidence/native/graph_severity_inherits_and_overrides_test.go
@@ -1,0 +1,68 @@
+package evidence
+
+import (
+  "encoding/json"
+  "fmt"
+  "testing"
+
+  "github.com/samchon/ttsc/packages/lint/rule"
+)
+
+/**
+ * Verifies severity inheritance and explicit overrides through graph evaluation.
+ *
+ * An off value must differ from an omitted one, and a warning must stay a
+ * warning even when the enclosing rule fails on errors by default.
+ *
+ * 1. Evaluate every outer, claim, and reference severity combination.
+ * 2. Leave one selected requirement uncited.
+ * 3. Assert the effective level, or complete silence for a disabled population.
+ */
+func TestGraphSeverityInheritsAndOverrides(t *testing.T) {
+  levels := []string{"", "off", "warning", "error"}
+  for _, outer := range []rule.Severity{rule.SeverityWarn, rule.SeverityError} {
+    for _, claimLevel := range levels {
+      for _, referenceLevel := range levels {
+        t.Run(fmt.Sprintf("%d/%s/%s", outer, claimLevel, referenceLevel), func(t *testing.T) {
+          reference := map[string]any{"type": "markdown", "files": []string{"docs/spec.md"}, "symbol": "h2"}
+          claim := map[string]any{"type": "typescript", "files": []string{"src/**"}, "symbol": "type", "reference": reference}
+          want := outer
+          for _, entry := range []struct {
+            object map[string]any
+            level  string
+          }{{claim, claimLevel}, {reference, referenceLevel}} {
+            if entry.level != "" {
+              entry.object["severity"] = entry.level
+              switch entry.level {
+              case "off":
+                want = rule.SeverityOff
+              case "warning":
+                want = rule.SeverityWarn
+              case "error":
+                want = rule.SeverityError
+              }
+            }
+          }
+          if claimLevel == "off" {
+            want = rule.SeverityOff
+          }
+          raw, err := json.Marshal(map[string]any{"claims": []any{claim}})
+          if err != nil {
+            t.Fatal(err)
+          }
+          reporter := runIndexRuleAtSeverity(t, t.TempDir(), map[string]string{
+            "src/contract.ts": "export interface IContract {}\n",
+            "docs/spec.md":    "## Requirement {#requirement}\n",
+          }, string(raw), outer)
+          if want == rule.SeverityOff {
+            if len(reporter.messages) != 0 || reporter.failed {
+              t.Fatalf("off population reported: %v", reporter.messages)
+            }
+          } else if len(reporter.findings) != 1 || reporter.findings[0].Severity != want || !reporter.failed {
+            t.Fatalf("want one finding at %v and failed graph state, got %#v", want, reporter)
+          }
+        })
+      }
+    }
+  }
+}

--- a/packages/evidence/native/graph_severity_keeps_references_independent_test.go
+++ b/packages/evidence/native/graph_severity_keeps_references_independent_test.go
@@ -1,0 +1,44 @@
+package evidence
+
+import (
+  "strings"
+  "testing"
+
+  "github.com/samchon/ttsc/packages/lint/rule"
+)
+
+/**
+ * Verifies overlapping references retain independent diagnostic levels.
+ *
+ * Identical populations must not pool their severities or coverage. An off
+ * reference must also avoid loading a nonexistent source.
+ *
+ * 1. Select the same uncited requirement twice at different levels.
+ * 2. Add an off reference naming a missing root.
+ * 3. Assert one warning and one error with the original reference indexes.
+ */
+func TestGraphSeverityKeepsReferencesIndependent(t *testing.T) {
+  reporter := runIndexRuleAtSeverity(t, t.TempDir(), map[string]string{
+    "src/contract.ts": "export interface IContract {}\n",
+    "docs/spec.md":    "## Requirement {#requirement}\n",
+  }, `{"claims":[{"type":"typescript","files":["src/**"],"symbol":"type","severity":"warning","reference":[
+    {"type":"markdown","files":["docs/spec.md"],"symbol":"h2"},
+    {"type":"markdown","root":"missing","files":["**"],"severity":"off"},
+    {"type":"markdown","files":["docs/spec.md"],"symbol":"h2","severity":"error"}
+  ]}]}`, rule.SeverityError)
+  if len(reporter.findings) != 2 {
+    t.Fatalf("want two independent findings, got %v", reporter.messages)
+  }
+  for _, finding := range reporter.findings {
+    want := rule.SeverityWarn
+    if strings.Contains(finding.Message, "reference 3") {
+      want = rule.SeverityError
+    }
+    if finding.Severity != want {
+      t.Fatalf("wrong severity: %#v", finding)
+    }
+    if strings.Contains(finding.Message, "missing") {
+      t.Fatalf("off reference loaded: %v", finding)
+    }
+  }
+}

--- a/packages/evidence/native/graph_severity_off_omits_inputs_test.go
+++ b/packages/evidence/native/graph_severity_off_omits_inputs_test.go
@@ -1,0 +1,37 @@
+package evidence
+
+import (
+  "encoding/json"
+  "strings"
+  "testing"
+)
+
+/**
+ * Verifies off populations leave no watched inputs but still validate options.
+ *
+ * Keeping an off reference in the input graph would trigger rebuilds for work
+ * the consumer explicitly staged. Invalid options still need a repair before
+ * that entry can safely be re-enabled.
+ *
+ * 1. Disable a claim and one reference of an enabled claim.
+ * 2. Assert only the enabled reference is watched.
+ * 3. Assert an invalid severity in an off claim is still rejected.
+ */
+func TestGraphSeverityOffOmitsInputs(t *testing.T) {
+  config, problems := decodeGraphConfig(json.RawMessage(`{"claims":[
+    {"type":"markdown","files":["staged/**"],"severity":"off","reference":{"type":"markdown","files":["staged-evidence/**"],"severity":"error"}},
+    {"type":"typescript","files":["src/**"],"reference":[
+      {"type":"markdown","files":["off/**"],"severity":0},
+      {"type":"markdown","files":["live/**"],"severity":"warning"}
+    ]}
+  ]}`))
+  assertNoProblems(t, problems)
+  inputs := graphProjectInputs(config)
+  if len(inputs) != 1 || inputs[0].Pattern != "live/**" {
+    t.Fatalf("off populations leaked inputs: %#v", inputs)
+  }
+  _, problems = decodeGraphConfig(json.RawMessage(`{"claims":[{"type":"typescript","files":["src/**"],"severity":"off","reference":{"type":"markdown","files":["docs/**"],"severity":null}}]}`))
+  if len(problems) != 1 || !strings.Contains(problems[0], "claims[0].reference.severity") {
+    t.Fatalf("off claim hid malformed severity: %v", problems)
+  }
+}

--- a/packages/evidence/native/graph_severity_scopes_source_failures_test.go
+++ b/packages/evidence/native/graph_severity_scopes_source_failures_test.go
@@ -1,0 +1,39 @@
+package evidence
+
+import (
+  "testing"
+
+  "github.com/samchon/ttsc/packages/lint/rule"
+)
+
+/**
+ * Verifies source failures keep the severity of their owning populations.
+ *
+ * Loaders merge populations for efficiency. An unrelated error reference must
+ * not promote a warning source failure, while a shared failure keeps an error
+ * when any population reading that source requires it.
+ *
+ * 1. Load missing Markdown roots beside a healthy error population.
+ * 2. Repeat with a second owner of the same failed root at error level.
+ * 3. Assert the failure is deduplicated at the strongest owning level.
+ */
+func TestGraphSeverityScopesSourceFailures(t *testing.T) {
+  for _, shared := range []bool{false, true} {
+    extra := ""
+    want := rule.SeverityWarn
+    if shared {
+      extra = `,{"type":"markdown","root":"missing","files":["**"],"severity":"error"}`
+      want = rule.SeverityError
+    }
+    reporter := runIndexRuleAtSeverity(t, t.TempDir(), map[string]string{
+      "src/contract.ts": "/** @evidence docs/spec.md#requirement Implements the requirement. */\nexport interface IContract {}\n",
+      "docs/spec.md":    "## Requirement {#requirement}\n",
+    }, `{"claims":[{"type":"typescript","files":["src/**"],"symbol":"type","reference":[
+      {"type":"markdown","root":"missing","files":["**"],"severity":"warning"},
+      {"type":"markdown","files":["docs/spec.md"],"symbol":"h2"}`+extra+`
+    ]}]}`, rule.SeverityError)
+    if len(reporter.findings) != 1 || reporter.findings[0].Severity != want {
+      t.Fatalf("shared=%v: want one source failure at %v, got %#v", shared, want, reporter.findings)
+    }
+  }
+}

--- a/packages/evidence/native/graph_suppresses_derivatives_of_loader_failures_test.go
+++ b/packages/evidence/native/graph_suppresses_derivatives_of_loader_failures_test.go
@@ -69,13 +69,13 @@ func TestReferenceLoaderFailureSuppressesOnlyItsOwnDerivedFindings(t *testing.T)
     t.Fatalf("reference health was not preserved: %+v", states[0].References)
   }
   if countProblemsContaining(messages, "found no selected evidence units") != 0 {
-    t.Fatalf("a failed loader was reinterpreted as an empty source:\n%s", strings.Join(messages, "\n"))
+    t.Fatalf("a failed loader was reinterpreted as an empty source:\n%s", strings.Join(problemMessages(messages), "\n"))
   }
   if countProblemsContaining(messages, "Missing acknowledgement") != 1 {
-    t.Fatalf("only the healthy obligation may derive coverage:\n%s", strings.Join(messages, "\n"))
+    t.Fatalf("only the healthy obligation may derive coverage:\n%s", strings.Join(problemMessages(messages), "\n"))
   }
   if countProblemsContaining(messages, "Unresolved evidence target") != 0 {
-    t.Fatalf("a failed reference cannot prove that a declaration target is unresolved:\n%s", strings.Join(messages, "\n"))
+    t.Fatalf("a failed reference cannot prove that a declaration target is unresolved:\n%s", strings.Join(problemMessages(messages), "\n"))
   }
   assertProblemContains(t, messages, "docs/good.md#good")
 }
@@ -150,7 +150,7 @@ func TestClaimLoaderFailureSuppressesOnlyItsOwnCoverage(t *testing.T) {
     t.Fatalf("claim health was not preserved: %+v", states)
   }
   if countProblemsContaining(messages, "Missing acknowledgement") != 1 {
-    t.Fatalf("only the healthy claim may derive coverage:\n%s", strings.Join(messages, "\n"))
+    t.Fatalf("only the healthy claim may derive coverage:\n%s", strings.Join(problemMessages(messages), "\n"))
   }
   assertProblemContains(t, messages, "Claim 2 ('healthy')")
 }
@@ -197,6 +197,6 @@ func TestPopulationLoaderFailureSuppressesMatchedNoFilesDerivative(t *testing.T)
     t.Fatal("a failed population root must keep its reference unhealthy")
   }
   if countProblemsContaining(messages, "matched no markdown files") != 0 {
-    t.Fatalf("a root failure was reinterpreted as a healthy glob miss:\n%s", strings.Join(messages, "\n"))
+    t.Fatalf("a root failure was reinterpreted as a healthy glob miss:\n%s", strings.Join(problemMessages(messages), "\n"))
   }
 }

--- a/packages/evidence/native/markdown.go
+++ b/packages/evidence/native/markdown.go
@@ -23,9 +23,9 @@ var explicitAnchorPattern = regexp.MustCompile(`\s*\{#([A-Za-z0-9][A-Za-z0-9._:-
 func loadMarkdownInventories(
   root string,
   config graphConfig,
-) (map[string]*artifactInventory, []string) {
+) (map[string]*artifactInventory, graphDiagnostics) {
   inventories := map[string]*artifactInventory{}
-  problems := []string{}
+  problems := graphDiagnostics{}
   for _, base := range configuredBases(config, artifactMarkdown) {
     problems = append(
       problems,
@@ -39,16 +39,17 @@ func loadMarkdownBase(
   base populationBase,
   config graphConfig,
   inventories map[string]*artifactInventory,
-) []string {
-  problems := []string{}
+) graphDiagnostics {
+  problems := graphDiagnostics{}
+  severity := populationSeverity(config, artifactMarkdown, base, "", "*", false)
   if problem := baseDirectoryProblem(base, artifactMarkdown); problem != "" {
     recordPopulationFailure(inventories, artifactMarkdown, base)
-    return []string{problem}
+    return problems.add(severity, problem)
   }
   from, resolved := resolvedBaseDirectory(base)
   if !resolved {
     recordPopulationFailure(inventories, artifactMarkdown, base)
-    return []string{unresolvedBaseProblem(base, artifactMarkdown)}
+    return problems.add(severity, unresolvedBaseProblem(base, artifactMarkdown))
   }
   err := filepath.WalkDir(from, func(current string, entry fs.DirEntry, walkErr error) error {
     if walkErr != nil {
@@ -82,7 +83,8 @@ func loadMarkdownBase(
       )
       if relevant {
         recordPopulationFailure(inventories, artifactMarkdown, base)
-        problems = append(problems, problem)
+        relative, _ := relativeProjectPath(from, current)
+        problems = problems.add(populationSeverity(config, artifactMarkdown, base, relative, "*", true), problem)
       }
       // `WalkDir` passes a nil entry only for its root, which the guard above
       // answers, so this error belongs to a directory whose listing failed and
@@ -105,6 +107,7 @@ func loadMarkdownBase(
     if !matchesConfiguredMarkdownFile(config, base, relative) {
       return nil
     }
+    severity := populationSeverity(config, artifactMarkdown, base, relative, "*", false)
     address := base.addressOf(relative)
     content, readErr := os.ReadFile(current)
     if readErr != nil {
@@ -113,26 +116,29 @@ func loadMarkdownBase(
         Type:       artifactMarkdown,
         LoadFailed: true,
       }
-      problems = append(problems, "Evidence graph could not read Markdown file '"+address.Display+"': "+causeText(readErr)+". Fix filesystem access or exclude the file from configured globs.")
+      problems = problems.add(
+        severity,
+        "Evidence graph could not read Markdown file '"+address.Display+"': "+causeText(readErr)+". Fix filesystem access or exclude the file from configured globs.",
+      )
       return nil
     }
     inventory, _ := scanMarkdownInventory(address, string(content))
     inventories[address.Key] = inventory
     for _, inventoryProblem := range inventory.Problems {
       if selectedByMarkdownPopulation(config, base, relative, inventoryProblem.Symbol) {
-        problems = append(problems, inventoryProblem.Message)
+        problems = problems.add(populationSeverity(config, artifactMarkdown, base, relative, inventoryProblem.Symbol, false), inventoryProblem.Message)
       }
     }
     // An unreadable tag is not a health question and not a symbol question
     // either: the file loaded, its units are complete, and the tag reaches no
     // host whichever symbol a reference selects. The walk already refuses a
     // path no configured glob takes, so reaching here is enough to report.
-    problems = append(problems, inventory.Unreadable...)
+    problems = problems.add(severity, inventory.Unreadable...)
     return nil
   })
   if err != nil {
     recordPopulationFailure(inventories, artifactMarkdown, base)
-    problems = append(problems, unlistableBaseProblem(base, "Markdown", err))
+    problems = problems.add(severity, unlistableBaseProblem(base, "Markdown", err))
   }
   return problems
 }

--- a/packages/evidence/native/model.go
+++ b/packages/evidence/native/model.go
@@ -5,6 +5,7 @@ import (
   "strings"
 
   shimast "github.com/microsoft/typescript-go/shim/ast"
+  "github.com/samchon/ttsc/packages/lint/rule"
 )
 
 const graphRuleName = "evidence/graph"
@@ -57,6 +58,8 @@ type graphConfig struct {
 }
 
 type claimSpec struct {
+  Severity *rule.Severity
+  Level    rule.Severity
   Index    int
   Type     artifactKind
   Name     string
@@ -84,13 +87,15 @@ type claimSpec struct {
 }
 
 type referenceSpec struct {
-  Index  int
-  Type   artifactKind
-  Policy referencePolicy
-  Root   string
-  Base   populationBase
-  Files  globSet
-  Source string
+  Severity *rule.Severity
+  Level    rule.Severity
+  Index    int
+  Type     artifactKind
+  Policy   referencePolicy
+  Root     string
+  Base     populationBase
+  Files    globSet
+  Source   string
   // Package moves the base that Files resolves against from the project to an
   // installed package. With no globs it also becomes the selection itself: the
   // package's declaration entry defines the population by reachability, while

--- a/packages/evidence/native/one_schema_reached_by_two_roots_is_parsed_once_test.go
+++ b/packages/evidence/native/one_schema_reached_by_two_roots_is_parsed_once_test.go
@@ -149,7 +149,7 @@ func TestOneSchemaHardLinkedIntoTwoRootsIsParsedOnce(t *testing.T) {
     t.Skipf("this filesystem does not support hard links: %v", err)
   }
   inventories, problems := loadPrismaInventories(root, twoRootedPrismaGraph(t, root))
-  assertBothPopulationsServed(t, inventories, problems)
+  assertBothPopulationsServed(t, inventories, problemMessages(problems))
 }
 
 /**
@@ -182,7 +182,7 @@ func TestOneSchemaReachedThroughALinkedDirectoryIsParsedOnce(t *testing.T) {
     t.Skipf("this environment cannot create a directory link: %v", err)
   }
   inventories, problems := loadPrismaInventories(root, twoRootedPrismaGraph(t, root))
-  assertBothPopulationsServed(t, inventories, problems)
+  assertBothPopulationsServed(t, inventories, problemMessages(problems))
 }
 
 /**
@@ -307,7 +307,7 @@ func TestAModelTheScanCouldNotLocateReachesEveryPopulationOfTheSet(t *testing.T)
       Digest: "model-digest",
       Fields: []prismaField{{Name: "id", Symbol: "column", Digest: "field-digest"}},
     }},
-  })
+  }, graphConfig{})
   if len(problems) != 0 {
     t.Fatalf("an unlocated model is not a problem, got %v", problems)
   }

--- a/packages/evidence/native/prisma.go
+++ b/packages/evidence/native/prisma.go
@@ -12,6 +12,8 @@ import (
   "sort"
   "strings"
   "time"
+
+  "github.com/samchon/ttsc/packages/lint/rule"
 )
 
 const prismaBridgeTimeout = 60 * time.Second
@@ -127,7 +129,7 @@ type prismaField struct {
 func loadPrismaInventories(
   root string,
   config graphConfig,
-) (map[string]*artifactInventory, []string) {
+) (map[string]*artifactInventory, graphDiagnostics) {
   // A graph that names no Prisma glob never pays for one. The walk below is
   // cheap on such a project — every directory fails the descendant test and is
   // skipped at once — but "cheap" is still a full listing of the project root
@@ -160,27 +162,28 @@ func loadPrismaInventories(
   // ten-model schema and a two-hundred-model one pay nearly the same. A
   // resident host repeats this every cycle, so an unchanged schema would
   // otherwise be re-parsed on every TypeScript keystroke that rebuilds.
+  severity := prismaSetSeverity(config, inventories)
   digest := prismaContentDigest(root, set.Sources)
   if outcome, hit := prismaSchemas.lookup(digest); hit {
     return inventories, append(
       problems,
-      prismaUnitsFromOutcome(root, set, inventories, outcome)...,
+      prismaUnitsFromOutcome(root, set, inventories, outcome, config)...,
     )
   }
 
   result, err := normalizePrismaSet(root, set.Sources)
   if err != nil {
     message := "Evidence graph could not run its Prisma schema loader: " + causeText(err) + ". Prisma references require Node.js and a resolvable @prisma/prisma-schema-wasm."
-    return inventories, append(problems, failPrismaSet(inventories, set, message))
+    return inventories, problems.add(severity, failPrismaSet(inventories, set, message))
   }
 
   outcome, problem := prismaOutcomeOf(result)
   if problem != "" {
-    return inventories, append(problems, failPrismaSet(inventories, set, problem))
+    return inventories, problems.add(severity, failPrismaSet(inventories, set, problem))
   }
   problems = append(
     problems,
-    prismaUnitsFromOutcome(root, set, inventories, outcome)...,
+    prismaUnitsFromOutcome(root, set, inventories, outcome, config)...,
   )
   rememberPrismaSchema(outcome.digest, outcome)
   return inventories, problems
@@ -223,27 +226,28 @@ func prismaOutcomeOf(result prismaNormalizationResult) (prismaSetOutcome, string
 // Order is the digest's, so it must not depend on filesystem enumeration.
 func configuredPrismaAddresses(
   config graphConfig,
-) ([]artifactAddress, []string) {
+) ([]artifactAddress, graphDiagnostics) {
   addresses, _, problems := configuredPrismaAddressesWithHealth(config)
   return addresses, problems
 }
 
 func configuredPrismaAddressesWithHealth(
   config graphConfig,
-) ([]artifactAddress, []populationBase, []string) {
+) ([]artifactAddress, []populationBase, graphDiagnostics) {
   addresses := []artifactAddress{}
   failedBases := []populationBase{}
-  problems := []string{}
+  problems := graphDiagnostics{}
   for _, base := range configuredBases(config, artifactPrisma) {
+    severity := populationSeverity(config, artifactPrisma, base, "", "*", false)
     if problem := baseDirectoryProblem(base, artifactPrisma); problem != "" {
-      problems = append(problems, problem)
+      problems = problems.add(severity, problem)
       failedBases = append(failedBases, base)
       continue
     }
     baseFailed := false
     from, resolved := resolvedBaseDirectory(base)
     if !resolved {
-      problems = append(problems, unresolvedBaseProblem(base, artifactPrisma))
+      problems = problems.add(severity, unresolvedBaseProblem(base, artifactPrisma))
       failedBases = append(failedBases, base)
       continue
     }
@@ -272,7 +276,8 @@ func configuredPrismaAddressesWithHealth(
         )
         if relevant {
           baseFailed = true
-          problems = append(problems, problem)
+          relative, _ := relativeProjectPath(from, current)
+          problems = problems.add(populationSeverity(config, artifactPrisma, base, relative, "*", true), problem)
         }
         return filepath.SkipDir
       }
@@ -295,7 +300,7 @@ func configuredPrismaAddressesWithHealth(
     })
     if err != nil {
       baseFailed = true
-      problems = append(problems, unlistableBaseProblem(base, "Prisma", err))
+      problems = problems.add(severity, unlistableBaseProblem(base, "Prisma", err))
     }
     if baseFailed {
       failedBases = append(failedBases, base)
@@ -647,15 +652,17 @@ func prismaDeclarationsFromComments(
   comments []prismaCommentRun,
   hosts map[string]*evidenceUnit,
   inventories map[string][]*artifactInventory,
-) []string {
-  problems := []string{}
+  levels map[string]rule.Severity,
+) graphDiagnostics {
+  problems := graphDiagnostics{}
   sequence := 0
   for _, run := range comments {
+    severity := levels[run.Path]
     location := run.Path + ":" + decimal(run.Line)
     if run.Form != prismaDocComment {
       if prismaCommentCarriesTag(run.Body) {
-        problems = append(
-          problems,
+        problems = problems.add(
+          severity,
           "Evidence tag at "+location+" sits in a '//' line comment, which Prisma discards rather than attaching to the declaration below it. Write the citation on a '///' or '/* */' documentation comment directly above the model, column, or relation it grounds.",
         )
       }
@@ -667,8 +674,8 @@ func prismaDeclarationsFromComments(
         continue
       }
       for _, offset := range prismaBuriedTagLines(run.Body) {
-        problems = append(
-          problems,
+        problems = problems.add(
+          severity,
           "Evidence tag at "+run.Path+":"+decimal(run.Line+offset)+" is buried behind an extra slash. Prisma reads a fourth slash as content, so the tag no longer opens its documentation line and nothing resolves it. Write exactly three slashes.",
         )
       }
@@ -676,8 +683,8 @@ func prismaDeclarationsFromComments(
         sequence++
         line := run.Line + parsed.LineOffset
         if parsed.Tag == tagEvidence {
-          problems = append(
-            problems,
+          problems = problems.add(
+            severity,
             "@evidence at "+run.Path+":"+decimal(line)+" is on a file-level Prisma exclusion carrier. Move ownership evidence directly above the selected model, column, or relation it grounds; only @evidenceExclude may be unattached at file level.",
           )
           continue
@@ -724,8 +731,8 @@ func prismaDeclarationsFromComments(
     }
     if run.Key == "" {
       if prismaCommentCarriesTag(run.Body) {
-        problems = append(
-          problems,
+        problems = problems.add(
+          severity,
           "Evidence tag at "+location+" documents no declaration. Prisma attaches a '///' comment to the declaration that immediately follows it, so a blank line before a top-level block, a block attribute, or a closing brace leaves the comment documenting nothing. Move the citation directly above the model, column, or relation it grounds.",
         )
       }
@@ -734,8 +741,8 @@ func prismaDeclarationsFromComments(
     host := hosts[run.Key]
     if host == nil {
       if prismaCommentCarriesTag(run.Body) {
-        problems = append(
-          problems,
+        problems = problems.add(
+          severity,
           "Evidence tag at "+location+" documents '"+run.Key+"', which is not a model, column, or relation. A model or a view and their members host an evidence citation; an enum, a composite type, and a datasource or generator setting do not.",
         )
       }
@@ -746,8 +753,8 @@ func prismaDeclarationsFromComments(
       continue
     }
     for _, offset := range prismaBuriedTagLines(run.Body) {
-      problems = append(
-        problems,
+      problems = problems.add(
+        severity,
         "Evidence tag at "+run.Path+":"+decimal(run.Line+offset)+" is buried behind an extra slash. Prisma reads a fourth slash as content, so the tag no longer opens its documentation line and nothing resolves it. Write exactly three slashes.",
       )
     }

--- a/packages/evidence/native/prisma_cache.go
+++ b/packages/evidence/native/prisma_cache.go
@@ -6,6 +6,8 @@ import (
   "os"
   "strings"
   "sync"
+
+  "github.com/samchon/ttsc/packages/lint/rule"
 )
 
 // prismaCacheLimit bounds the cache so a resident host cannot grow without end.
@@ -176,13 +178,14 @@ func prismaUnitsFromOutcome(
   set prismaSourceSet,
   inventories map[string]*artifactInventory,
   outcome prismaSetOutcome,
-) []string {
+  config graphConfig,
+) graphDiagnostics {
   if outcome.Rejected {
-    return []string{failPrismaSet(
+    return graphDiagnostics{}.add(prismaSetSeverity(config, inventories), failPrismaSet(
       inventories,
       set,
       prismaNormalizationFailure(outcome.Problem),
-    )}
+    ))
   }
   locations, comments := locatePrismaDeclarations(root, set.Sources)
   fallback := ""
@@ -230,7 +233,16 @@ func prismaUnitsFromOutcome(
   for _, inventory := range inventories {
     sortUnits(inventory.Units)
   }
-  return prismaDeclarationsFromComments(comments, hosts, indexed)
+  levels := map[string]rule.Severity{}
+  for key, inventory := range inventories {
+    levels[inventory.Path] = max(levels[inventory.Path], inventorySeverity(config, artifactPrisma, key, "*"))
+  }
+  for _, source := range set.Sources {
+    for _, spelling := range set.Spellings[source] {
+      levels[source] = max(levels[source], levels[spelling])
+    }
+  }
+  return prismaDeclarationsFromComments(comments, hosts, indexed, levels)
 }
 
 // joinPrismaIdentity renders a unit's identity the way the locator keys one.

--- a/packages/evidence/native/prisma_covers_relation_and_host_boundaries_test.go
+++ b/packages/evidence/native/prisma_covers_relation_and_host_boundaries_test.go
@@ -199,7 +199,7 @@ model Sale {
     unit.Path = "prisma/schema.prisma"
     hosts[joinPrismaIdentity(unit.Identity)] = unit
   }
-  if problems := prismaDeclarationsFromComments(scan.Comments, hosts, prismaInventoriesByDisplay(inventories)); len(problems) != 0 {
+  if problems := prismaDeclarationsFromComments(scan.Comments, hosts, prismaInventoriesByDisplay(inventories), nil); len(problems) != 0 {
     t.Fatalf("validity belongs to the graph, not the scan: %v", problems)
   }
   document, _ := scanProjectMarkdown("docs/spec.md", "## Amounts {#amounts}\n")
@@ -259,7 +259,7 @@ func TestPrismaClaimSelectorRefusesAnUnselectedHost(t *testing.T) {
     unit.Path = "prisma/schema.prisma"
     hosts[joinPrismaIdentity(unit.Identity)] = unit
   }
-  if problems := prismaDeclarationsFromComments(scan.Comments, hosts, prismaInventoriesByDisplay(inventories)); len(problems) != 0 {
+  if problems := prismaDeclarationsFromComments(scan.Comments, hosts, prismaInventoriesByDisplay(inventories), nil); len(problems) != 0 {
     t.Fatalf("host eligibility belongs to the graph, not the scan: %v", problems)
   }
   document, _ := scanProjectMarkdown("docs/spec.md", "## Amounts {#amounts}\n")
@@ -363,7 +363,7 @@ model Seller {
       hosts[joinPrismaIdentity(unit.Identity)] = unit
     }
   }
-  if problems := prismaDeclarationsFromComments(scan.Comments, hosts, prismaInventoriesByDisplay(inventories)); len(problems) != 0 {
+  if problems := prismaDeclarationsFromComments(scan.Comments, hosts, prismaInventoriesByDisplay(inventories), nil); len(problems) != 0 {
     t.Fatalf("the contradiction belongs to the graph, not the scan: %v", problems)
   }
   document, _ := scanProjectMarkdown("docs/spec.md", "## Amounts {#amounts}\n")
@@ -387,7 +387,7 @@ model Seller {
   )
   messages := append(problems, evaluateEvidenceGraph(states, loader)...)
   if got := countProblemsContaining(messages, "Conflicting acknowledgements"); got != 1 {
-    t.Fatalf("expected exactly one conflict diagnostic, got %d:\n%s", got, strings.Join(messages, "\n"))
+    t.Fatalf("expected exactly one conflict diagnostic, got %d:\n%s", got, strings.Join(problemMessages(messages), "\n"))
   }
   assertProblemContains(t, messages, "docs/spec.md#amounts")
 }

--- a/packages/evidence/native/prisma_failure_severity_uses_loaded_sources_test.go
+++ b/packages/evidence/native/prisma_failure_severity_uses_loaded_sources_test.go
@@ -1,0 +1,42 @@
+package evidence
+
+import (
+  "encoding/json"
+  "os"
+  "path/filepath"
+  "testing"
+
+  "github.com/samchon/ttsc/packages/lint/rule"
+)
+
+/**
+ * Verifies a Prisma loader failure belongs only to populations in its input set.
+ *
+ * An unmatched error reference supplies no schema to the parser. It must not
+ * promote a failure from a separate warning reference that did supply a file.
+ *
+ * 1. Select one schema at warning level and an absent schema at error level.
+ * 2. Make the shared parser unavailable.
+ * 3. Assert its failure remains a warning.
+ */
+func TestPrismaFailureSeverityUsesLoadedSources(t *testing.T) {
+  previous := prismaSchemas
+  prismaSchemas = newPrismaCache()
+  t.Cleanup(func() { prismaSchemas = previous })
+  root := t.TempDir()
+  if err := os.WriteFile(filepath.Join(root, "schema.prisma"), []byte("model Item {\n  id Int @id\n}\n"), 0o644); err != nil {
+    t.Fatal(err)
+  }
+  config, problems := decodeGraphConfig(json.RawMessage(`{"claims":[{"type":"typescript","files":["src/**"],"reference":[
+    {"type":"prisma","files":["schema.prisma"],"severity":"warning"},
+    {"type":"prisma","files":["absent.prisma"],"severity":"error"}
+  ]}]}`))
+  assertNoProblems(t, problems)
+  resolveGraphSeverities(&config, rule.SeverityError)
+  resolveGraphBases(root, &config)
+  t.Setenv("TTSC_NODE_BINARY", filepath.Join(root, "missing-node"))
+  _, findings := loadPrismaInventories(root, config)
+  if len(findings) != 1 || findings[0].Severity != rule.SeverityWarn {
+    t.Fatalf("unmatched reference promoted loader failure: %#v", findings)
+  }
+}

--- a/packages/evidence/native/prisma_hosts_declarations_in_doc_comments_test.go
+++ b/packages/evidence/native/prisma_hosts_declarations_in_doc_comments_test.go
@@ -33,12 +33,12 @@ func prismaClaimOf(
       hosts[key] = unit
     }
   }
-  problems := prismaDeclarationsFromComments(scan.Comments, hosts, prismaInventoriesByDisplay(inventories))
+  problems := prismaDeclarationsFromComments(scan.Comments, hosts, prismaInventoriesByDisplay(inventories), nil)
   declarations := inventories["prisma/schema.prisma"].Declarations
   sort.SliceStable(declarations, func(left int, right int) bool {
     return declarations[left].Line < declarations[right].Line
   })
-  return declarations, problems
+  return declarations, problemMessages(problems)
 }
 
 func prismaDeclarationIndex(declarations []*evidenceDeclaration) string {

--- a/packages/evidence/native/severity.go
+++ b/packages/evidence/native/severity.go
@@ -1,0 +1,156 @@
+package evidence
+
+import (
+  "encoding/json"
+  "sort"
+
+  "github.com/samchon/ttsc/packages/lint/rule"
+)
+
+func decodeGraphSeverity(raw json.RawMessage, path string) (*rule.Severity, []string) {
+  if len(raw) == 0 {
+    return nil, nil
+  }
+  var severity rule.Severity
+  var value any
+  if err := json.Unmarshal(raw, &value); err != nil {
+    return nil, []string{"Invalid evidence/graph configuration at " + path + ": expected a lint severity value."}
+  }
+  switch value {
+  case "off", float64(0):
+    severity = rule.SeverityOff
+  case "warning", "warn", float64(1):
+    severity = rule.SeverityWarn
+  case "error", float64(2):
+    severity = rule.SeverityError
+  default:
+    return nil, []string{"Invalid evidence/graph configuration at " + path + ": expected 'off', 'warning', 'warn', 'error', 0, 1, or 2; omit severity or use undefined to inherit the enclosing level."}
+  }
+  return &severity, nil
+}
+
+// Resolve inheritance once, before populations are loaded. A nil severity is
+// unset; an explicit zero disables its population.
+func resolveGraphSeverities(config *graphConfig, severity rule.Severity) {
+  for i := range config.Claims {
+    claim := &config.Claims[i]
+    claim.Level = severity
+    if claim.Severity != nil {
+      claim.Level = *claim.Severity
+    }
+    for j := range claim.References {
+      reference := &claim.References[j]
+      reference.Level = claim.Level
+      if reference.Severity != nil {
+        reference.Level = *reference.Severity
+      }
+    }
+  }
+}
+
+type graphDiagnostic struct {
+  Message  string
+  Severity rule.Severity
+}
+
+type graphDiagnostics []graphDiagnostic
+
+func (problems graphDiagnostics) add(severity rule.Severity, messages ...string) graphDiagnostics {
+  for _, message := range messages {
+    problems = append(problems, graphDiagnostic{Message: message, Severity: severity})
+  }
+  return problems
+}
+
+func (problems graphDiagnostics) report(ctx *rule.ProjectContext) {
+  levels := map[string]rule.Severity{}
+  for _, problem := range problems {
+    levels[problem.Message] = max(levels[problem.Message], problem.Severity)
+  }
+  messages := make([]string, 0, len(levels))
+  for message := range levels {
+    messages = append(messages, message)
+  }
+  sort.Strings(messages)
+  for _, message := range messages {
+    ctx.ReportSeverity(levels[message], message)
+  }
+}
+
+// A shared source problem belongs to every population that reads it. Keep the
+// strongest owning level without pooling independent coverage obligations.
+func populationSeverity(config graphConfig, kind artifactKind, base populationBase, path string, symbol string, descendants bool) rule.Severity {
+  var severity rule.Severity
+  matches := func(candidate populationBase, files globSet, symbols symbolSet) bool {
+    return candidate.Absolute == base.Absolute &&
+      (path == "" || files.matches(path) || descendants && files.couldMatchDescendant(path)) &&
+      (symbol == "*" || symbols.contains(symbol))
+  }
+  for _, claim := range config.Claims {
+    if claim.Type == kind && matches(claim.Base, claim.Files, claim.Symbols) {
+      severity = max(severity, claim.Level)
+    }
+    for _, reference := range claim.References {
+      if reference.Type == kind && reference.Package == "" && matches(reference.Base, reference.Files, reference.Symbols) {
+        severity = max(severity, reference.Level)
+      }
+    }
+  }
+  return severity
+}
+
+func artifactSeverity(config graphConfig, kind artifactKind) rule.Severity {
+  var severity rule.Severity
+  for _, claim := range config.Claims {
+    if claim.Type == kind {
+      severity = max(severity, claim.Level)
+    }
+    for _, reference := range claim.References {
+      if reference.Type == kind {
+        severity = max(severity, reference.Level)
+      }
+    }
+  }
+  return severity
+}
+
+func swaggerSeverity(config graphConfig, source string) rule.Severity {
+  var severity rule.Severity
+  for _, claim := range config.Claims {
+    for _, reference := range claim.References {
+      if reference.Type == artifactSwagger && reference.Source == source {
+        severity = max(severity, reference.Level)
+      }
+    }
+  }
+  return severity
+}
+
+func ownerSeverity(owners []claimState) rule.Severity {
+  var severity rule.Severity
+  for _, owner := range owners {
+    severity = max(severity, owner.Spec.Level)
+  }
+  return severity
+}
+
+func inventorySeverity(config graphConfig, kind artifactKind, address string, symbol string) rule.Severity {
+  var severity rule.Severity
+  for _, base := range configuredBases(config, kind) {
+    if relative, ok := base.relativeOf(address); ok {
+      severity = max(severity, populationSeverity(config, kind, base, relative, symbol, false))
+    }
+  }
+  return severity
+}
+
+// Empty or failed populations contribute no file to the shared Prisma parse.
+func prismaSetSeverity(config graphConfig, inventories map[string]*artifactInventory) rule.Severity {
+  var severity rule.Severity
+  for address, inventory := range inventories {
+    if inventory != nil && inventory.FailureBase == "" {
+      severity = max(severity, inventorySeverity(config, artifactPrisma, address, "*"))
+    }
+  }
+  return severity
+}

--- a/packages/evidence/native/swagger.go
+++ b/packages/evidence/native/swagger.go
@@ -11,6 +11,8 @@ import (
   "sort"
   "strings"
   "time"
+
+  "github.com/samchon/ttsc/packages/lint/rule"
 )
 
 const swaggerBridgeTimeout = 60 * time.Second
@@ -94,7 +96,7 @@ type swaggerOperation struct {
 func loadSwaggerInventories(
   root string,
   config graphConfig,
-) (map[string]*artifactInventory, []string) {
+) (map[string]*artifactInventory, graphDiagnostics) {
   sources := configuredSwaggerSources(config)
   inventories := map[string]*artifactInventory{}
   for _, source := range sources {
@@ -114,15 +116,16 @@ func loadSwaggerInventories(
   // TypeScript keystroke that triggers a rebuild.
   digests := swaggerContentDigests(root, sources)
   pending := []string{}
-  problems := []string{}
+  problems := graphDiagnostics{}
+  severity := artifactSeverity(config, artifactSwagger)
   for _, source := range sources {
     outcome, hit := lookupSwaggerDocument(source, digests[source])
     if !hit {
       pending = append(pending, source)
       continue
     }
-    problems = append(
-      problems,
+    problems = problems.add(
+      swaggerSeverity(config, source),
       swaggerUnitsFromOutcome(source, inventories[source], outcome)...,
     )
   }
@@ -140,30 +143,34 @@ func loadSwaggerInventories(
         inventoryProblem{Symbol: "operation", Message: message},
       )
     }
-    return inventories, append(problems, message)
+    var pendingSeverity rule.Severity
+    for _, source := range pending {
+      pendingSeverity = max(pendingSeverity, swaggerSeverity(config, source))
+    }
+    return inventories, problems.add(pendingSeverity, message)
   }
 
   seen := map[string]bool{}
   for _, document := range result.Documents {
     inventory := inventories[document.Source]
     if inventory == nil {
-      problems = append(
-        problems,
+      problems = problems.add(
+        severity,
         "Evidence graph Swagger normalizer returned an unconfigured source '"+displaySwaggerSource(document.Source)+"'. Reinstall @ttsc/evidence; the native and JavaScript bridge contracts disagree.",
       )
       continue
     }
     if seen[document.Source] {
-      problems = append(
-        problems,
+      problems = problems.add(
+        swaggerSeverity(config, document.Source),
         "Evidence graph Swagger normalizer returned source '"+displaySwaggerSource(document.Source)+"' more than once. Reinstall @ttsc/evidence; the native and JavaScript bridge contracts disagree.",
       )
       continue
     }
     seen[document.Source] = true
     outcome := swaggerDocumentOutcome{Operations: document.Operations}
-    problems = append(
-      problems,
+    problems = problems.add(
+      swaggerSeverity(config, document.Source),
       swaggerUnitsFromOutcome(document.Source, inventory, outcome)...,
     )
     rememberSwaggerDocument(document.Source, document.Digest, outcome)
@@ -171,8 +178,8 @@ func loadSwaggerInventories(
   for _, problem := range result.Problems {
     inventory := inventories[problem.Source]
     if inventory == nil {
-      problems = append(
-        problems,
+      problems = problems.add(
+        severity,
         "Evidence graph Swagger normalizer rejected an unconfigured source '"+displaySwaggerSource(problem.Source)+"'. Reinstall @ttsc/evidence; the native and JavaScript bridge contracts disagree.",
       )
       continue
@@ -182,8 +189,8 @@ func loadSwaggerInventories(
       Rejected: true,
       Problem:  problem.Message,
     }
-    problems = append(
-      problems,
+    problems = problems.add(
+      swaggerSeverity(config, problem.Source),
       swaggerUnitsFromOutcome(problem.Source, inventory, outcome)...,
     )
     rememberSwaggerDocument(problem.Source, problem.Digest, outcome)
@@ -198,7 +205,7 @@ func loadSwaggerInventories(
       inventories[source].Problems,
       inventoryProblem{Symbol: "operation", Message: message},
     )
-    problems = append(problems, message)
+    problems = problems.add(swaggerSeverity(config, source), message)
   }
   return inventories, problems
 }

--- a/packages/evidence/native/swagger_cached_failure_uses_current_severity_test.go
+++ b/packages/evidence/native/swagger_cached_failure_uses_current_severity_test.go
@@ -1,0 +1,34 @@
+package evidence
+
+import (
+  "path/filepath"
+  "testing"
+
+  "github.com/samchon/ttsc/packages/lint/rule"
+)
+
+/**
+ * Verifies cached Swagger failures use the current reference severity.
+ *
+ * A resident graph reuses normalized sources across config changes. Caching
+ * severity with that result would leave a warning as an error after an edit.
+ *
+ * 1. Cache a rejected source and make the normalizer unavailable.
+ * 2. Evaluate it at error and warning levels without editing the source.
+ * 3. Assert each cached diagnostic uses the current level.
+ */
+func TestSwaggerCachedFailureUsesCurrentSeverity(t *testing.T) {
+  isolateSwaggerCache(t)
+  root := writeInventoryFixture(t, "swagger.json", swaggerCacheDocument)
+  swaggerDocuments.store(swaggerContentDigest(root, "swagger.json"), swaggerDocumentOutcome{Rejected: true, Problem: "rejected source"})
+  t.Setenv("TTSC_NODE_BINARY", filepath.Join(root, "missing-node"))
+  for _, severity := range []rule.Severity{rule.SeverityError, rule.SeverityWarn} {
+    config := swaggerCacheConfig(t, "swagger.json")
+    config.Claims[0].References[0].Severity = &severity
+    resolveGraphSeverities(&config, rule.SeverityError)
+    _, findings := loadSwaggerInventories(root, config)
+    if len(findings) != 1 || findings[0].Severity != severity {
+      t.Fatalf("cached source retained a stale level: %#v", findings)
+    }
+  }
+}

--- a/packages/evidence/native/swagger_reference_contract_test.go
+++ b/packages/evidence/native/swagger_reference_contract_test.go
@@ -138,7 +138,7 @@ func TestSwaggerConfigurationRejectsClaimAndLocatorViolations(t *testing.T) {
   for _, entry := range cases {
     t.Run(entry.name, func(t *testing.T) {
       _, problems := decodeGraphConfig(json.RawMessage(entry.raw))
-      if !strings.Contains(strings.Join(problems, "\n"), entry.want) {
+      if !strings.Contains(strings.Join(problemMessages(problems), "\n"), entry.want) {
         t.Fatalf("expected %q, got %v", entry.want, problems)
       }
     })
@@ -260,7 +260,7 @@ func TestSwaggerOperationsParticipateInCoverage(t *testing.T) {
       newTypeScriptLoader("", map[string]*artifactInventory{"src/ref.ts": claimInventory}),
     )...,
   )
-  joined := strings.Join(problems, "\n")
+  joined := strings.Join(problemMessages(problems), "\n")
   if !strings.Contains(joined, "Missing acknowledgement for 'GET:/members/{id}'") {
     t.Fatalf("uncited GET operation did not fail coverage:\n%s", joined)
   }

--- a/packages/evidence/native/swagger_reuses_unchanged_documents_test.go
+++ b/packages/evidence/native/swagger_reuses_unchanged_documents_test.go
@@ -321,7 +321,7 @@ func TestSwaggerRenormalizesOnlyTheChangedSource(t *testing.T) {
     t.Fatal("the edited source must be re-normalized")
   }
   for _, problem := range problems {
-    if strings.Contains(problem, "stable.json") {
+    if strings.Contains(problem.Message, "stable.json") {
       t.Fatalf("the unchanged source must not be re-normalized, got: %v", problems)
     }
   }
@@ -420,7 +420,7 @@ func TestSwaggerReusesARejectedDocumentWithoutSpawning(t *testing.T) {
 
   t.Setenv("TTSC_NODE_BINARY", filepath.Join(t.TempDir(), "node-that-does-not-exist"))
   inventories, problems := loadSwaggerInventories(root, swaggerCacheConfig(t, "swagger.json"))
-  joined := strings.Join(problems, "\n")
+  joined := strings.Join(problemMessages(problems), "\n")
   if !strings.Contains(joined, "unsupported OpenAPI version") {
     t.Fatalf("the remembered rejection must be reported verbatim, got: %v", problems)
   }
@@ -458,7 +458,7 @@ func TestSwaggerForgetsARejectedDocumentOnceItIsFixed(t *testing.T) {
   }
   t.Setenv("TTSC_NODE_BINARY", filepath.Join(t.TempDir(), "node-that-does-not-exist"))
   _, problems := loadSwaggerInventories(root, swaggerCacheConfig(t, "swagger.json"))
-  joined := strings.Join(problems, "\n")
+  joined := strings.Join(problemMessages(problems), "\n")
   if strings.Contains(joined, "unsupported OpenAPI version") {
     t.Fatalf("a repaired document must not replay its rejection, got: %v", problems)
   }
@@ -494,7 +494,7 @@ func TestSwaggerReportsARejectionThatCarriesNoReason(t *testing.T) {
   if len(problems) == 0 {
     t.Fatal("a reason-less rejection must still fail the build")
   }
-  if !strings.Contains(strings.Join(problems, "\n"), "swagger.json") {
+  if !strings.Contains(strings.Join(problemMessages(problems), "\n"), "swagger.json") {
     t.Fatalf("the diagnostic must name the refused source, got: %v", problems)
   }
   if len(inventories["swagger.json"].Units) != 0 {

--- a/packages/evidence/native/test_support_test.go
+++ b/packages/evidence/native/test_support_test.go
@@ -19,6 +19,7 @@ import (
 
 type capturedProjectReporter struct {
   messages []string
+  findings graphDiagnostics
   failed   bool
   state    any
 }
@@ -30,6 +31,11 @@ func (reporter *capturedProjectReporter) Fail() {
 func (reporter *capturedProjectReporter) Report(message string) {
   reporter.failed = true
   reporter.messages = append(reporter.messages, message)
+}
+
+func (reporter *capturedProjectReporter) ReportSeverity(severity rule.Severity, message string) {
+  reporter.Report(message)
+  reporter.findings = reporter.findings.add(severity, message)
 }
 
 func (reporter *capturedProjectReporter) SetState(state any) {
@@ -143,6 +149,11 @@ func runIndexRuleAtRoot(
   config string,
 ) []string {
   t.Helper()
+  return runIndexRuleAtSeverity(t, root, files, config, rule.SeverityError).messages
+}
+
+func runIndexRuleAtSeverity(t *testing.T, root string, files map[string]string, config string, severity rule.Severity) *capturedProjectReporter {
+  t.Helper()
   paths := make([]string, 0, len(files))
   for path := range files {
     paths = append(paths, path)
@@ -177,13 +188,13 @@ func runIndexRuleAtRoot(
     rule.ProjectIdentity{PhysicalProjectRoot: root},
     sources,
     nil,
-    rule.SeverityError,
+    severity,
     json.RawMessage(config),
     reporter,
   )
   graphRule{}.Check(context)
   sort.Strings(reporter.messages)
-  return reporter.messages
+  return reporter
 }
 
 // capturedFileReporter records what a file rule reported.
@@ -323,14 +334,16 @@ func anchoredGraph(root string, config graphConfig) graphConfig {
   return config
 }
 
-func assertSilent(t *testing.T, messages []string) {
+func assertSilent[T string | graphDiagnostic](t *testing.T, problems []T) {
+  messages := problemMessages(problems)
   t.Helper()
   if len(messages) != 0 {
     t.Fatalf("expected no diagnostics, got:\n%s", strings.Join(messages, "\n"))
   }
 }
 
-func assertReportedAmong(t *testing.T, messages []string, expected string) {
+func assertReportedAmong[T string | graphDiagnostic](t *testing.T, problems []T, expected string) {
+  messages := problemMessages(problems)
   t.Helper()
   for _, message := range messages {
     if strings.Contains(message, expected) {
@@ -344,7 +357,8 @@ func assertReportedAmong(t *testing.T, messages []string, expected string) {
   )
 }
 
-func assertReported(t *testing.T, messages []string, expected string) {
+func assertReported[T string | graphDiagnostic](t *testing.T, problems []T, expected string) {
+  messages := problemMessages(problems)
   t.Helper()
   if len(messages) != 1 {
     t.Fatalf(
@@ -384,14 +398,16 @@ func parseTypeScriptInventory(
   return scanTypeScriptInventory(path, file)
 }
 
-func assertNoProblems(t *testing.T, messages []string) {
+func assertNoProblems[T string | graphDiagnostic](t *testing.T, problems []T) {
+  messages := problemMessages(problems)
   t.Helper()
   if len(messages) != 0 {
     t.Fatalf("expected no evidence diagnostics, got:\n%s", strings.Join(messages, "\n"))
   }
 }
 
-func assertProblemContains(t *testing.T, messages []string, expected string) {
+func assertProblemContains[T string | graphDiagnostic](t *testing.T, problems []T, expected string) {
+  messages := problemMessages(problems)
   t.Helper()
   for _, message := range messages {
     if strings.Contains(message, expected) {
@@ -405,7 +421,8 @@ func assertProblemContains(t *testing.T, messages []string, expected string) {
   )
 }
 
-func countProblemsContaining(messages []string, expected string) int {
+func countProblemsContaining[T string | graphDiagnostic](problems []T, expected string) int {
+  messages := problemMessages(problems)
   count := 0
   for _, message := range messages {
     if strings.Contains(message, expected) {
@@ -429,4 +446,17 @@ func linkDirectory(target string, link string) error {
     "cmd", "/c", "mklink", "/J",
     filepath.FromSlash(link), filepath.FromSlash(target),
   ).Run()
+}
+
+func problemMessages[T string | graphDiagnostic](problems []T) []string {
+  messages := make([]string, 0, len(problems))
+  for _, problem := range problems {
+    switch value := any(problem).(type) {
+    case string:
+      messages = append(messages, value)
+    case graphDiagnostic:
+      messages = append(messages, value.Message)
+    }
+  }
+  return messages
 }

--- a/packages/evidence/native/typescript.go
+++ b/packages/evidence/native/typescript.go
@@ -79,8 +79,8 @@ func extendTypeScriptInventories(
 func typeScriptBaseProblems(
   config graphConfig,
   inventories map[string]*artifactInventory,
-) []string {
-  problems := []string{}
+) graphDiagnostics {
+  problems := graphDiagnostics{}
   for _, base := range configuredBases(config, artifactTypeScript) {
     problem := baseDirectoryProblem(base, artifactTypeScript)
     // The stat accepts a chain of links the resolver will not finish, and this
@@ -111,7 +111,7 @@ func typeScriptBaseProblems(
       continue
     }
     recordPopulationFailure(inventories, artifactTypeScript, base)
-    problems = append(problems, problem)
+    problems = problems.add(populationSeverity(config, artifactTypeScript, base, "", "*", false), problem)
   }
   return problems
 }

--- a/packages/evidence/native/unreadable.go
+++ b/packages/evidence/native/unreadable.go
@@ -1,7 +1,6 @@
 package evidence
 
 import (
-  "sort"
   "strings"
 
   shimast "github.com/microsoft/typescript-go/shim/ast"
@@ -142,14 +141,14 @@ func readableCommentBody(comment string) string {
 func unreadableTypeScriptTags(
   inventories map[string]*artifactInventory,
   governed map[string]bool,
-) []string {
-  reported := []string{}
+  config graphConfig,
+) graphDiagnostics {
+  reported := graphDiagnostics{}
   for address, inventory := range inventories {
-    if inventory == nil || !governed[address] {
+    if inventory == nil || len(inventory.Unreadable) == 0 || !governed[address] {
       continue
     }
-    reported = append(reported, inventory.Unreadable...)
+    reported = reported.add(inventorySeverity(config, artifactTypeScript, address, "*"), inventory.Unreadable...)
   }
-  sort.Strings(reported)
   return reported
 }

--- a/packages/evidence/package.json
+++ b/packages/evidence/package.json
@@ -50,7 +50,7 @@
     "url": "https://github.com/samchon/ttsc/issues"
   },
   "peerDependencies": {
-    "@ttsc/lint": ">=0.24.0"
+    "@ttsc/lint": ">0.28.6"
   },
   "devDependencies": {
     "@ttsc/lint": "workspace:*",

--- a/packages/evidence/src/structures/ITtscEvidenceGraphClaimBase.ts
+++ b/packages/evidence/src/structures/ITtscEvidenceGraphClaimBase.ts
@@ -1,3 +1,5 @@
+import type { TtscLintSeverity } from "@ttsc/lint";
+
 import type { ITtscEvidenceGraphReference } from "./ITtscEvidenceGraphReference";
 
 /**
@@ -23,6 +25,13 @@ export interface ITtscEvidenceGraphClaimBase<Type extends string> {
    * configuration entries.
    */
   name?: string;
+
+  /**
+   * Diagnostic level for this claim. Omit it or use `undefined` to inherit the
+   * outer `evidence/graph` rule level. A reference may override this level
+   * again. `"off"` disables the entire claim, including its references.
+   */
+  severity?: TtscLintSeverity | undefined;
 
   /**
    * Excludes this claim from graph loading and evaluation.

--- a/packages/evidence/src/structures/ITtscEvidenceGraphReferenceBase.ts
+++ b/packages/evidence/src/structures/ITtscEvidenceGraphReferenceBase.ts
@@ -1,3 +1,5 @@
+import type { TtscLintSeverity } from "@ttsc/lint";
+
 /**
  * What every evidence population declares: which artifact kind it materializes,
  * and how strictly the owning claim must acknowledge it.
@@ -25,6 +27,13 @@
 export interface ITtscEvidenceGraphReferenceBase<Type extends string> {
   /** Identifies the artifact kind this population materializes. */
   type: Type;
+
+  /**
+   * Diagnostic level for this reference's obligation. Omit it or use
+   * `undefined` to inherit the claim level, then the outer `evidence/graph`
+   * rule level. `"off"` disables this reference's population and obligation.
+   */
+  severity?: TtscLintSeverity | undefined;
 
   /**
    * Whether this reference refuses `@evidenceExclude` as an acknowledgement.

--- a/packages/lint/README.md
+++ b/packages/lint/README.md
@@ -1185,6 +1185,8 @@ func init() { rule.RegisterProject(noCycles{}) }
 
 Each project rule runs once per loaded Program, before file rules. `ctx.Identity` includes the invocation cwd, logical and physical config paths and roots, an optional explicit project root, the plugin-config origin, and a lifecycle id. `Report` marks the rule failed and emits one project finding; `Fail` marks it failed without a finding. Later file rules can call `ctx.ProjectResult(name)` and distinguish `absent`, `off`, `not_evaluated`, `passed`, and `failed`.
 
+`ctx.ReportSeverity(rule.SeverityWarn, message)` overrides the level of one project finding. An off rule or off finding remains silent. A warning still marks the project result failed, while only an error fails the command. Snapshots retain each finding's severity, and duplicate messages keep the strongest reported level. Hosts implementing only `ProjectReporter` receive the message at the rule's configured level; `ProjectSeverityReporter` is the optional extension for individual levels.
+
 When a project rule reads local files outside the TypeScript Program, implement `rule.ProjectInputRule` so watch and editor hosts can observe exactly those inputs:
 
 ```go

--- a/packages/lint/linthost/project_engine.go
+++ b/packages/lint/linthost/project_engine.go
@@ -50,7 +50,8 @@ type projectReporter struct {
   mu       sync.Mutex
   active   bool
   failed   bool
-  messages map[string]struct{}
+  messages map[string]publicrule.Severity
+  severity publicrule.Severity
   state    any
 }
 
@@ -66,19 +67,27 @@ func (r *projectReporter) Fail() {
 }
 
 func (r *projectReporter) Report(message string) {
+  if r != nil {
+    r.ReportSeverity(r.severity, message)
+  }
+}
+
+func (r *projectReporter) ReportSeverity(severity publicrule.Severity, message string) {
   if r == nil {
     return
   }
   r.mu.Lock()
   defer r.mu.Unlock()
-  if !r.active {
+  if !r.active || severity == publicrule.SeverityOff {
     return
   }
   r.failed = true
   if r.messages == nil {
-    r.messages = map[string]struct{}{}
+    r.messages = map[string]publicrule.Severity{}
   }
-  r.messages[message] = struct{}{}
+  if severity > r.messages[message] {
+    r.messages[message] = severity
+  }
 }
 
 func (r *projectReporter) SetState(state any) {
@@ -120,7 +129,7 @@ func (r *projectReporter) snapshotLocked(close bool) publicrule.ProjectRuleResul
   }
   findings := make([]publicrule.ProjectFinding, 0, len(messages))
   for _, message := range messages {
-    findings = append(findings, publicrule.ProjectFinding{Message: message})
+    findings = append(findings, publicrule.ProjectFinding{Message: message, Severity: r.messages[message]})
   }
   return publicrule.NewProjectRuleResult(status, r.state, findings, r)
 }
@@ -144,7 +153,7 @@ func (c *projectCycle) finalize() []*Finding {
       for _, finding := range result.Findings {
         c.findings = append(c.findings, &Finding{
           Rule:     name,
-          Severity: entry.severity,
+          Severity: Severity(finding.Severity),
           Message:  finding.Message,
         })
       }
@@ -193,7 +202,7 @@ func (e *Engine) evaluateProject(
     if adapter.declinesTypeChecker {
       ruleChecker = nil
     }
-    reporter := &projectReporter{active: true}
+    reporter := &projectReporter{active: true, severity: publicrule.Severity(setting.Severity)}
     context := publicrule.NewProjectContext(
       identity,
       sources,

--- a/packages/lint/rule/project.go
+++ b/packages/lint/rule/project.go
@@ -36,7 +36,8 @@ const (
 // ProjectFinding is a non-file finding retained in a project rule's cycle
 // result. Project findings never contain edits or source ranges.
 type ProjectFinding struct {
-  Message string
+  Message  string
+  Severity Severity
 }
 
 // ProjectRuleResult is one snapshot of a named project rule in the current
@@ -169,6 +170,13 @@ type ProjectReporter interface {
   Report(message string)
 }
 
+// ProjectSeverityReporter optionally accepts a severity for each finding.
+// Reporting still marks the rule failed, including for warnings, so consumers
+// cannot treat an incomplete project result as a clean one.
+type ProjectSeverityReporter interface {
+  ReportSeverity(severity Severity, message string)
+}
+
 // ProjectContext contains the immutable inputs for one project-rule check.
 //
 // Sources is a defensive copy of the user sources the host read for this cycle:
@@ -254,6 +262,19 @@ func (c *ProjectContext) Report(message string) {
     return
   }
   c.reporter.Report(message)
+}
+
+// ReportSeverity records a finding at an explicit level. An off rule or off
+// finding remains silent. Hosts without this extension use the rule's level.
+func (c *ProjectContext) ReportSeverity(severity Severity, message string) {
+  if c == nil || c.reporter == nil || c.Severity == SeverityOff || severity == SeverityOff {
+    return
+  }
+  if reporter, ok := c.reporter.(ProjectSeverityReporter); ok {
+    reporter.ReportSeverity(severity, message)
+  } else {
+    c.reporter.Report(message)
+  }
 }
 
 var projectRegistry []ProjectRule

--- a/packages/lint/test/plugin/project_rule_reports_per_finding_severity_test.go
+++ b/packages/lint/test/plugin/project_rule_reports_per_finding_severity_test.go
@@ -1,0 +1,56 @@
+package linthost
+
+import (
+  "testing"
+
+  publicrule "github.com/samchon/ttsc/packages/lint/rule"
+)
+
+// TestProjectRuleReportsPerFindingSeverity verifies levels survive project
+// result snapshots, deduplication, and final diagnostic conversion.
+//
+// A warning still means the project result is incomplete, while only errors
+// fail the command. Equal messages keep the strongest reported level.
+//
+// 1. Report mixed levels, including an off finding and a duplicate.
+// 2. Read the live result and finalize the cycle.
+// 3. Assert severities, failed graph status, and the outer off gate.
+func TestProjectRuleReportsPerFindingSeverity(t *testing.T) {
+  const name = "severity-test/project"
+  installProjectRuleTestDouble(t, projectRuleTestDouble{name: name, check: func(ctx *publicrule.ProjectContext) {
+    ctx.Report("inherited")
+    ctx.ReportSeverity(publicrule.SeverityWarn, "warning")
+    ctx.ReportSeverity(publicrule.SeverityOff, "off")
+    ctx.ReportSeverity(publicrule.SeverityError, "duplicate")
+    ctx.ReportSeverity(publicrule.SeverityWarn, "duplicate")
+  }})
+  for _, outer := range []Severity{SeverityWarn, SeverityError} {
+    cycle := NewEngine(RuleConfig{name: outer}).evaluateProject(publicrule.ProjectIdentity{}, nil, nil)
+    result := cycle.results.ProjectResult(name)
+    if result.Status != publicrule.ProjectRuleFailed || len(result.Findings) != 3 {
+      t.Fatalf("unexpected result: %#v", result)
+    }
+    expected := map[string]Severity{"inherited": outer, "warning": SeverityWarn, "duplicate": SeverityError}
+    for _, finding := range result.Findings {
+      if Severity(finding.Severity) != expected[finding.Message] {
+        t.Fatalf("wrong snapshot severity: %#v", finding)
+      }
+    }
+    for _, finding := range cycle.finalize() {
+      if finding.Severity != expected[finding.Message] {
+        t.Fatalf("wrong finalized severity: %#v", finding)
+      }
+    }
+  }
+  if findings := NewEngine(RuleConfig{name: SeverityOff}).Run(nil, nil); len(findings) != 0 {
+    t.Fatalf("off rule reported: %#v", findings)
+  }
+  installProjectRuleTestDouble(t, projectRuleTestDouble{name: name, check: func(ctx *publicrule.ProjectContext) {
+    ctx.ReportSeverity(publicrule.SeverityWarn, "warning only")
+  }})
+  cycle := NewEngine(RuleConfig{name: SeverityError}).evaluateProject(publicrule.ProjectIdentity{}, nil, nil)
+  result := cycle.results.ProjectResult(name)
+  if result.Status != publicrule.ProjectRuleFailed || len(result.Findings) != 1 || result.Findings[0].Severity != publicrule.SeverityWarn {
+    t.Fatalf("warning-only result must remain incomplete: %#v", result)
+  }
+}

--- a/tests/test-evidence/src/features/test_evidence_graph_severity_controls_exit_status.ts
+++ b/tests/test-evidence/src/features/test_evidence_graph_severity_controls_exit_status.ts
@@ -1,0 +1,105 @@
+import fs from "node:fs";
+import path from "node:path";
+import { stripVTControlCharacters } from "node:util";
+
+import {
+  assertExcludes,
+  assertFailure,
+  assertIncludes,
+  assertStatus,
+  createProject,
+  runCheck,
+} from "../internal/index";
+
+/**
+ * Verifies per-claim and per-reference severity reaches the real compiler.
+ *
+ * Typed undefined values must survive config validation as inheritance, while
+ * warnings must reach the CLI without failing its exit status. Off populations
+ * must not load, even if their sources do not exist.
+ *
+ * 1. Run an error rule with a warning claim and an undefined reference level.
+ * 2. Override that reference to error and then off.
+ * 3. Disable the claim with an error reference and restore undefined inheritance.
+ */
+export const test_evidence_graph_severity_controls_exit_status = (): void => {
+  const config = (
+    claim: string,
+    reference: string,
+    files = "docs/spec.md",
+  ): string => `
+import type { ITtscLintConfig } from "@ttsc/lint";
+import { evidence, type ITtscEvidenceGraphConfig } from "@ttsc/evidence";
+const graph: ITtscEvidenceGraphConfig = {
+  claims: [{
+    type: "typescript", files: ["src/**"], symbol: "type",
+    severity: ${claim},
+    reference: { type: "markdown", files: ["${files}"], symbol: "h2", severity: ${reference} },
+  }],
+};
+export default {
+  plugins: { evidence },
+  rules: { "evidence/graph": ["error", graph] },
+} satisfies ITtscLintConfig;
+`;
+  const project = createProject({
+    name: "severity-controls-exit-status",
+    compilerOptions: { exactOptionalPropertyTypes: true },
+    lintConfig: config('"warning"', "undefined"),
+    files: {
+      "src/contract.ts": "export interface IContract {}\n",
+      "docs/spec.md": "## Requirement {#requirement}\n",
+    },
+  });
+  const check = (claim: string, reference: string, files?: string) => {
+    fs.writeFileSync(
+      path.join(project.directory, "lint.config.ts"),
+      config(claim, reference, files),
+      "utf8",
+    );
+    const result = runCheck(project.directory);
+    return { ...result, output: stripVTControlCharacters(result.output) };
+  };
+  try {
+    const warning = check('"warning"', "undefined");
+    assertStatus(warning, 0, "An inherited warning must not fail the command.");
+    assertIncludes(warning, "warning TS", "The CLI must print a warning.");
+    assertIncludes(
+      warning,
+      "Missing acknowledgement",
+      "The warning must carry the graph finding.",
+    );
+    const error = check('"warning"', '"error"');
+    assertFailure(error, "An error reference must override its warning claim.");
+    assertIncludes(error, "error TS", "The CLI must print an error.");
+    const offReference = check('"error"', '"off"', "missing/**/*.md");
+    assertStatus(
+      offReference,
+      0,
+      "An off reference must not load missing evidence.",
+    );
+    assertExcludes(
+      offReference,
+      "[evidence/graph]",
+      "An off reference must remain silent.",
+    );
+    const offClaim = check('"off"', '"error"', "missing/**/*.md");
+    assertStatus(
+      offClaim,
+      0,
+      "An off claim must suppress even an error reference.",
+    );
+    const inherited = check("undefined", "undefined");
+    assertFailure(
+      inherited,
+      "Undefined at both levels must inherit the outer error.",
+    );
+    assertIncludes(
+      inherited,
+      "Missing acknowledgement",
+      "Restoring inheritance must re-enable coverage.",
+    );
+  } finally {
+    project.cleanup();
+  }
+};

--- a/website/src/content/docs/development/walkthroughs/lint.mdx
+++ b/website/src/content/docs/development/walkthroughs/lint.mdx
@@ -670,6 +670,8 @@ One exception is worth knowing when a rule reasons about coverage. `ttsc format`
 
 The host runs each project rule once per Program, before file rules, even when `ctx.Sources` is empty. `ctx.Identity` keeps the caller's logical config and root spelling separate from the real paths used by the compiler, and also carries the invocation cwd, optional explicit project root, plugin-config origin, and lifecycle id. `ctx.Report` records a project finding and fails the rule; `ctx.Fail` fails it silently. A later file rule reads the same cycle through `ctx.ProjectResult(name)`, whose status is one of `absent`, `off`, `not_evaluated`, `passed`, or `failed`.
 
+Use `ctx.ReportSeverity(rule.SeverityWarn, message)` to set one finding's level. An off finding is ignored, and an off rule cannot be re-enabled by a report. Warnings still mark the project result `failed`, so dependent rules and hint providers see incomplete state, while the command's exit status follows the emitted severity. `ProjectFinding.Severity` preserves the level in snapshots; equal messages keep the strongest level. This uses the optional `ProjectSeverityReporter` interface. A custom host implementing only `ProjectReporter` receives the message at the rule's configured level.
+
 If the rule reads local files that are not TypeScript Program inputs, publish their configured topology through the optional `rule.ProjectInputRule` contract:
 
 ```go

--- a/website/src/content/docs/evidence/claims.mdx
+++ b/website/src/content/docs/evidence/claims.mdx
@@ -97,12 +97,39 @@ TypeScript evidence carries one more restriction: only a TypeScript claim may ci
 | `files` | yes | Globs for the artifacts that must cite. At least one positive pattern. |
 | `reference` | yes | One reference, or an array of independently complete references. |
 | `name` | no | Label carried by this claim's diagnostics, and nothing else. |
+| `severity` | no | Inherits the rule level when omitted or `undefined`; `"off"` disables the claim. |
 | `symbol` | no | Which declaration kinds may host a tag. Defaults differ per artifact kind. |
 | `root` | no | Directory the `files` patterns resolve against. Defaults to the project root. |
 | `disabled` | no | Validates the shape and contributes nothing else. |
 | `evidenceExcludeCarriers` | no | Globs for the only files that may host this claim's exclusions. |
 
 A named claim reads as `Claim 1 ('dto-types')` wherever it is reported, which is worth the line as soon as a config holds more than two claims.
+
+### Severity
+
+Per-claim and per-reference severity requires an `@ttsc/lint` release newer than 0.28.6. Update `@ttsc/evidence` and `@ttsc/lint` together.
+
+Both claims and references accept optional `severity`. Reference diagnostics use `reference.severity`, then `claim.severity`, then the outer `evidence/graph` rule level. Omitting a property or setting it to `undefined` inherits the enclosing level. The values are the same as `@ttsc/lint`: `"off"`, `"warning"` (also `"warn"`), and `"error"`, or `0`, `1`, and `2`.
+
+Keep the graph at `"error"` and lower one obligation to a warning:
+
+```ts
+{
+  type: "typescript",
+  files: ["src/controllers/**/*.ts"],
+  symbol: "function",
+  severity: undefined, // Inherit the outer rule's "error".
+  reference: [
+    { type: "markdown", files: ["docs/requirements/**/*.md"], symbol: "h2" },
+    { type: "markdown", files: ["docs/drafts/**/*.md"], symbol: "h2", severity: "warning" },
+    { type: "prisma", files: ["prisma/**/*.prisma"], severity: "off" },
+  ],
+}
+```
+
+Set severity on the claim to change its own diagnostics and the default for all its references. A claim's `"off"` disables the whole claim, including references with an explicit level. A reference's `"off"` disables only that reference. Disabled entries are still validated but contribute no populations, obligations, completion hints, or watched inputs. A claim whose references are all off contributes nothing. The outer rule's `"off"` disables the entire graph, and `disabled: true` on a claim continues to disable it regardless of severity.
+
+Coverage and reference-policy findings use the reference level. Malformed or unresolved claim tags use the claim level because no reference owns a resolved obligation yet. A shared source or tag finding keeps the strongest level among its owners. Configuration errors and an invalid project root use the outer rule level. Warnings are printed without failing the command; they still represent an incomplete graph, so completion hints remain withheld until the graph has no findings.
 
 ### Globs, not regular expressions
 
@@ -181,7 +208,7 @@ A `checklist` reference refuses these globs, because a checklist makes every ack
 
 ## Reference properties
 
-Every reference declares its `type` and may declare any of the [policies](#policies) below. The rest is per kind.
+Every reference declares its `type` and may declare [severity](#severity) and any of the [policies](#policies) below. The rest is per kind.
 
 **Markdown** takes `files`, an optional `root`, an optional `symbol`, and `checklist`. Every matching regular file is parsed as Markdown regardless of extension, so keep images and other assets out of the patterns.
 

--- a/website/src/content/docs/setup/evidence.mdx
+++ b/website/src/content/docs/setup/evidence.mdx
@@ -149,6 +149,8 @@ Start with `evidence/graph` alone and add the others once the graph is green.
 
 ## Stage the rollout
 
+To keep findings visible without failing the build, set `severity: "warning"` on one claim or reference. Omit it or set it to `undefined` to inherit the enclosing level. `severity: "off"` disables that claim or reference. See [severity precedence](/docs/evidence/claims#severity).
+
 A claim you are not ready to enforce carries `disabled: true`. Its shape is still validated, but it contributes no populations, no obligations, no completion hints, and no watched inputs:
 
 ```ts


### PR DESCRIPTION
Allow consumers to keep `evidence/graph` at error while downgrading individual claims or references to warnings. Both levels accept the shared lint severity type, including `off` and explicit `undefined`; inheritance is reference ? claim ? rule. Off claims and references are validated but omitted from loading, obligations, hints, and watched inputs.

Carry severity through source loading, graph evaluation, project-result snapshots, and CLI/LSP findings. Shared findings retain the strongest owning level, warnings still mark graph state incomplete, and independent obligations remain separate. The new project reporting API requires `@ttsc/lint >0.28.6`; consumer and contributor documentation explain the contract.

Validation:
- Passed: targeted evidence severity/configuration, off-input, source-failure, and cached-Swagger tests (`go test ./native/ -run 'Test(GraphSeverity|ConfigurationSeverity|PrismaFailureSeverity|SwaggerCachedFailure)' -count=1`).
- Passed: targeted lint project severity, concurrent reporting, and cycle-isolation tests in the standard scratch test module.
- Passed: `pnpm --filter @ttsc/evidence build`, frozen offline lockfile validation, `pnpm format`, and `git diff --check`.
- The focused CLI exit-status test is running in the background after correcting its ANSI-sensitive output assertion. Its first run confirmed a warning diagnostic and exit status 0.
- An earlier evidence Go suite passed before the request to limit local testing. The local full lint suite and broad build were stopped; subsequent local tests are focused, and complete validation is delegated to CI.

No product behavior is deferred. Solo Overall Self-Review rounds and subsequent verification are recorded as formal COMMENT reviews before merging a green head.
