### PR TITLE
fix(ttsx): lower standard decorators for Node execution

### DIFF
--- a/packages/ttsc/package.json
+++ b/packages/ttsc/package.json
@@ -64,6 +64,7 @@
   },
   "homepage": "https://ttsc.dev",
   "dependencies": {
+    "acorn": "8.16.0",
     "cjs-module-lexer": "2.2.1"
   },
   "devDependencies": {

--- a/packages/ttsc/package.json
+++ b/packages/ttsc/package.json
@@ -63,6 +63,9 @@
     "url": "https://github.com/samchon/ttsc/issues"
   },
   "homepage": "https://ttsc.dev",
+  "dependencies": {
+    "cjs-module-lexer": "2.2.1"
+  },
   "devDependencies": {
     "@types/node": "catalog:utils",
     "rimraf": "catalog:utils",

--- a/packages/ttsc/src/launcher/internal/commonJsExportMetadata.ts
+++ b/packages/ttsc/src/launcher/internal/commonJsExportMetadata.ts
@@ -1,0 +1,91 @@
+import { type AnyNode, parse as parseJavaScript } from "acorn";
+import { parse as parseCommonJs } from "cjs-module-lexer";
+
+/**
+ * Node's export metadata plus the scoped star helpers ttsx already supports.
+ * Node's frozen lexer patterns omit helpers inside blocks and functions. An AST
+ * supplies those calls without interpreting regex or template text as code.
+ */
+export function parseCommonJsExports(
+  source: string,
+): ReturnType<typeof parseCommonJs> {
+  let parsed: ReturnType<typeof parseCommonJs>;
+  try {
+    parsed = parseCommonJs(source);
+  } catch {
+    // Metadata never replaces the syntax diagnostic from Node's actual load.
+    parsed = { exports: [], reexports: [] };
+  }
+  if (!source.includes("__exportStar")) return parsed;
+  try {
+    const root = parseJavaScript(source, {
+      ecmaVersion: "latest",
+      sourceType: "commonjs",
+      // Name-only lowering of owned ESM may retain import.meta.
+      allowImportExportEverywhere: true,
+    });
+    const pending: AnyNode[] = [root];
+    const found: { start: number; specifier: string }[] = [];
+    while (pending.length !== 0) {
+      const node = pending.pop()!;
+      if (node.type === "CallExpression" && !node.optional) {
+        const callee = node.callee;
+        const star =
+          (callee.type === "Identifier" && callee.name === "__exportStar") ||
+          (callee.type === "MemberExpression" &&
+            !callee.computed &&
+            !callee.optional &&
+            callee.object.type === "Identifier" &&
+            callee.property.type === "Identifier" &&
+            callee.property.name === "__exportStar");
+        const [required, target] = node.arguments;
+        if (
+          star &&
+          target?.type === "Identifier" &&
+          target.name === "exports" &&
+          required?.type === "CallExpression" &&
+          !required.optional &&
+          required.callee.type === "Identifier" &&
+          required.callee.name === "require" &&
+          required.arguments.length === 1
+        ) {
+          const specifier = required.arguments[0];
+          if (
+            specifier?.type === "Literal" &&
+            typeof specifier.value === "string"
+          ) {
+            found.push({ start: node.start, specifier: specifier.value });
+          }
+        }
+      }
+      for (const value of Object.values(node)) {
+        for (const child of Array.isArray(value) ? value : [value]) {
+          if (isJavaScriptNode(child)) pending.push(child);
+        }
+      }
+    }
+    found.sort((a, b) => a.start - b.start);
+    return {
+      exports: parsed.exports,
+      reexports: [
+        ...new Set([
+          ...found.map((entry) => entry.specifier),
+          ...parsed.reexports,
+        ]),
+      ],
+    };
+  } catch {
+    // Retain native metadata if a source is outside the supplemental parser's grammar.
+    return parsed;
+  }
+}
+
+function isJavaScriptNode(value: unknown): value is AnyNode {
+  if (typeof value !== "object" || value === null) return false;
+  const node = value as { type?: unknown; start?: unknown; end?: unknown };
+  return (
+    typeof node.type === "string" &&
+    typeof node.start === "number" &&
+    typeof node.end === "number"
+  );
+}

--- a/packages/ttsc/src/launcher/internal/prepareExecution.ts
+++ b/packages/ttsc/src/launcher/internal/prepareExecution.ts
@@ -8,6 +8,7 @@ import { resolveEmittedJavaScript } from "../../compiler/internal/resolveEmitted
 import { runBuild } from "../../compiler/internal/runBuild";
 import { createFilesystemPathIdentityContext } from "../../internal/projectInputPathIdentity";
 import type { TtscCommonOptions } from "../../structures/internal/TtscCommonOptions";
+import { runtimeCompilerArgs } from "./runtimeCompilerArgs";
 import { type OwningModuleOptions, projectModuleOptions } from "./runtimeHooks";
 
 /**
@@ -297,7 +298,10 @@ function buildProject(
     forceListEmittedFiles: true,
     cacheDir: context.pluginCacheDir,
     outDir: context.emitDir,
-    passthrough: options.passthrough,
+    passthrough: runtimeCompilerArgs(
+      context.project.compilerOptions,
+      options.passthrough,
+    ),
     // `context.emitDir` is ttsx's own temp directory, not an output the project
     // asked for, and tsgo demands an explicit `rootDir` (TS5011) as soon as any
     // `outDir` is in play. Pinning the root tsgo would infer keeps a check-only
@@ -422,7 +426,10 @@ function buildEntryProject(
       forceListEmittedFiles: true,
       cacheDir: context.pluginCacheDir,
       outDir: emitDir,
-      passthrough: options.passthrough,
+      passthrough: runtimeCompilerArgs(
+        project.compilerOptions,
+        options.passthrough,
+      ),
       forceRuntimeSourceMap: context.forceRuntimeSourceMap,
       pluginConfigDir: options.pluginConfigDir,
       plugins: options.plugins,

--- a/packages/ttsc/src/launcher/internal/prepareExecution.ts
+++ b/packages/ttsc/src/launcher/internal/prepareExecution.ts
@@ -299,8 +299,9 @@ function buildProject(
     cacheDir: context.pluginCacheDir,
     outDir: context.emitDir,
     passthrough: runtimeCompilerArgs(
-      context.project.compilerOptions,
+      context.project,
       options.passthrough,
+      options.binary,
     ),
     // `context.emitDir` is ttsx's own temp directory, not an output the project
     // asked for, and tsgo demands an explicit `rootDir` (TS5011) as soon as any
@@ -427,8 +428,9 @@ function buildEntryProject(
       cacheDir: context.pluginCacheDir,
       outDir: emitDir,
       passthrough: runtimeCompilerArgs(
-        project.compilerOptions,
+        project,
         options.passthrough,
+        options.binary,
       ),
       forceRuntimeSourceMap: context.forceRuntimeSourceMap,
       pluginConfigDir: options.pluginConfigDir,

--- a/packages/ttsc/src/launcher/internal/runtimeCompilerArgs.ts
+++ b/packages/ttsc/src/launcher/internal/runtimeCompilerArgs.ts
@@ -1,0 +1,57 @@
+import { normalizeFlagToken } from "../../flags/schema";
+
+/**
+ * Lower proposal syntax in ESNext runtime builds without changing the implied
+ * library or module kind. TypeScript-Go preserves standard decorators at
+ * ESNext, while Node cannot parse them. Its latest standard target, ES2025,
+ * runs the upstream decorator transform and keeps native class-field
+ * semantics.
+ */
+export function runtimeCompilerArgs(
+  compilerOptions: Record<string, unknown>,
+  passthrough: readonly string[] = [],
+): string[] {
+  const option = (name: string, aliases: readonly string[] = []): unknown => {
+    let value = compilerOptions[name];
+    for (let i = 0; i < passthrough.length; i++) {
+      const token = passthrough[i]!;
+      if (!token.startsWith("-")) continue;
+      const normalized = normalizeFlagToken(token);
+      if (normalized !== name.toLowerCase() && !aliases.includes(normalized)) {
+        continue;
+      }
+      const next = passthrough[i + 1];
+      value =
+        name === "noLib" &&
+        next !== "true" &&
+        next !== "false" &&
+        next !== "null"
+          ? true
+          : next === "null"
+            ? undefined
+            : next;
+    }
+    return value;
+  };
+  const target = option("target", ["t"]);
+  if (typeof target !== "string" || target.toLowerCase() !== "esnext") {
+    return [...passthrough];
+  }
+
+  const args = [...passthrough, "--target", "es2025"];
+  const module = option("module", ["m"]);
+  if (module == null || String(module).toLowerCase() === "none") {
+    // GetEmitModuleKind derives ESNext from the original target.
+    args.push("--module", "esnext");
+  }
+  const noLib = option("noLib");
+  if (option("lib") == null && noLib !== true && noLib !== "true") {
+    // The references in TypeScript-Go's lib.esnext.full.d.ts. An explicit lib
+    // (including []) or noLib keeps the user's exact library selection.
+    args.push(
+      "--lib",
+      "esnext,dom,webworker.importscripts,scripthost,dom.iterable,dom.asynciterable",
+    );
+  }
+  return args;
+}

--- a/packages/ttsc/src/launcher/internal/runtimeCompilerArgs.ts
+++ b/packages/ttsc/src/launcher/internal/runtimeCompilerArgs.ts
@@ -1,4 +1,7 @@
+import { resolveTsgo } from "../../compiler/internal/resolveTsgo";
+import { outputText, spawnNative } from "../../compiler/internal/spawnNative";
 import { normalizeFlagToken } from "../../flags/schema";
+import type { ITtscParsedProjectConfig } from "../../structures/internal/ITtscParsedProjectConfig";
 
 /**
  * Lower proposal syntax in ESNext runtime builds without changing the implied
@@ -8,10 +11,27 @@ import { normalizeFlagToken } from "../../flags/schema";
  * semantics.
  */
 export function runtimeCompilerArgs(
-  compilerOptions: Record<string, unknown>,
+  project: ITtscParsedProjectConfig,
   passthrough: readonly string[] = [],
+  binary?: string,
 ): string[] {
+  let compilerOptions = project.compilerOptions;
+  const hasResponseFile = passthrough.some((token) => token.startsWith("@"));
+  if (hasResponseFile) {
+    // Let TypeScript-Go own response-file quoting, nesting, cwd, and ordering.
+    // Replaying just the visible flags would overwrite options inside @files.
+    const tsgo = resolveTsgo({ cwd: project.root, binary });
+    const result = spawnNative(
+      tsgo.binary,
+      ["-p", project.path, ...passthrough, "--showConfig"],
+      { cwd: project.root, encoding: "utf8" },
+    );
+    // Preserve the original compiler's diagnostic when its arguments are invalid.
+    if (result.status !== 0) return [...passthrough];
+    compilerOptions = JSON.parse(outputText(result.stdout)).compilerOptions;
+  }
   const option = (name: string, aliases: readonly string[] = []): unknown => {
+    if (hasResponseFile) return compilerOptions[name];
     let value = compilerOptions[name];
     for (let i = 0; i < passthrough.length; i++) {
       const token = passthrough[i]!;

--- a/packages/ttsc/src/launcher/internal/runtimeHooks.ts
+++ b/packages/ttsc/src/launcher/internal/runtimeHooks.ts
@@ -1367,7 +1367,10 @@ function emitOrphanSource(
 }
 
 /**
- * Emit a source file only for CommonJS export-name discovery.
+ * Read actual owned output for CommonJS export-name discovery, falling back to
+ * isolated emission only when no project emitted this source. Project
+ * transforms and const-enum settings decide which names exist at runtime. An
+ * ESM emit is lowered as JavaScript solely to scan its CommonJS names.
  *
  * This intentionally does not read or write the runtime orphan cache. Name
  * discovery may inspect a source dependency without executing it, so sharing
@@ -1380,6 +1383,14 @@ function emitCommonJsForNameScan(filename: string): string | null {
   if (cached !== undefined) {
     return cached;
   }
+  const served = serveEntryEmit(real) ?? serveDependencyEmit(real);
+  if (
+    served !== null &&
+    moduleFormat(real, served.moduleOptions) === "commonjs"
+  ) {
+    commonJsNameScanSources.set(real, served.source);
+    return served.source;
+  }
   let tsgo: string;
   try {
     tsgo = resolveTsgo({ cwd: path.dirname(real) }).binary;
@@ -1389,10 +1400,14 @@ function emitCommonJsForNameScan(filename: string): string | null {
   }
   const outDir = createCanonicalTempDirectory("ttsx-export-scan-");
   try {
+    // Compile the owned JavaScript, not the original TypeScript whose project
+    // may already have erased or transformed declarations. No source executes.
+    const input = served === null ? real : path.join(outDir, "source.cts");
+    if (served !== null) fs.writeFileSync(input, served.source);
     const res = spawnNative(
       tsgo,
       [
-        real,
+        input,
         "--module",
         "commonjs",
         ...ISOLATED_EMIT_ARGS,
@@ -1403,7 +1418,7 @@ function emitCommonJsForNameScan(filename: string): string | null {
       { cwd: path.dirname(real), encoding: "utf8" },
     );
     const emitted = pickEmittedJavaScript(
-      real,
+      input,
       parseEmittedFiles(outputText(res.stdout)),
     );
     const lowered = emitted === null ? null : readFileOrNull(emitted);

--- a/packages/ttsc/src/launcher/internal/runtimeHooks.ts
+++ b/packages/ttsc/src/launcher/internal/runtimeHooks.ts
@@ -1530,8 +1530,9 @@ function pickEmittedJavaScript(
  * Runtime CommonJS consumers see the getters that helper installs, but Node's
  * ESM linker only exposes named imports it can statically identify from
  * `exports.name = ...` assignments. For relative star re-exports whose emitted
- * target is available, replace the helper call with explicit configurable
- * export placeholders followed by the same `__createBinding` getter install.
+ * target is available, advertise its names through inert assignments that
+ * Node's static lexer recognizes. The original helper still owns every runtime
+ * binding, including values static discovery cannot enumerate.
  */
 function exposeCommonJsStarExports(
   source: string,
@@ -1542,10 +1543,17 @@ function exposeCommonJsStarExports(
     return source;
   }
   const reserved = collectStaticCommonJsExportNames(source);
-  let index = 0;
+  const executable = maskCommentsAndStrings(source);
   return source.replace(
-    /^(\s*)__exportStar\(\s*require\((["'])([^"']+)\2\)\s*,\s*exports\s*\);/gm,
-    (statement: string, indent: string, _quote: string, specifier: string) => {
+    commonJsExportStarPattern(),
+    (
+      statement: string,
+      indent: string,
+      _quote: string,
+      specifier: string,
+      offset: number,
+    ) => {
+      if (executable[offset + indent.length] === " ") return statement;
       const names = [
         ...collectStarExportNames(emittedFile, sourceFile, specifier),
       ].filter(
@@ -1561,15 +1569,10 @@ function exposeCommonJsStarExports(
       for (const name of names) {
         reserved.add(name);
       }
-      const receiver = `__ttsx_export_star_${index++}`;
-      return [
-        ...names.map((name) => `${indent}exports.${name} = void 0;`),
-        `${indent}var ${receiver} = require(${JSON.stringify(specifier)});`,
-        ...names.map(
-          (name) =>
-            `${indent}__createBinding(exports, ${receiver}, ${JSON.stringify(name)});`,
-        ),
-      ].join("\n");
+      const hints = names.map((name) => `exports.${name} = void 0;`).join(" ");
+      // A block remains one statement in an unbraced control-flow body. Keep
+      // the original line count and never execute the static lexer hints.
+      return `${indent}{ if (false) { ${hints} } ${statement.slice(indent.length)} }`;
     },
   );
 }
@@ -1810,13 +1813,19 @@ function collectSourceCommonJsExportNames(
 
 function collectExportStarSpecifiers(source: string): string[] {
   const specifiers: string[] = [];
-  const pattern =
-    /^(\s*)__exportStar\(\s*require\((["'])([^"']+)\2\)\s*,\s*exports\s*\);/gm;
+  const pattern = commonJsExportStarPattern();
+  const executable = maskCommentsAndStrings(source);
   let match: RegExpExecArray | null;
   while ((match = pattern.exec(source)) !== null) {
+    if (executable[match.index + match[1]!.length] === " ") continue;
     specifiers.push(match[3]!);
   }
   return specifiers;
+}
+
+/** TypeScript-Go's inline and tslib-qualified CommonJS star-helper calls. */
+function commonJsExportStarPattern(): RegExp {
+  return /^([ \t]*)(?:[A-Za-z_$][\w$]*\.)?__exportStar\(\s*require\((["'])([^"']+)\2\)\s*,\s*exports\s*\);/gm;
 }
 
 function resolveEmittedRequire(
@@ -1854,7 +1863,8 @@ function resolveSourceSpecifier(
   }
   const base = path.resolve(path.dirname(sourceFile), specifier);
   if (path.extname(base).length !== 0) {
-    return isFile(base) ? base : null;
+    if (isFile(base)) return base;
+    return typescriptSourcesForJavaScriptSpecifier(base).find(isFile) ?? null;
   }
   for (const extension of TYPESCRIPT_EXTENSIONS) {
     const candidate = base + extension;

--- a/packages/ttsc/src/launcher/internal/runtimeHooks.ts
+++ b/packages/ttsc/src/launcher/internal/runtimeHooks.ts
@@ -42,11 +42,9 @@ import { inlineServedSourceMap } from "./servedSourceMap";
  *    type-stripping cannot do cross-file type-only elision — e.g. a
  *    value-shaped import of a type+namespace merge survives stripping and
  *    dangles at runtime.
- * 3. No owning tsconfig → transform the lone file by the format it resolves to: a
- *    CommonJS-classified file (`.cts`, or a `.ts` in a package without `type:
- *    "module"`) is lowered to CommonJS through a tsgo single-file emit so its
- *    `export` syntax becomes `module.exports`; any other (ESM) file keeps the
- *    fast in-process `mode: "transform"` type-strip.
+ * 3. No owning tsconfig: use an isolated tsgo emit in the runtime module format,
+ *    lowering standard decorators and CommonJS imports/exports. Type stripping
+ *    remains recovery when no compiler emit is available.
  *
  * The hooks are synchronous and run on the main thread (not a loader worker):
  * that is what lets a CommonJS `require("./x")` chain reach them and what makes
@@ -1037,7 +1035,7 @@ function owningModuleOptions(filename: string): OwningModuleOptions | null {
     // The owning project cannot be read, so nothing is known about the format
     // it would have emitted. That is the same state as having no project at
     // all, and it is what the dependency lane will conclude too when its build
-    // fails and the file falls through to the orphan type-strip.
+    // fails and the file falls through to the isolated orphan emit.
     moduleOptionsCache.set(tsconfig, null);
     return null;
   }
@@ -1203,9 +1201,8 @@ export function projectModuleOptions(
 /**
  * Resolve the JavaScript to run for a TypeScript source file, in priority
  * order: the entry project's pre-built emit (transform plugins applied), a
- * built raw `.ts` dependency, or — when no tsconfig owns it — a `mode:
- * "transform"` type-strip. Shared by the ESM `load` hook and the CommonJS
- * `require` handler.
+ * built raw `.ts` dependency, or an isolated emit when no tsconfig owns it.
+ * Shared by the ESM `load` hook and the CommonJS `require` handler.
  */
 function resolveServedSource(
   filename: string,
@@ -1252,7 +1249,8 @@ function resolveServedSource(
  * map's `sources`, so the JavaScript executed under the `.ts` source URL stays
  * self-describing after the per-run emit directory is deleted. Applied to both
  * the entry lane (`serveEntryEmit`) and the dependency lane
- * (`serveBuiltDependency`); the orphan type-strip lane carries no emitted map.
+ * (`serveBuiltDependency`); the orphan lane inlines its own map before
+ * caching.
  */
 function withInlineSourceMap(served: ServedSource): ServedSource {
   const source = inlineServedSourceMap(
@@ -1337,6 +1335,13 @@ function emitOrphanSource(
         // each one would otherwise pay a full single-file check.
         "--noCheck",
         "--skipLibCheck",
+        // This cache owns one source, not its dependency graph. Do not inline
+        // imported const enums or emit other files (which can share its stem).
+        // Isolated modules also retain each const enum's runtime definition.
+        "--noResolve",
+        "--isolatedModules",
+        "--sourceMap",
+        "--inlineSources",
         "--outDir",
         outDir,
         "--listEmittedFiles",
@@ -1347,7 +1352,11 @@ function emitOrphanSource(
       filename,
       parseEmittedFiles(outputText(res.stdout)),
     );
-    const lowered = emitted === null ? null : readFileOrNull(emitted);
+    const source = emitted === null ? null : readFileOrNull(emitted);
+    const lowered =
+      source === null
+        ? null
+        : inlineServedSourceMap(source, emitted!, filename);
     if (lowered !== null && cacheFile !== null) {
       writeOrphanCache(cacheFile, lowered);
     }
@@ -1427,9 +1436,9 @@ function orphanCacheRoot(): string {
 }
 
 /**
- * Content-addressed cache path for one orphan file's lowering, keyed by source
- * bytes, module format and the tsgo binary. `null` when the source cannot be
- * read.
+ * Content-addressed cache path for isolated orphan lowering, including the
+ * source path because the inlined map identifies that path. `null` when the
+ * source cannot be read.
  */
 function orphanCacheFile(
   filename: string,
@@ -1445,6 +1454,8 @@ function orphanCacheFile(
   const key = crypto
     .createHash("sha256")
     .update(tsgo)
+    .update("\0isolated-source-map-v1\0")
+    .update(filename)
     .update("\0" + format)
     .update("\0")
     .update(source)
@@ -2014,7 +2025,7 @@ function serveDependencyEmit(real: string): ServedSource | null {
   try {
     built = ensureProjectBuilt(tsconfig);
   } catch {
-    // The owning project produced no emit at all; fall back to type-stripping
+    // The owning project produced no emit at all; fall back to isolated emit of
     // this single file rather than failing the whole run.
     return null;
   }
@@ -2312,7 +2323,7 @@ function buildDependency(
   fs.mkdirSync(emitDir, { recursive: true });
   const result = runBuild({
     cwd: project.root,
-    passthrough: runtimeCompilerArgs(project.compilerOptions),
+    passthrough: runtimeCompilerArgs(project),
     emit: true,
     forceListEmittedFiles: true,
     outDir: emitDir,
@@ -2356,7 +2367,7 @@ function buildDependency(
   // list": a native transform host (typia, @ttsc/banner, …) emits without
   // printing the `--listEmittedFiles` lines, so `result.emittedFiles` is empty
   // even on a clean build. A genuinely empty output directory is the real
-  // failure; the caller then falls back to type-stripping the one file.
+  // failure; the caller then falls back to isolated emit of the one file.
   if (!emittedAnything(emitDir)) {
     // Drop the failed generation so its partial directory can never be mistaken
     // for a reusable build.
@@ -2810,8 +2821,8 @@ const moduleOptionsCache = new Map<string, OwningModuleOptions | null>();
  * walk stops at a `node_modules` boundary: a tsconfig above `node_modules`
  * belongs to the consumer, not to the published dependency inside it, so a
  * dependency that ships no tsconfig of its own has no owning project and is
- * type-stripped instead. A pnpm-symlinked workspace package is unaffected
- * because `file` is already its real path (outside `node_modules`).
+ * compiled in isolation instead. A pnpm-symlinked workspace package is
+ * unaffected because `file` is already its real path (outside `node_modules`).
  *
  * The walk is memoised per directory (the whole walked chain shares one
  * answer), so the thousands of files a fanned-out test corpus imports from the

--- a/packages/ttsc/src/launcher/internal/runtimeHooks.ts
+++ b/packages/ttsc/src/launcher/internal/runtimeHooks.ts
@@ -1,4 +1,3 @@
-import { parse as parseCommonJs } from "cjs-module-lexer";
 import crypto from "node:crypto";
 import fs from "node:fs";
 import {
@@ -22,6 +21,7 @@ import {
   type FilesystemPathIdentityContext,
   createFilesystemPathIdentityContext,
 } from "../../internal/projectInputPathIdentity";
+import { parseCommonJsExports } from "./commonJsExportMetadata";
 import { runtimeCompilerArgs } from "./runtimeCompilerArgs";
 import { inlineServedSourceMap } from "./servedSourceMap";
 
@@ -1611,19 +1611,6 @@ function collectCommonJsExportNames(
     }
   }
   return names;
-}
-
-/** Read Node-compatible export metadata without replacing Node's syntax errors. */
-function parseCommonJsExports(
-  source: string,
-): ReturnType<typeof parseCommonJs> {
-  try {
-    return parseCommonJs(source);
-  } catch {
-    // Discovery is advisory. The unchanged source still reaches Node, which
-    // owns the diagnostic if the module is not valid JavaScript.
-    return { exports: [], reexports: [] };
-  }
 }
 
 function collectSourceCommonJsExportNames(

--- a/packages/ttsc/src/launcher/internal/runtimeHooks.ts
+++ b/packages/ttsc/src/launcher/internal/runtimeHooks.ts
@@ -21,6 +21,7 @@ import {
   type FilesystemPathIdentityContext,
   createFilesystemPathIdentityContext,
 } from "../../internal/projectInputPathIdentity";
+import { runtimeCompilerArgs } from "./runtimeCompilerArgs";
 import { inlineServedSourceMap } from "./servedSourceMap";
 
 /**
@@ -1267,23 +1268,17 @@ function withInlineSourceMap(served: ServedSource): ServedSource {
  * vendored package that ships raw `.ts`/`.cts`/`.mts` straight under
  * `node_modules`), choosing the lowering by the format the file resolves to.
  *
- * Node's in-process `stripTypeScriptTypes` only erases type syntax; it never
- * rewrites ECMAScript `import`/`export` into CommonJS. That is correct for a
- * file Node will load as ESM, but wrong for one classified CommonJS — a `.cts`,
- * or a `.ts` in a package without `type: "module"` — when the author wrote it
- * with module syntax (`export const`, `export namespace`, `export function`).
- * Stripping leaves the `export` in place and Node's CommonJS loader dies with
- * `SyntaxError: Unexpected token 'export'`. So a CommonJS-format orphan is
- * lowered through a real tsgo `--module commonjs` single-file emit (which also
- * handles `export =`), exactly the format decision tsgo would have made for an
- * owning project; an ESM-format orphan keeps the fast in-process strip.
+ * Both module formats need the compiler: Node's type stripping neither lowers
+ * standard decorators nor rewrites ESM exports for CommonJS. Use the existing
+ * single-file emit with the file's own module format and a standard target.
+ * Retain stripping as recovery when no compiler emit is available.
  */
 function transformOrphanSource(filename: string, url: string): string {
-  if (moduleFormat(filename, null) === "commonjs") {
-    const lowered = emitOrphanAsCommonJs(filename);
-    if (lowered !== null) {
-      return lowered;
-    }
+  const format =
+    moduleFormat(filename, null) === "commonjs" ? "commonjs" : "module";
+  const lowered = emitOrphanSource(filename, format);
+  if (lowered !== null) {
+    return lowered;
   }
   return stripTypeScriptTypes(fs.readFileSync(filename, "utf8"), {
     mode: "transform",
@@ -1292,25 +1287,27 @@ function transformOrphanSource(filename: string, url: string): string {
 }
 
 /**
- * Lower a single CommonJS-format source file to CommonJS JavaScript by running
- * tsgo on the lone file with `--module commonjs`. Emit-only, no diagnostic gate
- * (the entry project's up-front check is the type gate), matching
- * `buildDependency`. Returns `null` when tsgo is unavailable or produced no
- * output, so the caller can fall back to the in-process strip.
+ * Lower a single source file to its runtime module format. Emit-only, no
+ * diagnostic gate (the entry project's up-front check is the type gate),
+ * matching `buildDependency`. Returns `null` when tsgo is unavailable or
+ * produced no output, so the caller can fall back to the in-process strip.
  */
-function emitOrphanAsCommonJs(filename: string): string | null {
+function emitOrphanSource(
+  filename: string,
+  format: "commonjs" | "module",
+): string | null {
   let tsgo: string;
   try {
     tsgo = resolveTsgo({ cwd: path.dirname(filename) }).binary;
   } catch {
     return null;
   }
-  // Content-hash cache: a CJS-format orphan ('s tsgo single-file emit) is lowered
+  // Content-hash cache: an orphan's tsgo single-file emit is lowered
   // once and reused by every other process in the run, and across runs. Without
   // it a program that fans out into many processes (the automated test corpus
   // imports the same vendored `.ts` deps from thousands of generated files) would
   // re-spawn tsgo per file per process and crawl.
-  const cacheFile = orphanCacheFile(filename, tsgo);
+  const cacheFile = orphanCacheFile(filename, tsgo, format);
   if (cacheFile !== null) {
     const hit = readFileOrNull(cacheFile);
     if (hit !== null) {
@@ -1329,7 +1326,7 @@ function emitOrphanAsCommonJs(filename: string): string | null {
         // ("tsconfig.json is present but will not be loaded") otherwise.
         "--ignoreConfig",
         "--module",
-        "commonjs",
+        format === "commonjs" ? "commonjs" : "esnext",
         "--target",
         "es2022",
         // This is an emit-only lowering: the entry project's up-front build is
@@ -1346,7 +1343,10 @@ function emitOrphanAsCommonJs(filename: string): string | null {
       ],
       { cwd: path.dirname(filename), encoding: "utf8" },
     );
-    const emitted = parseFirstEmittedFile(outputText(res.stdout));
+    const emitted = pickEmittedJavaScript(
+      filename,
+      parseEmittedFiles(outputText(res.stdout)),
+    );
     const lowered = emitted === null ? null : readFileOrNull(emitted);
     if (lowered !== null && cacheFile !== null) {
       writeOrphanCache(cacheFile, lowered);
@@ -1423,15 +1423,19 @@ function orphanCacheRoot(): string {
     process.env.TTSC_CACHE_DIR && process.env.TTSC_CACHE_DIR.length !== 0
       ? process.env.TTSC_CACHE_DIR
       : path.join(os.tmpdir(), "ttsc-orphan");
-  return path.join(base, "ttsx-orphan-cjs");
+  return path.join(base, "ttsx-orphan");
 }
 
 /**
- * Content-addressed cache path for one orphan file's CommonJS lowering, keyed
- * by source bytes and the tsgo binary so a tsgo bump invalidates it. `null`
- * when the source cannot be read.
+ * Content-addressed cache path for one orphan file's lowering, keyed by source
+ * bytes, module format and the tsgo binary. `null` when the source cannot be
+ * read.
  */
-function orphanCacheFile(filename: string, tsgo: string): string | null {
+function orphanCacheFile(
+  filename: string,
+  tsgo: string,
+  format: "commonjs" | "module",
+): string | null {
   let source: Buffer;
   try {
     source = fs.readFileSync(filename);
@@ -1441,6 +1445,7 @@ function orphanCacheFile(filename: string, tsgo: string): string | null {
   const key = crypto
     .createHash("sha256")
     .update(tsgo)
+    .update("\0" + format)
     .update("\0")
     .update(source)
     .digest("hex")
@@ -1462,17 +1467,6 @@ function writeOrphanCache(cacheFile: string, lowered: string): void {
   } catch {
     // ignore — caching is an optimization, correctness does not depend on it
   }
-}
-
-/** First `TSFILE:` path tsgo printed under `--listEmittedFiles`, or `null`. */
-function parseFirstEmittedFile(stdout: string): string | null {
-  for (const line of stdout.split(/\r?\n/)) {
-    const match = line.match(/^TSFILE:\s*(.+)$/);
-    if (match?.[1]) {
-      return match[1].trim();
-    }
-  }
-  return null;
 }
 
 /** `TSFILE:` paths tsgo printed under `--listEmittedFiles`. */
@@ -2140,6 +2134,7 @@ export function dependencyCacheKey(
     crypto
       .createHash("sha256")
       .update(tsconfig)
+      .update("\0runtime-es2025")
       // Descriptor evaluation promises a result bound to this process's exact
       // input observations. Reusing an emit another evaluator built can pair
       // that process's old source/config bytes with this process's later hashes.
@@ -2317,6 +2312,7 @@ function buildDependency(
   fs.mkdirSync(emitDir, { recursive: true });
   const result = runBuild({
     cwd: project.root,
+    passthrough: runtimeCompilerArgs(project.compilerOptions),
     emit: true,
     forceListEmittedFiles: true,
     outDir: emitDir,

--- a/packages/ttsc/src/launcher/internal/runtimeHooks.ts
+++ b/packages/ttsc/src/launcher/internal/runtimeHooks.ts
@@ -25,6 +25,23 @@ import { runtimeCompilerArgs } from "./runtimeCompilerArgs";
 import { inlineServedSourceMap } from "./servedSourceMap";
 
 /**
+ * One emit policy for orphan execution and CommonJS export discovery. The
+ * compiler ignores the consumer's config, lowers proposal syntax, and checks no
+ * types because the entry build owns diagnostics. Isolation prevents imported
+ * const-enum inlining and secondary emits, and keeps const enums as runtime
+ * exports that the name scanner must also observe.
+ */
+const ISOLATED_EMIT_ARGS = [
+  "--ignoreConfig",
+  "--target",
+  "es2022",
+  "--noCheck",
+  "--skipLibCheck",
+  "--noResolve",
+  "--isolatedModules",
+] as const;
+
+/**
  * Synchronous Node module hooks installed (via `module.registerHooks`) in the
  * child process `ttsx` spawns to run a TypeScript entry _from source_.
  *
@@ -1318,28 +1335,9 @@ function emitOrphanSource(
       tsgo,
       [
         filename,
-        // The file is named on the command line, so any tsconfig tsgo would
-        // discover by walking up (the consumer's own) must be ignored — both
-        // because it is not this file's project and because tsgo errors out
-        // ("tsconfig.json is present but will not be loaded") otherwise.
-        "--ignoreConfig",
         "--module",
         format === "commonjs" ? "commonjs" : "esnext",
-        "--target",
-        "es2022",
-        // This is an emit-only lowering: the entry project's up-front build is
-        // the type gate, so the single-file pass does not need to type-check.
-        // Skipping the check (and the lib check it implies) cuts the per-file
-        // cost several-fold, which matters when a program generates and imports
-        // thousands of raw `.ts` files at runtime (a fanned-out test corpus) and
-        // each one would otherwise pay a full single-file check.
-        "--noCheck",
-        "--skipLibCheck",
-        // This cache owns one source, not its dependency graph. Do not inline
-        // imported const enums or emit other files (which can share its stem).
-        // Isolated modules also retain each const enum's runtime definition.
-        "--noResolve",
-        "--isolatedModules",
+        ...ISOLATED_EMIT_ARGS,
         "--sourceMap",
         "--inlineSources",
         "--outDir",
@@ -1395,13 +1393,9 @@ function emitCommonJsForNameScan(filename: string): string | null {
       tsgo,
       [
         real,
-        "--ignoreConfig",
         "--module",
         "commonjs",
-        "--target",
-        "es2022",
-        "--noCheck",
-        "--skipLibCheck",
+        ...ISOLATED_EMIT_ARGS,
         "--outDir",
         outDir,
         "--listEmittedFiles",

--- a/packages/ttsc/src/launcher/internal/runtimeHooks.ts
+++ b/packages/ttsc/src/launcher/internal/runtimeHooks.ts
@@ -1,3 +1,4 @@
+import { parse as parseCommonJs } from "cjs-module-lexer";
 import crypto from "node:crypto";
 import fs from "node:fs";
 import {
@@ -1539,42 +1540,28 @@ function exposeCommonJsStarExports(
   emittedFile: string | undefined,
   sourceFile: string | undefined,
 ): string {
-  if (!source.includes("__exportStar(")) {
-    return source;
+  const parsed = parseCommonJsExports(source);
+  const reserved = new Set(parsed.exports);
+  const names = new Set<string>();
+  for (const specifier of parsed.reexports) {
+    for (const name of collectStarExportNames(
+      emittedFile,
+      sourceFile,
+      specifier,
+    )) {
+      if (name !== "default" && name !== "__esModule" && !reserved.has(name)) {
+        names.add(name);
+      }
+    }
   }
-  const reserved = collectStaticCommonJsExportNames(source);
-  const executable = maskCommentsAndStrings(source);
-  return source.replace(
-    commonJsExportStarPattern(),
-    (
-      statement: string,
-      indent: string,
-      _quote: string,
-      specifier: string,
-      offset: number,
-    ) => {
-      if (executable[offset + indent.length] === " ") return statement;
-      const names = [
-        ...collectStarExportNames(emittedFile, sourceFile, specifier),
-      ].filter(
-        (name) =>
-          name !== "default" &&
-          name !== "__esModule" &&
-          isIdentifierName(name) &&
-          !reserved.has(name),
-      );
-      if (names.length === 0) {
-        return statement;
-      }
-      for (const name of names) {
-        reserved.add(name);
-      }
-      const hints = names.map((name) => `exports.${name} = void 0;`).join(" ");
-      // A block remains one statement in an unbraced control-flow body. Keep
-      // the original line count and never execute the static lexer hints.
-      return `${indent}{ if (false) { ${hints} } ${statement.slice(indent.length)} }`;
-    },
-  );
+  if (names.size === 0) return source;
+  // Node's lexer reads these assignments statically. Nothing executes, and no
+  // existing statement, source position, control-flow body or runtime export
+  // is changed. Keep all specifier/literal parsing in the same lexer Node uses.
+  const hints = [...names]
+    .map((name) => `exports[${JSON.stringify(name)}] = void 0;`)
+    .join(" ");
+  return source + `\nif (false) { ${hints} }\n`;
 }
 
 function collectStarExportNames(
@@ -1610,8 +1597,9 @@ function collectCommonJsExportNames(
   if (source === null) {
     return new Set();
   }
-  const names = collectStaticCommonJsExportNames(source);
-  for (const specifier of collectExportStarSpecifiers(source)) {
+  const parsed = parseCommonJsExports(source);
+  const names = new Set(parsed.exports);
+  for (const specifier of parsed.reexports) {
     const target = resolveEmittedRequire(real, specifier);
     if (target === null) {
       continue;
@@ -1625,162 +1613,17 @@ function collectCommonJsExportNames(
   return names;
 }
 
-function collectStaticCommonJsExportNames(source: string): Set<string> {
-  // Scan executable syntax only. Text that merely resembles an assignment —
-  // `exports.x =` inside a comment, string, or template-literal text — must not
-  // become an ESM-visible export name, or a named import of it would link to
-  // `undefined` for a property the CommonJS module never defines. Masking the
-  // inert lexical spans before matching keeps genuine top-level assignments
-  // (and executable `${ ... }` template substitutions) while dropping the
-  // decoys.
-  const scannable = maskCommentsAndStrings(source);
-  const names = new Set<string>();
-  const pattern =
-    /(?:^|[^\w$])(?:exports|module\.exports)\.([A-Za-z_$][\w$]*)\s*=/g;
-  let match: RegExpExecArray | null;
-  while ((match = pattern.exec(scannable)) !== null) {
-    names.add(match[1]!);
+/** Read Node-compatible export metadata without replacing Node's syntax errors. */
+function parseCommonJsExports(
+  source: string,
+): ReturnType<typeof parseCommonJs> {
+  try {
+    return parseCommonJs(source);
+  } catch {
+    // Discovery is advisory. The unchanged source still reaches Node, which
+    // owns the diagnostic if the module is not valid JavaScript.
+    return { exports: [], reexports: [] };
   }
-  return names;
-}
-
-/**
- * Blank out the interior of line comments, block comments, string literals, and
- * template-literal text in emitted JavaScript, replacing each masked character
- * with a space while preserving newlines, code, and template `${ ... }`
- * substitutions verbatim. Positions and length are preserved so an offset in
- * the masked text maps back to the same offset in the source.
- *
- * The input is tsgo's CommonJS emit (well-formed JavaScript), so a character
- * scanner that tracks the standard comment/string/template states is sufficient
- * to separate executable tokens from inert text. Regular-expression literals
- * are intentionally not masked: distinguishing `/`-division from a regex
- * literal needs full tokenization, and tsgo's CommonJS emit never wraps an
- * `exports.<name> =` assignment inside a regex literal.
- */
-function maskCommentsAndStrings(source: string): string {
-  const out = source.split("");
-  const n = out.length;
-  const blank = (index: number): void => {
-    const ch = out[index];
-    if (ch !== "\n" && ch !== "\r") {
-      out[index] = " ";
-    }
-  };
-  // A stack of lexical contexts. The base is code; each backtick pushes a
-  // template context, and each `${` inside a template pushes a nested code
-  // context whose `braceDepth` tracks `{}` nesting so an object literal inside
-  // the substitution does not end it early.
-  interface Context {
-    kind: "code" | "template";
-    braceDepth: number;
-  }
-  const stack: Context[] = [{ kind: "code", braceDepth: 0 }];
-  let i = 0;
-  while (i < n) {
-    const top = stack[stack.length - 1]!;
-    const ch = out[i]!;
-    if (top.kind === "template") {
-      if (ch === "\\") {
-        blank(i);
-        blank(i + 1);
-        i += 2;
-        continue;
-      }
-      if (ch === "`") {
-        blank(i);
-        stack.pop();
-        i += 1;
-        continue;
-      }
-      if (ch === "$" && out[i + 1] === "{") {
-        // Enter a code substitution: `${` and its contents stay executable.
-        stack.push({ kind: "code", braceDepth: 0 });
-        i += 2;
-        continue;
-      }
-      blank(i);
-      i += 1;
-      continue;
-    }
-    // Code context.
-    if (ch === "/" && out[i + 1] === "/") {
-      blank(i);
-      blank(i + 1);
-      i += 2;
-      while (i < n && out[i] !== "\n") {
-        blank(i);
-        i += 1;
-      }
-      continue;
-    }
-    if (ch === "/" && out[i + 1] === "*") {
-      blank(i);
-      blank(i + 1);
-      i += 2;
-      while (i < n && !(out[i] === "*" && out[i + 1] === "/")) {
-        blank(i);
-        i += 1;
-      }
-      if (i < n) {
-        blank(i);
-        blank(i + 1);
-        i += 2;
-      }
-      continue;
-    }
-    if (ch === '"' || ch === "'") {
-      blank(i);
-      i += 1;
-      while (i < n && out[i] !== ch) {
-        if (out[i] === "\\") {
-          blank(i);
-          blank(i + 1);
-          i += 2;
-          continue;
-        }
-        // A bare newline ends an unterminated string; stop masking so the rest
-        // of the line is still scanned as code (defensive — tsgo never emits
-        // one).
-        if (out[i] === "\n") {
-          break;
-        }
-        blank(i);
-        i += 1;
-      }
-      if (i < n && out[i] === ch) {
-        blank(i);
-        i += 1;
-      }
-      continue;
-    }
-    if (ch === "`") {
-      blank(i);
-      stack.push({ kind: "template", braceDepth: 0 });
-      i += 1;
-      continue;
-    }
-    if (ch === "{") {
-      top.braceDepth += 1;
-      i += 1;
-      continue;
-    }
-    if (ch === "}") {
-      if (top.braceDepth === 0 && stack.length > 1) {
-        // Close the enclosing template `${ ... }` and resume template text.
-        stack.pop();
-        i += 1;
-        continue;
-      }
-      if (top.braceDepth > 0) {
-        top.braceDepth -= 1;
-      }
-      i += 1;
-      continue;
-    }
-    i += 1;
-  }
-  return out.join("");
 }
 
 function collectSourceCommonJsExportNames(
@@ -1796,8 +1639,9 @@ function collectSourceCommonJsExportNames(
   if (source === null) {
     return new Set();
   }
-  const names = collectStaticCommonJsExportNames(source);
-  for (const specifier of collectExportStarSpecifiers(source)) {
+  const parsed = parseCommonJsExports(source);
+  const names = new Set(parsed.exports);
+  for (const specifier of parsed.reexports) {
     const target = resolveSourceSpecifier(real, specifier);
     if (target === null) {
       continue;
@@ -1809,23 +1653,6 @@ function collectSourceCommonJsExportNames(
     }
   }
   return names;
-}
-
-function collectExportStarSpecifiers(source: string): string[] {
-  const specifiers: string[] = [];
-  const pattern = commonJsExportStarPattern();
-  const executable = maskCommentsAndStrings(source);
-  let match: RegExpExecArray | null;
-  while ((match = pattern.exec(source)) !== null) {
-    if (executable[match.index + match[1]!.length] === " ") continue;
-    specifiers.push(match[3]!);
-  }
-  return specifiers;
-}
-
-/** TypeScript-Go's inline and tslib-qualified CommonJS star-helper calls. */
-function commonJsExportStarPattern(): RegExp {
-  return /^([ \t]*)(?:[A-Za-z_$][\w$]*\.)?__exportStar\(\s*require\((["'])([^"']+)\2\)\s*,\s*exports\s*\);/gm;
 }
 
 function resolveEmittedRequire(
@@ -1879,10 +1706,6 @@ function resolveSourceSpecifier(
     }
   }
   return null;
-}
-
-function isIdentifierName(name: string): boolean {
-  return /^[A-Za-z_$][\w$]*$/.test(name);
 }
 
 /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -710,6 +710,9 @@ importers:
       mocha:
         specifier: ^11
         version: 11.8.0
+      tslib:
+        specifier: 2.8.1
+        version: 2.8.1
       ttsc:
         specifier: workspace:*
         version: link:../../packages/ttsc

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,6 +57,9 @@ overrides:
   mocha>serialize-javascript: 7.0.3
   browserslist: 4.28.8
   fast-uri: 3.1.7
+  '@xmldom/xmldom': 0.9.12
+  sharp: 0.35.4
+  js-yaml@^4: 4.3.2
 
 importers:
 
@@ -826,14 +829,14 @@ importers:
         specifier: ^0.52.0
         version: 0.52.2
       next:
-        specifier: ^16.3.0
-        version: 16.3.0(@types/node@20.19.41)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: ^16.3.3
+        version: 16.3.4(@types/node@20.19.41)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       nextra:
         specifier: 4.6.0
-        version: 4.6.0(next@16.3.0(@types/node@20.19.41)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
+        version: 4.6.0(next@16.3.4(@types/node@20.19.41)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
       nextra-theme-docs:
         specifier: 4.6.0
-        version: 4.6.0(@types/react@18.3.29)(next@16.3.0(@types/node@20.19.41)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(nextra@4.6.0(next@16.3.0(@types/node@20.19.41)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(use-sync-external-store@1.6.0(react@18.3.1))
+        version: 4.6.0(@types/react@18.3.29)(next@16.3.4(@types/node@20.19.41)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(nextra@4.6.0(next@16.3.4(@types/node@20.19.41)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(use-sync-external-store@1.6.0(react@18.3.1))
       path:
         specifier: ^0.12.7
         version: 0.12.7
@@ -879,10 +882,10 @@ importers:
         version: 2.6.2
       '@rspack/cli':
         specifier: ^1.3.0
-        version: 1.7.11(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@types/express@4.17.25)(webpack@5.107.1(postcss@8.5.23))
+        version: 1.7.11(@rspack/core@1.7.11(@swc/helpers@0.5.23))(@types/express@4.17.25)(webpack@5.107.1(postcss@8.5.23))
       '@rspack/core':
         specifier: ^1.3.0
-        version: 1.7.11(@swc/helpers@0.5.21)
+        version: 1.7.11(@swc/helpers@0.5.23)
       '@types/node':
         specifier: ^20.11.0
         version: 20.19.41
@@ -897,7 +900,7 @@ importers:
         version: 6.3.0
       next-sitemap:
         specifier: ^4.2.3
-        version: 4.2.3(next@16.3.0(@types/node@20.19.41)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+        version: 4.2.3(next@16.3.4(@types/node@20.19.41)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       pagefind:
         specifier: ^1.3.0
         version: 1.5.2
@@ -1423,144 +1426,144 @@ packages:
     resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
     engines: {node: '>=18'}
 
-  '@img/sharp-darwin-arm64@0.35.3':
-    resolution: {integrity: sha512-RMnFX7YQsMoh7lWfcM4NEHHymBX/rLuKNPVM84XE9ONPcaSCDgE7CHIHpSgPcO2xcRthgBy1HfNO319mwhIAkg==}
+  '@img/sharp-darwin-arm64@0.35.4':
+    resolution: {integrity: sha512-Uhfl4V4lhP2nbUVF9+hyH1+luj86f1gUFeo8ALYxFoULoU+G87D43BfeMP8XHsk9boxAnCY/bf2EHwhA7MuGsA==}
     engines: {node: '>=20.9.0'}
     cpu: [arm64]
     os: [darwin]
 
-  '@img/sharp-darwin-x64@0.35.3':
-    resolution: {integrity: sha512-Xo+5uFBtLN0BKqieTxiFzFPQAUlBbbH5iBKyRX/z1JrbnYsHTfKJnUfL8+p2TPXr1pXqao4eeL4Rl144uDpK9w==}
+  '@img/sharp-darwin-x64@0.35.4':
+    resolution: {integrity: sha512-hWniXY3bG5qKpkKrAwPe4y+VTPmf086YQAnkxWh7uA1YrlRouWGa0M0Mxj3ZjnXFkv7/TD1bTy9lGUK26vRvWw==}
     engines: {node: '>=20.9.0'}
     cpu: [x64]
     os: [darwin]
 
-  '@img/sharp-freebsd-wasm32@0.35.3':
-    resolution: {integrity: sha512-lUxcqWIj2wMQ9BrwNjngcr1gWUr5xgaGThBRqPPalIC2n67Cqj1uPh8NnA/ZhAg8hUbKl+kVHKwgUIwe6ZYPrg==}
+  '@img/sharp-freebsd-wasm32@0.35.4':
+    resolution: {integrity: sha512-lIsKw/BU+kjB4eZjxrYrZmwOJYi3Ajrv66iAlBmUPyKc3HpnloevB1g3wxGD9P/5BbQ1brBGl65VRRrCvQDEqA==}
     engines: {node: '>=20.9.0'}
     os: [freebsd]
 
-  '@img/sharp-libvips-darwin-arm64@1.3.2':
-    resolution: {integrity: sha512-9J6ypZFpQBj4YnePGoq/S38w6nz+vqg5WZLrLGY4YuSemdMq47GMLBPO42MzwdGwpg/agZ7xzZcFHa48xlywfg==}
+  '@img/sharp-libvips-darwin-arm64@1.3.3':
+    resolution: {integrity: sha512-suTBPTDGrI9WodccaDdwZItTSaBYASlBk1NSfElSHrUfzu3szG6lvIF58+WiFvnfzuK8ZBFS5zE00PxqxnRiPg==}
     cpu: [arm64]
     os: [darwin]
 
-  '@img/sharp-libvips-darwin-x64@1.3.2':
-    resolution: {integrity: sha512-m2pW1n6cns9VaubNwsZ+c3CRYjxNQWgJ5gPlnL1nbBcpkBvFm6SCFN5o0psFHI8w9n11NKhFkeEDns98tiqbEw==}
+  '@img/sharp-libvips-darwin-x64@1.3.3':
+    resolution: {integrity: sha512-FVJZ5mITMobmXIz/hPDTw0EintTW5H3WfrxwLqEqjiIihlu+hVRyGrFQ60xl0Lxn7Bt3zdpevPaQi0HEzqz9fw==}
     cpu: [x64]
     os: [darwin]
 
-  '@img/sharp-libvips-linux-arm64@1.3.2':
-    resolution: {integrity: sha512-dqVSFynCox4C/J8kT16V7SIFAns0IjgLwkvYT7p8LQVmJ5OS5b6tI9IGflxTeuBS//zXeFIUbwt5dwxyZ17cnA==}
+  '@img/sharp-libvips-linux-arm64@1.3.3':
+    resolution: {integrity: sha512-0DaL0A6Xu6sQSQFwe4iVCrKWU2cCTItnRsYsCdxAMm9NF6twAA9BKnoqy4hqz4+azQ0JHuA26qiUKsf1XJ/v5A==}
     cpu: [arm64]
     os: [linux]
 
-  '@img/sharp-libvips-linux-arm@1.3.2':
-    resolution: {integrity: sha512-1eMLzy92I4J6rmi4mAT8yC3HxOtniyGELlzGbNMLLeqe052ahFQ0h6LFq+lh5DsDIdYViIDst08abvSbcEdLXQ==}
+  '@img/sharp-libvips-linux-arm@1.3.3':
+    resolution: {integrity: sha512-3rbU4vqXXc3hY/OiXdl52xZvT0F1yEngWfvqudtPJg/KkyiaQw2DRsFrNzpmLvfavbwOq3qXn36GP8obHRULQA==}
     cpu: [arm]
     os: [linux]
 
-  '@img/sharp-libvips-linux-ppc64@1.3.2':
-    resolution: {integrity: sha512-3z0NHDxD6n5I9gc05U1eW1AyRm+Gznzq3naMrthPNqE6oYykcogW0l/jfpJdjYnuNl8R7yI9pNbE1XiUeyq0Aw==}
+  '@img/sharp-libvips-linux-ppc64@1.3.3':
+    resolution: {integrity: sha512-cdn1OvUBwsXhbC0zSzJnNzf5MZ/mTrobawDvNXBTxe8VtqKAm0sRuEY2Evzovb/w9JMk4TvRxqt1mekSuJz64w==}
     cpu: [ppc64]
     os: [linux]
 
-  '@img/sharp-libvips-linux-riscv64@1.3.2':
-    resolution: {integrity: sha512-bsb4rI+NldGOsXuej2r8OdSS8+zXDVaCWxyWrcv6kneTOlgAHtZABRzBBCwdsPiD90J4myNJuHpg6kA20ImW/w==}
+  '@img/sharp-libvips-linux-riscv64@1.3.3':
+    resolution: {integrity: sha512-HjPVx7yKz+0lqdhDlTw1tt90wamBoxhiXpvl1XZpJLiHH4RCJ5yDTqH+VlYPv2fwFs89JFw4c1IexYOcQUi4IQ==}
     cpu: [riscv64]
     os: [linux]
 
-  '@img/sharp-libvips-linux-s390x@1.3.2':
-    resolution: {integrity: sha512-/ABshyj8gCpyIrNXnHn4LorDJ0HHm1VhXPBlxZ8zAtfVPAaSafXPGn+sUSIRiwaSBy0mmFjSjiXI5mkcwdChKQ==}
+  '@img/sharp-libvips-linux-s390x@1.3.3':
+    resolution: {integrity: sha512-neWLh+3yCNThxnfy3c4BbVBeGgt9aftno+XbT56iK28RgeDs3UOFWviLWlUu0bArYVYJaFDK+RRohbicUNCm8Q==}
     cpu: [s390x]
     os: [linux]
 
-  '@img/sharp-libvips-linux-x64@1.3.2':
-    resolution: {integrity: sha512-ITPEtgffGJ0S6G9dRyw/366tJQqFRcHWPHhC+Stpg3Z8AEMrDrTr2lhdz4f/Y/HMbRh//7Z5mBzEpVdi62Oc3w==}
+  '@img/sharp-libvips-linux-x64@1.3.3':
+    resolution: {integrity: sha512-4vKmvAst9nrowcqquKFAyZJUDolUaIp8uRiN0mWFguJ1IplC9/pitXtlnnlU4aa/eJw3J7i67V+pwUL+wZGdsA==}
     cpu: [x64]
     os: [linux]
 
-  '@img/sharp-libvips-linuxmusl-arm64@1.3.2':
-    resolution: {integrity: sha512-zE9EdiUzUmg5mDT5a1rk5fYJ6GWPloTwWBYDS14naqHsL+EaMpDj1AWnpLgh3u0YCORv2Tt50wrcrpYqkP97Kw==}
+  '@img/sharp-libvips-linuxmusl-arm64@1.3.3':
+    resolution: {integrity: sha512-Y9kQaLMuNoB0bPYOOdcZMaseNrFpPodIWWMrx+CZyydf2xn68j9WYc6sWWRrDwNkzCQjKYfc68L7jKjGlHMibw==}
     cpu: [arm64]
     os: [linux]
 
-  '@img/sharp-libvips-linuxmusl-x64@1.3.2':
-    resolution: {integrity: sha512-m0lrLiUt+lBYnCFr8qV/65yMR4E/c7/wf78I5eKTdkEakFAlZ9QlzEM3QIhhAwVeUhLAHLcCq7a7Vszq/oFNZQ==}
+  '@img/sharp-libvips-linuxmusl-x64@1.3.3':
+    resolution: {integrity: sha512-fj8Mv0HHfD1Rr+4I68+3agJynxDWtBFgicTbSOb9Bke6pIwzGcJ+RX/yHjmiEGFMCavY/dxvem7MyNaJF+wDiw==}
     cpu: [x64]
     os: [linux]
 
-  '@img/sharp-linux-arm64@0.35.3':
-    resolution: {integrity: sha512-QgKDspHPnrU+GQ55XPhGwyhC8acLVOOSyAvo1oVfFmrIXLkDNmGWzAfDZ4xK8oSA1qBQrALcHX0G5UZni/SuFQ==}
+  '@img/sharp-linux-arm64@0.35.4':
+    resolution: {integrity: sha512-De4jpEnAU8Hd5oT0j1G3uL4ZvTuipVMn7YC6vPaJhy6/7EwEae0SVAoBrUMYQbkLGDm85taVWwuPc1a44LTzCQ==}
     engines: {node: '>=20.9.0'}
     cpu: [arm64]
     os: [linux]
 
-  '@img/sharp-linux-arm@0.35.3':
-    resolution: {integrity: sha512-affVWCTLooy8TSxbDx2qkzuDeaWLNVBA+P//FNBirHsXpP2fuBhk5AuboYUnrDnzoXes8GFjpTx0SBFOCRg+FA==}
+  '@img/sharp-linux-arm@0.35.4':
+    resolution: {integrity: sha512-7OAS8gI0EReKGVN2HssHlM6umJgxF5VI3xN0p9FA91p/YO+ou5hiNghLdZ5BEHztwaaK5+bLKRf8x/o2L2nk9A==}
     engines: {node: '>=20.9.0'}
     cpu: [arm]
     os: [linux]
 
-  '@img/sharp-linux-ppc64@0.35.3':
-    resolution: {integrity: sha512-sMd8rDxmpLOwv/7N44klFjOD5DUO7FLdjiXDI0hoxYaf7Ar262dQIEkosE98bps+5HPLtp/EvNqeqQtOycP/IA==}
+  '@img/sharp-linux-ppc64@0.35.4':
+    resolution: {integrity: sha512-2oYZJeIl4kCcMGk4ouZVjnkCtFrpQFlNEtJ6GbxzhHQchwH0NH/qEb9ykmOl29dqwMq+JhFdZn+1ak2FKhI9fQ==}
     engines: {node: '>=20.9.0'}
     cpu: [ppc64]
     os: [linux]
 
-  '@img/sharp-linux-riscv64@0.35.3':
-    resolution: {integrity: sha512-0Eob78yjlYPfL5vMNWAW55l3R9Y6BQS/gOfe0ZcP9mEz9ohhKSt4im1hayiknXgf8AWrFqMvJcKIdmLmEe7yeQ==}
+  '@img/sharp-linux-riscv64@0.35.4':
+    resolution: {integrity: sha512-cPbNChoRURAWdebDIHSenxRpgEdy7JkPydSnUxRm9VvKD7m0/xVaR/8Fzlu81pk5nHEvHH87UZUA7cTtwnbJSA==}
     engines: {node: '>=20.9.0'}
     cpu: [riscv64]
     os: [linux]
 
-  '@img/sharp-linux-s390x@0.35.3':
-    resolution: {integrity: sha512-KgAxQ0DxpNOq1rG2t5cgTgShJFGSuU7XO45cqC+1NVOuZnP6tlgZRuSYOfNupGkHID0o3cJOsw4DVeJpMovcGw==}
+  '@img/sharp-linux-s390x@0.35.4':
+    resolution: {integrity: sha512-RY0JFY8Fd6RonCBtHz+DvadaPkXDSI1AUn6yWL9TipqkZ1vY8w8evqdgyDFnkm4/K1ve1TvZiaePP5oSd4+WVQ==}
     engines: {node: '>=20.9.0'}
     cpu: [s390x]
     os: [linux]
 
-  '@img/sharp-linux-x64@0.35.3':
-    resolution: {integrity: sha512-8pqvxubL2PGdhlPy6GLqzDYMUjyRmKAwKHYKixpdJYBUK7PJ0C029XdsnpFIdgRZG68fZiGdHVWcKPvtiPB4cA==}
+  '@img/sharp-linux-x64@0.35.4':
+    resolution: {integrity: sha512-9qvvEAuk8k89TfWUoX2htWjbAMX8p+NxCppjpcg5k6xMsjhBQPTsoIh36h9Qde4WRuGpJeYnOjdosDn/cnv+OA==}
     engines: {node: '>=20.9.0'}
     cpu: [x64]
     os: [linux]
 
-  '@img/sharp-linuxmusl-arm64@0.35.3':
-    resolution: {integrity: sha512-Vz0iQjzzcSX3HCbfwFfCSG/9SCIqyO0mH2sXyiHaAYfBk0cRsCWXRyQYX0ovCK/PAQBbTzQ0dsPQHh5MAFL59w==}
+  '@img/sharp-linuxmusl-arm64@0.35.4':
+    resolution: {integrity: sha512-KB5jxpfWQTr0nc3xdHtWChdbifHrBGsd2SM62Eyxrl8afikm+f5qGBU75SJIZBT/S1MC8XyacdlXBMSWq6OURA==}
     engines: {node: '>=20.9.0'}
     cpu: [arm64]
     os: [linux]
 
-  '@img/sharp-linuxmusl-x64@0.35.3':
-    resolution: {integrity: sha512-6O1NPKcDVj9QEdg7Hx549EX8U0rp6yXQERqru6yRN7fGBn32UvIRJUlWnk+8xDCiG76hXVBbX82NZ/ZKr0euIg==}
+  '@img/sharp-linuxmusl-x64@0.35.4':
+    resolution: {integrity: sha512-f+eZJZIQNEEd26RPSW+76chwOf1XtA2Y/O+5ocVyLliHkeih3e+jhLVBdNTd2rS3IbNXK8+ug93Vf5ZXtF5Lxg==}
     engines: {node: '>=20.9.0'}
     cpu: [x64]
     os: [linux]
 
-  '@img/sharp-wasm32@0.35.3':
-    resolution: {integrity: sha512-cZ0XkcYGpHZkqW6iCkqTcmUC0CD9DhD5d/qeZlZkfRBn6GnHniZXLUo5+9xw8Iv76YE6LQFN9YNBlKREcCG76w==}
+  '@img/sharp-wasm32@0.35.4':
+    resolution: {integrity: sha512-zQnl4Kwp7Q6NHsENtU2T/00Zi+w3AQNwz3+UaTyVBy2FpXrzXzGjndpK61onhZjRtRpQXxCTeqw19bVyXOh7jA==}
     engines: {node: '>=20.9.0'}
 
-  '@img/sharp-webcontainers-wasm32@0.35.3':
-    resolution: {integrity: sha512-2rnq7bX3NzeR2T4YWgz8qiG4h3TSdMe+vN1iQXpJleSJ3SM5zQ8Fy2SyyXAWlbxpEZ2Y+Z4u1BePgJEYbSy80Q==}
+  '@img/sharp-webcontainers-wasm32@0.35.4':
+    resolution: {integrity: sha512-ESfNkywmCfPNyaZjxooddJQiQ+l/nTpGEOGthxiLnIHXC/CmcBixnfwUleX9mCz9ovrUUvKMap/pm8RYbzfwaA==}
     engines: {node: '>=20.9.0'}
     cpu: [wasm32]
 
-  '@img/sharp-win32-arm64@0.35.3':
-    resolution: {integrity: sha512-4bPwFdMbeC4JQ8L8LOyWp6nsHcboP5fxkp6iPOXz2Vg49R42TuMs2whkJ5OAP4/Ul035qOzy0AecOF9VOscn4w==}
+  '@img/sharp-win32-arm64@0.35.4':
+    resolution: {integrity: sha512-iNdlBX9gLVvqe2I3uIJSIKTq6wckP/DYxZtcqxm09x5Gi24DnFBmPAWZmr60ZyYMG0xlzo6goG3670ar+RXvRw==}
     engines: {node: '>=20.9.0'}
     cpu: [arm64]
     os: [win32]
 
-  '@img/sharp-win32-ia32@0.35.3':
-    resolution: {integrity: sha512-r53mXsBN6lFUDiST764SvgwUdHAqM4rPAiDzAmf4fLoB6X/rkfyTrLCg6+g17wJJiCmB3JYgHuUldCWUIRFSXw==}
+  '@img/sharp-win32-ia32@0.35.4':
+    resolution: {integrity: sha512-kqRsbaa5CS6KHlpxnN7WhE6vAAugXyZButpRdvDWetlv6Qv4N9WTcrWzF7tXfB9T7MsoadqdI8hmwLq6UlLvtw==}
     engines: {node: ^20.9.0}
     cpu: [ia32]
     os: [win32]
 
-  '@img/sharp-win32-x64@0.35.3':
-    resolution: {integrity: sha512-D4y1vNeZrIIJCN+uHaWVtH86B+aCrdMYYjicy9pXHvbGZeGYLLSd3wdVuC37FxVXlU1ARsk84eKWfWMXGYEqvA==}
+  '@img/sharp-win32-x64@0.35.4':
+    resolution: {integrity: sha512-XtmnYhBcrORsJ4XJngyzr/EWP0hRZLAZRFaApdKuviyqF78+ylxh2y06ZmtULAMOnObJ3ucpN0AcwSWnMowTRg==}
     engines: {node: '>=20.9.0'}
     cpu: [x64]
     os: [win32]
@@ -1888,53 +1891,53 @@ packages:
   '@next/env@13.5.11':
     resolution: {integrity: sha512-fbb2C7HChgM7CemdCY+y3N1n8pcTKdqtQLbC7/EQtPdLvlMUT9JX/dBYl8MMZAtYG4uVMyPFHXckb68q/NRwqg==}
 
-  '@next/env@16.3.0':
-    resolution: {integrity: sha512-o9r1S0BNiNreHP9Vs+Qnqd9kviDkJh8xIACY7UFZSmiGbbQRzPBBosvHzAU4TULHOIuOj/18RSsyz2qrREmIFw==}
+  '@next/env@16.3.4':
+    resolution: {integrity: sha512-cjWZnUUa6jZq2kFaNe/ZyJdZonOZ/QoN0Zka2nz/FLOrfx14pQuM9c5RaSVkWMqgdt4ksgPAMWPyHSs/CyV48Q==}
 
-  '@next/swc-darwin-arm64@16.3.0':
-    resolution: {integrity: sha512-55hpqq18bEVAlxedlTt3tFqZmKg2nUXT1kn1G/BGEy0R13h3LwtwHPVzzjG6P4LLeOHE32PFDQUVaJEWvBEZBw==}
+  '@next/swc-darwin-arm64@16.3.4':
+    resolution: {integrity: sha512-iBr3I5LZNk5/bgl5//iTgD2tcym14MX0Xo7fD//u9dYAEgGzza1y9oywluPtf74YnOswVdH1908aK9xVz7zQTw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
 
-  '@next/swc-darwin-x64@16.3.0':
-    resolution: {integrity: sha512-SOi96kSaF5T+0wW4koiM1bWzSPwjzTesC1p3df+FjdOi5LIQkBK/blxh7HdoKnNuI4PURF1OO7TZqtfnbWDSgw==}
+  '@next/swc-darwin-x64@16.3.4':
+    resolution: {integrity: sha512-2dpiSyl2Jw/NrBPaU2MAKGSa+2MR82pJIn4Sm5Rjr+gxAeuh0z158Su3Z2O8zn7UNNq+ej4bToed6RcRN/Lydg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [darwin]
 
-  '@next/swc-linux-arm64-gnu@16.3.0':
-    resolution: {integrity: sha512-P0gZAoPMF4dyTRzhmkV4PrqVzSOB6t4mC1oI3c4dqijJ+OVEVx5clIXAKR4/uQpsqw2KKM/0D5tVumcR2r5blg==}
+  '@next/swc-linux-arm64-gnu@16.3.4':
+    resolution: {integrity: sha512-+t+U8HZT+fApePCS5h89CSH3datz29MkzyfCn+6fpsZBG/oiEOhINcb9rtkv6sdpToLGFn2e6146NzaKCXkqrA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
 
-  '@next/swc-linux-arm64-musl@16.3.0':
-    resolution: {integrity: sha512-tXXGKJw0m37O0eKJARVTX/TheKPhz0QFVtVVZXmOig+9YKLQOSP6hvf2pxv5DO7CLEJyTHx3Pg043CDQkv1G4Q==}
+  '@next/swc-linux-arm64-musl@16.3.4':
+    resolution: {integrity: sha512-mx03GNs1ocQA5JQ4FxDMmIsNkdrZh8cuezKCrId28e5/gIPU/l7Kcy2+vmCCzdjnnmXJy+iOAu+7K0QppO6Urg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
 
-  '@next/swc-linux-x64-gnu@16.3.0':
-    resolution: {integrity: sha512-pjGxK5EY7yWml78ALejFkWmgHsU7wbFQrISiugpH6FbUJhgEvw3xFZ/EBAtLl7QtL0WdQKiG9eWJ3mOKGTukHw==}
+  '@next/swc-linux-x64-gnu@16.3.4':
+    resolution: {integrity: sha512-YIhGY6fSMfha52bnVxnzc9zaVBzJg+cqQTOD8tXIBSx4fuv0pVMxQTE0PaS59YhnMOiYiG09IMwxJAf/CFm/Dw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
 
-  '@next/swc-linux-x64-musl@16.3.0':
-    resolution: {integrity: sha512-sjo++Xx+lomlPs3HRsHWhVDyGG6ms1kGW5EtHLERdII8AyG1i+f6aq68xHREO6AEMlhjTNEWBSmfJfqm9orf7g==}
+  '@next/swc-linux-x64-musl@16.3.4':
+    resolution: {integrity: sha512-+eaaX6axpDb0yF1GCpiERe6njplvdC+nks/fKfcHu3XPGRrald8P3/X7yv7QLdjA51knnxwl9pxdIJsg+w1L+Q==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
 
-  '@next/swc-win32-arm64-msvc@16.3.0':
-    resolution: {integrity: sha512-C5JSgiO54wURdaxdEUIXqkz04uMqC9UmPX1gtDrV/5Tf1UowdWYI8uA5hfFbPolTlp0q4KZ60xlHePNibf0VIw==}
+  '@next/swc-win32-arm64-msvc@16.3.4':
+    resolution: {integrity: sha512-0jcXW7Xs/uzICrmgV3MhDYDeRy++1CqnpDIerlPIqYO4bhzB4WNbX/aRnQclustsAyTkFKB0z6rbcjmNg5tR8A==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [win32]
 
-  '@next/swc-win32-x64-msvc@16.3.0':
-    resolution: {integrity: sha512-fDOggsweNb5SSw0ZKVk6U+gxSyGFFlIBY/LBc1r8GUj4u/6t6oArL+Pmkg0MBnsgR+KkdsURilVH4F3GXUGepA==}
+  '@next/swc-win32-x64-msvc@16.3.4':
+    resolution: {integrity: sha512-vvBzwu1pYQCp92maZCFCIw/XgOTMR5tur9GjakwIo2cmwRTMKajRZZDS9+e4KsUZWKu1E007WUeAFXRRjZeuzw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
@@ -2413,11 +2416,11 @@ packages:
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
-  '@swc/helpers@0.5.15':
-    resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
-
   '@swc/helpers@0.5.21':
     resolution: {integrity: sha512-jI/VAmtdjB/RnI8GTnokyX7Ug8c+g+ffD6QRLa6XQewtnGyukKkKSk3wLTM3b5cjt1jNh9x0jfVlagdN2gDKQg==}
+
+  '@swc/helpers@0.5.23':
+    resolution: {integrity: sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==}
 
   '@tailwindcss/node@4.3.0':
     resolution: {integrity: sha512-aFb4gUhFOgdh9AXo4IzBEOzBkkAxm9VigwDJnMIYv3lcfXCJVesNfbEaBl4BNgVRyid92AmdviqwBUBRKSeY3g==}
@@ -3054,8 +3057,8 @@ packages:
   '@webassemblyjs/wast-printer@1.14.1':
     resolution: {integrity: sha512-kPSSXE6De1XOR820C90RIo2ogvZG+c3KiHzqUoO/F34Y2shGzesfqv7o57xrxovZJH/MetF5UjroJ/R/3isoiw==}
 
-  '@xmldom/xmldom@0.9.10':
-    resolution: {integrity: sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==}
+  '@xmldom/xmldom@0.9.12':
+    resolution: {integrity: sha512-5AXjrcMClTryPe9LgZrygpB1lj7s0S9E0+W+AHaVKAVyHanafK86iPSvG5xHVSp/jC+VH1UXu0TAEmY279xH7A==}
     engines: {node: '>=14.6'}
 
   '@xtuc/ieee754@1.2.0':
@@ -3252,11 +3255,6 @@ packages:
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
-  baseline-browser-mapping@2.10.32:
-    resolution: {integrity: sha512-wbPvpyjJPC0zdfdKXxqEL3Ea+bOMD/87X4lftiJkkaBiuG6ALQy1SLmEd7BSmVCuwCQsBrCamgBoLyfFDD1EPg==}
-    engines: {node: '>=6.0.0'}
-    hasBin: true
-
   baseline-browser-mapping@2.11.20:
     resolution: {integrity: sha512-H0ulySigv6icDJ1F7SjtdCD6PrhTpdYCmP0CactWy1+ekh0AFd0o1Wn5T8b+hnTmdBx19u9yhL6wvCylXMY7zw==}
     engines: {node: '>=6.0.0'}
@@ -3376,9 +3374,6 @@ packages:
   camelcase@6.3.0:
     resolution: {integrity: sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==}
     engines: {node: '>=10'}
-
-  caniuse-lite@1.0.30001793:
-    resolution: {integrity: sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA==}
 
   caniuse-lite@1.0.30001810:
     resolution: {integrity: sha512-TITQPUkaz+aVk5GL6NhOdwk1aEaNTSDPsGFWrTuhKGtjTF70jL/Oht2W4c6rXUe5fu7Ie19VIahAXHIIiWWNeg==}
@@ -4693,8 +4688,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@4.3.1:
-    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
+  js-yaml@4.3.2:
+    resolution: {integrity: sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==}
     hasBin: true
 
   jsesc@3.1.0:
@@ -5283,8 +5278,8 @@ packages:
       react: ^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc
       react-dom: ^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc
 
-  next@16.3.0:
-    resolution: {integrity: sha512-NEdGOzH+08eTXMUp9UYkA99Nhi5N6Thrhc1jgFOQgfgnGK/dA2hRwBpXep+exdFQrnwlRf/3Wixyp8lLBUpE2A==}
+  next@16.3.4:
+    resolution: {integrity: sha512-/Ztf6CeRH+ejEXUrYtqI4gkS66eFIHuSwqi60RgcpWKodxFZx2/dqVCMKBwILfAHXQ+F1b1vAudgj3mnxqtoIA==}
     engines: {node: '>=20.9.0'}
     hasBin: true
     peerDependencies:
@@ -5985,8 +5980,8 @@ packages:
   setprototypeof@1.2.0:
     resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
 
-  sharp@0.35.3:
-    resolution: {integrity: sha512-ej0zVHuZGHCiABXcNxeYhpRnPNPAcvbG8RMdBAhDAxLKkCRVSpK3Iyu7qbqw3JMzoj0REeM6f3tJLtVwl0023Q==}
+  sharp@0.35.4:
+    resolution: {integrity: sha512-n++8XWcj+jCOr2IOl7h8LbKnGBDY4aPbmprMONBNFdn0ImXqpGVv5zliDs0V9HbmbCQLpbuo2ej9rAoOQTvMDA==}
     engines: {node: '>=20.9.0'}
     peerDependencies:
       '@types/node': '*'
@@ -7242,108 +7237,108 @@ snapshots:
   '@img/colour@1.1.0':
     optional: true
 
-  '@img/sharp-darwin-arm64@0.35.3':
+  '@img/sharp-darwin-arm64@0.35.4':
     optionalDependencies:
-      '@img/sharp-libvips-darwin-arm64': 1.3.2
+      '@img/sharp-libvips-darwin-arm64': 1.3.3
     optional: true
 
-  '@img/sharp-darwin-x64@0.35.3':
+  '@img/sharp-darwin-x64@0.35.4':
     optionalDependencies:
-      '@img/sharp-libvips-darwin-x64': 1.3.2
+      '@img/sharp-libvips-darwin-x64': 1.3.3
     optional: true
 
-  '@img/sharp-freebsd-wasm32@0.35.3':
+  '@img/sharp-freebsd-wasm32@0.35.4':
     dependencies:
-      '@img/sharp-wasm32': 0.35.3
+      '@img/sharp-wasm32': 0.35.4
     optional: true
 
-  '@img/sharp-libvips-darwin-arm64@1.3.2':
+  '@img/sharp-libvips-darwin-arm64@1.3.3':
     optional: true
 
-  '@img/sharp-libvips-darwin-x64@1.3.2':
+  '@img/sharp-libvips-darwin-x64@1.3.3':
     optional: true
 
-  '@img/sharp-libvips-linux-arm64@1.3.2':
+  '@img/sharp-libvips-linux-arm64@1.3.3':
     optional: true
 
-  '@img/sharp-libvips-linux-arm@1.3.2':
+  '@img/sharp-libvips-linux-arm@1.3.3':
     optional: true
 
-  '@img/sharp-libvips-linux-ppc64@1.3.2':
+  '@img/sharp-libvips-linux-ppc64@1.3.3':
     optional: true
 
-  '@img/sharp-libvips-linux-riscv64@1.3.2':
+  '@img/sharp-libvips-linux-riscv64@1.3.3':
     optional: true
 
-  '@img/sharp-libvips-linux-s390x@1.3.2':
+  '@img/sharp-libvips-linux-s390x@1.3.3':
     optional: true
 
-  '@img/sharp-libvips-linux-x64@1.3.2':
+  '@img/sharp-libvips-linux-x64@1.3.3':
     optional: true
 
-  '@img/sharp-libvips-linuxmusl-arm64@1.3.2':
+  '@img/sharp-libvips-linuxmusl-arm64@1.3.3':
     optional: true
 
-  '@img/sharp-libvips-linuxmusl-x64@1.3.2':
+  '@img/sharp-libvips-linuxmusl-x64@1.3.3':
     optional: true
 
-  '@img/sharp-linux-arm64@0.35.3':
+  '@img/sharp-linux-arm64@0.35.4':
     optionalDependencies:
-      '@img/sharp-libvips-linux-arm64': 1.3.2
+      '@img/sharp-libvips-linux-arm64': 1.3.3
     optional: true
 
-  '@img/sharp-linux-arm@0.35.3':
+  '@img/sharp-linux-arm@0.35.4':
     optionalDependencies:
-      '@img/sharp-libvips-linux-arm': 1.3.2
+      '@img/sharp-libvips-linux-arm': 1.3.3
     optional: true
 
-  '@img/sharp-linux-ppc64@0.35.3':
+  '@img/sharp-linux-ppc64@0.35.4':
     optionalDependencies:
-      '@img/sharp-libvips-linux-ppc64': 1.3.2
+      '@img/sharp-libvips-linux-ppc64': 1.3.3
     optional: true
 
-  '@img/sharp-linux-riscv64@0.35.3':
+  '@img/sharp-linux-riscv64@0.35.4':
     optionalDependencies:
-      '@img/sharp-libvips-linux-riscv64': 1.3.2
+      '@img/sharp-libvips-linux-riscv64': 1.3.3
     optional: true
 
-  '@img/sharp-linux-s390x@0.35.3':
+  '@img/sharp-linux-s390x@0.35.4':
     optionalDependencies:
-      '@img/sharp-libvips-linux-s390x': 1.3.2
+      '@img/sharp-libvips-linux-s390x': 1.3.3
     optional: true
 
-  '@img/sharp-linux-x64@0.35.3':
+  '@img/sharp-linux-x64@0.35.4':
     optionalDependencies:
-      '@img/sharp-libvips-linux-x64': 1.3.2
+      '@img/sharp-libvips-linux-x64': 1.3.3
     optional: true
 
-  '@img/sharp-linuxmusl-arm64@0.35.3':
+  '@img/sharp-linuxmusl-arm64@0.35.4':
     optionalDependencies:
-      '@img/sharp-libvips-linuxmusl-arm64': 1.3.2
+      '@img/sharp-libvips-linuxmusl-arm64': 1.3.3
     optional: true
 
-  '@img/sharp-linuxmusl-x64@0.35.3':
+  '@img/sharp-linuxmusl-x64@0.35.4':
     optionalDependencies:
-      '@img/sharp-libvips-linuxmusl-x64': 1.3.2
+      '@img/sharp-libvips-linuxmusl-x64': 1.3.3
     optional: true
 
-  '@img/sharp-wasm32@0.35.3':
+  '@img/sharp-wasm32@0.35.4':
     dependencies:
       '@emnapi/runtime': 1.11.3
     optional: true
 
-  '@img/sharp-webcontainers-wasm32@0.35.3':
+  '@img/sharp-webcontainers-wasm32@0.35.4':
     dependencies:
-      '@img/sharp-wasm32': 0.35.3
+      '@img/sharp-wasm32': 0.35.4
     optional: true
 
-  '@img/sharp-win32-arm64@0.35.3':
+  '@img/sharp-win32-arm64@0.35.4':
     optional: true
 
-  '@img/sharp-win32-ia32@0.35.3':
+  '@img/sharp-win32-ia32@0.35.4':
     optional: true
 
-  '@img/sharp-win32-x64@0.35.3':
+  '@img/sharp-win32-x64@0.35.4':
     optional: true
 
   '@internationalized/date@3.12.1':
@@ -7557,7 +7552,7 @@ snapshots:
     dependencies:
       '@csstools/postcss-is-pseudo-class': 5.0.3(postcss@8.5.23)
       cssesc: 3.0.0
-      js-yaml: 4.3.1
+      js-yaml: 4.3.2
       lodash.kebabcase: 4.1.1
       markdown-it: 14.3.0
       markdown-it-front-matter: 0.2.4
@@ -7730,30 +7725,30 @@ snapshots:
 
   '@next/env@13.5.11': {}
 
-  '@next/env@16.3.0': {}
+  '@next/env@16.3.4': {}
 
-  '@next/swc-darwin-arm64@16.3.0':
+  '@next/swc-darwin-arm64@16.3.4':
     optional: true
 
-  '@next/swc-darwin-x64@16.3.0':
+  '@next/swc-darwin-x64@16.3.4':
     optional: true
 
-  '@next/swc-linux-arm64-gnu@16.3.0':
+  '@next/swc-linux-arm64-gnu@16.3.4':
     optional: true
 
-  '@next/swc-linux-arm64-musl@16.3.0':
+  '@next/swc-linux-arm64-musl@16.3.4':
     optional: true
 
-  '@next/swc-linux-x64-gnu@16.3.0':
+  '@next/swc-linux-x64-gnu@16.3.4':
     optional: true
 
-  '@next/swc-linux-x64-musl@16.3.0':
+  '@next/swc-linux-x64-musl@16.3.4':
     optional: true
 
-  '@next/swc-win32-arm64-msvc@16.3.0':
+  '@next/swc-win32-arm64-msvc@16.3.4':
     optional: true
 
-  '@next/swc-win32-x64-msvc@16.3.0':
+  '@next/swc-win32-x64-msvc@16.3.4':
     optional: true
 
   '@nodelib/fs.scandir@2.1.5':
@@ -8040,11 +8035,11 @@ snapshots:
       '@rspack/binding-win32-ia32-msvc': 1.7.11
       '@rspack/binding-win32-x64-msvc': 1.7.11
 
-  '@rspack/cli@1.7.11(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@types/express@4.17.25)(webpack@5.107.1(postcss@8.5.23))':
+  '@rspack/cli@1.7.11(@rspack/core@1.7.11(@swc/helpers@0.5.23))(@types/express@4.17.25)(webpack@5.107.1(postcss@8.5.23))':
     dependencies:
       '@discoveryjs/json-ext': 0.5.7
-      '@rspack/core': 1.7.11(@swc/helpers@0.5.21)
-      '@rspack/dev-server': 1.1.5(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@types/express@4.17.25)(webpack@5.107.1(postcss@8.5.23))
+      '@rspack/core': 1.7.11(@swc/helpers@0.5.23)
+      '@rspack/dev-server': 1.1.5(@rspack/core@1.7.11(@swc/helpers@0.5.23))(@types/express@4.17.25)(webpack@5.107.1(postcss@8.5.23))
       exit-hook: 4.0.0
       webpack-bundle-analyzer: 4.10.2
     transitivePeerDependencies:
@@ -8056,17 +8051,17 @@ snapshots:
       - webpack
       - webpack-cli
 
-  '@rspack/core@1.7.11(@swc/helpers@0.5.21)':
+  '@rspack/core@1.7.11(@swc/helpers@0.5.23)':
     dependencies:
       '@module-federation/runtime-tools': 0.22.0
       '@rspack/binding': 1.7.11
       '@rspack/lite-tapable': 1.1.0
     optionalDependencies:
-      '@swc/helpers': 0.5.21
+      '@swc/helpers': 0.5.23
 
-  '@rspack/dev-server@1.1.5(@rspack/core@1.7.11(@swc/helpers@0.5.21))(@types/express@4.17.25)(webpack@5.107.1(postcss@8.5.23))':
+  '@rspack/dev-server@1.1.5(@rspack/core@1.7.11(@swc/helpers@0.5.23))(@types/express@4.17.25)(webpack@5.107.1(postcss@8.5.23))':
     dependencies:
-      '@rspack/core': 1.7.11(@swc/helpers@0.5.21)
+      '@rspack/core': 1.7.11(@swc/helpers@0.5.23)
       chokidar: 3.6.0
       http-proxy-middleware: 2.0.9(@types/express@4.17.25)
       p-retry: 6.2.1
@@ -8203,11 +8198,11 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
-  '@swc/helpers@0.5.15':
+  '@swc/helpers@0.5.21':
     dependencies:
       tslib: 2.8.1
 
-  '@swc/helpers@0.5.21':
+  '@swc/helpers@0.5.23':
     dependencies:
       tslib: 2.8.1
 
@@ -8299,7 +8294,7 @@ snapshots:
       '@textlint/types': 15.7.1
       chalk: 4.1.2
       debug: 4.4.3(supports-color@8.1.1)
-      js-yaml: 4.3.1
+      js-yaml: 4.3.2
       lodash: 4.18.1
       pluralize: 2.0.0
       string-width: 4.2.3
@@ -8888,7 +8883,7 @@ snapshots:
       '@webassemblyjs/ast': 1.14.1
       '@xtuc/long': 4.2.2
 
-  '@xmldom/xmldom@0.9.10': {}
+  '@xmldom/xmldom@0.9.12': {}
 
   '@xtuc/ieee754@1.2.0': {}
 
@@ -9039,8 +9034,6 @@ snapshots:
 
   base64-js@1.5.1:
     optional: true
-
-  baseline-browser-mapping@2.10.32: {}
 
   baseline-browser-mapping@2.11.20: {}
 
@@ -9194,8 +9187,6 @@ snapshots:
   callsites@3.1.0: {}
 
   camelcase@6.3.0: {}
-
-  caniuse-lite@1.0.30001793: {}
 
   caniuse-lite@1.0.30001810: {}
 
@@ -9379,7 +9370,7 @@ snapshots:
     dependencies:
       env-paths: 2.2.1
       import-fresh: 3.3.1
-      js-yaml: 4.3.1
+      js-yaml: 4.3.2
       parse-json: 5.2.0
     optionalDependencies:
       typescript: 5.9.3
@@ -10694,7 +10685,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@4.3.1:
+  js-yaml@4.3.2:
     dependencies:
       argparse: 2.0.1
 
@@ -11508,7 +11499,7 @@ snapshots:
       glob: 10.5.0
       he: 1.2.0
       is-path-inside: 3.0.3
-      js-yaml: 4.3.1
+      js-yaml: 4.3.2
       log-symbols: 4.1.0
       minimatch: 9.0.9
       ms: 2.1.3
@@ -11551,51 +11542,51 @@ snapshots:
 
   netmask@2.1.1: {}
 
-  next-sitemap@4.2.3(next@16.3.0(@types/node@20.19.41)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)):
+  next-sitemap@4.2.3(next@16.3.4(@types/node@20.19.41)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)):
     dependencies:
       '@corex/deepmerge': 4.0.43
       '@next/env': 13.5.11
       fast-glob: 3.3.3
       minimist: 1.2.8
-      next: 16.3.0(@types/node@20.19.41)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      next: 16.3.4(@types/node@20.19.41)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
 
   next-themes@0.4.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  next@16.3.0(@types/node@20.19.41)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  next@16.3.4(@types/node@20.19.41)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
-      '@next/env': 16.3.0
-      '@swc/helpers': 0.5.15
-      baseline-browser-mapping: 2.10.32
-      caniuse-lite: 1.0.30001793
+      '@next/env': 16.3.4
+      '@swc/helpers': 0.5.23
+      baseline-browser-mapping: 2.11.20
+      caniuse-lite: 1.0.30001810
       postcss: 8.5.23
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       styled-jsx: 5.1.6(react@18.3.1)
     optionalDependencies:
-      '@next/swc-darwin-arm64': 16.3.0
-      '@next/swc-darwin-x64': 16.3.0
-      '@next/swc-linux-arm64-gnu': 16.3.0
-      '@next/swc-linux-arm64-musl': 16.3.0
-      '@next/swc-linux-x64-gnu': 16.3.0
-      '@next/swc-linux-x64-musl': 16.3.0
-      '@next/swc-win32-arm64-msvc': 16.3.0
-      '@next/swc-win32-x64-msvc': 16.3.0
-      sharp: 0.35.3(@types/node@20.19.41)
+      '@next/swc-darwin-arm64': 16.3.4
+      '@next/swc-darwin-x64': 16.3.4
+      '@next/swc-linux-arm64-gnu': 16.3.4
+      '@next/swc-linux-arm64-musl': 16.3.4
+      '@next/swc-linux-x64-gnu': 16.3.4
+      '@next/swc-linux-x64-musl': 16.3.4
+      '@next/swc-win32-arm64-msvc': 16.3.4
+      '@next/swc-win32-x64-msvc': 16.3.4
+      sharp: 0.35.4(@types/node@20.19.41)
     transitivePeerDependencies:
       - '@babel/core'
       - '@types/node'
       - babel-plugin-macros
 
-  nextra-theme-docs@4.6.0(@types/react@18.3.29)(next@16.3.0(@types/node@20.19.41)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(nextra@4.6.0(next@16.3.0(@types/node@20.19.41)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(use-sync-external-store@1.6.0(react@18.3.1)):
+  nextra-theme-docs@4.6.0(@types/react@18.3.29)(next@16.3.4(@types/node@20.19.41)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(nextra@4.6.0(next@16.3.4(@types/node@20.19.41)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(use-sync-external-store@1.6.0(react@18.3.1)):
     dependencies:
       '@headlessui/react': 2.2.10(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       clsx: 2.1.1
-      next: 16.3.0(@types/node@20.19.41)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      next: 16.3.4(@types/node@20.19.41)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       next-themes: 0.4.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      nextra: 4.6.0(next@16.3.0(@types/node@20.19.41)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
+      nextra: 4.6.0(next@16.3.4(@types/node@20.19.41)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
       react: 18.3.1
       react-compiler-runtime: 19.1.0-rc.3(react@18.3.1)
       react-dom: 18.3.1(react@18.3.1)
@@ -11607,7 +11598,7 @@ snapshots:
       - immer
       - use-sync-external-store
 
-  nextra@4.6.0(next@16.3.0(@types/node@20.19.41)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3):
+  nextra@4.6.0(next@16.3.4(@types/node@20.19.41)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3):
     dependencies:
       '@formatjs/intl-localematcher': 0.6.2
       '@headlessui/react': 2.2.10(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -11628,7 +11619,7 @@ snapshots:
       mdast-util-gfm: 3.1.0
       mdast-util-to-hast: 13.2.1
       negotiator: 1.0.0
-      next: 16.3.0(@types/node@20.19.41)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      next: 16.3.4(@types/node@20.19.41)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react: 18.3.1
       react-compiler-runtime: 19.1.0-rc.3(react@18.3.1)
       react-dom: 18.3.1(react@18.3.1)
@@ -12067,7 +12058,7 @@ snapshots:
   rc-config-loader@4.1.4:
     dependencies:
       debug: 4.4.3(supports-color@8.1.1)
-      js-yaml: 4.3.1
+      js-yaml: 4.3.2
       json5: 2.2.3
       require-from-string: 2.0.2
     transitivePeerDependencies:
@@ -12548,37 +12539,37 @@ snapshots:
 
   setprototypeof@1.2.0: {}
 
-  sharp@0.35.3(@types/node@20.19.41):
+  sharp@0.35.4(@types/node@20.19.41):
     dependencies:
       '@img/colour': 1.1.0
       detect-libc: 2.1.2
       semver: 7.8.5
     optionalDependencies:
-      '@img/sharp-darwin-arm64': 0.35.3
-      '@img/sharp-darwin-x64': 0.35.3
-      '@img/sharp-freebsd-wasm32': 0.35.3
-      '@img/sharp-libvips-darwin-arm64': 1.3.2
-      '@img/sharp-libvips-darwin-x64': 1.3.2
-      '@img/sharp-libvips-linux-arm': 1.3.2
-      '@img/sharp-libvips-linux-arm64': 1.3.2
-      '@img/sharp-libvips-linux-ppc64': 1.3.2
-      '@img/sharp-libvips-linux-riscv64': 1.3.2
-      '@img/sharp-libvips-linux-s390x': 1.3.2
-      '@img/sharp-libvips-linux-x64': 1.3.2
-      '@img/sharp-libvips-linuxmusl-arm64': 1.3.2
-      '@img/sharp-libvips-linuxmusl-x64': 1.3.2
-      '@img/sharp-linux-arm': 0.35.3
-      '@img/sharp-linux-arm64': 0.35.3
-      '@img/sharp-linux-ppc64': 0.35.3
-      '@img/sharp-linux-riscv64': 0.35.3
-      '@img/sharp-linux-s390x': 0.35.3
-      '@img/sharp-linux-x64': 0.35.3
-      '@img/sharp-linuxmusl-arm64': 0.35.3
-      '@img/sharp-linuxmusl-x64': 0.35.3
-      '@img/sharp-webcontainers-wasm32': 0.35.3
-      '@img/sharp-win32-arm64': 0.35.3
-      '@img/sharp-win32-ia32': 0.35.3
-      '@img/sharp-win32-x64': 0.35.3
+      '@img/sharp-darwin-arm64': 0.35.4
+      '@img/sharp-darwin-x64': 0.35.4
+      '@img/sharp-freebsd-wasm32': 0.35.4
+      '@img/sharp-libvips-darwin-arm64': 1.3.3
+      '@img/sharp-libvips-darwin-x64': 1.3.3
+      '@img/sharp-libvips-linux-arm': 1.3.3
+      '@img/sharp-libvips-linux-arm64': 1.3.3
+      '@img/sharp-libvips-linux-ppc64': 1.3.3
+      '@img/sharp-libvips-linux-riscv64': 1.3.3
+      '@img/sharp-libvips-linux-s390x': 1.3.3
+      '@img/sharp-libvips-linux-x64': 1.3.3
+      '@img/sharp-libvips-linuxmusl-arm64': 1.3.3
+      '@img/sharp-libvips-linuxmusl-x64': 1.3.3
+      '@img/sharp-linux-arm': 0.35.4
+      '@img/sharp-linux-arm64': 0.35.4
+      '@img/sharp-linux-ppc64': 0.35.4
+      '@img/sharp-linux-riscv64': 0.35.4
+      '@img/sharp-linux-s390x': 0.35.4
+      '@img/sharp-linux-x64': 0.35.4
+      '@img/sharp-linuxmusl-arm64': 0.35.4
+      '@img/sharp-linuxmusl-x64': 0.35.4
+      '@img/sharp-webcontainers-wasm32': 0.35.4
+      '@img/sharp-win32-arm64': 0.35.4
+      '@img/sharp-win32-ia32': 0.35.4
+      '@img/sharp-win32-x64': 0.35.4
       '@types/node': 20.19.41
     optional: true
 
@@ -12728,7 +12719,7 @@ snapshots:
 
   speech-rule-engine@4.1.4:
     dependencies:
-      '@xmldom/xmldom': 0.9.10
+      '@xmldom/xmldom': 0.9.12
       commander: 13.1.0
       wicked-good-xpath: 1.3.0
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -340,6 +340,9 @@ importers:
 
   packages/ttsc:
     dependencies:
+      acorn:
+        specifier: 8.16.0
+        version: 8.16.0
       cjs-module-lexer:
         specifier: 2.2.1
         version: 2.2.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -339,6 +339,10 @@ importers:
   packages/strip: {}
 
   packages/ttsc:
+    dependencies:
+      cjs-module-lexer:
+        specifier: 2.2.1
+        version: 2.2.1
     devDependencies:
       '@types/node':
         specifier: catalog:utils
@@ -3429,6 +3433,9 @@ packages:
     resolution: {integrity: sha512-9gYlLtS6tStdRWzrtXaTMnqcM4dudNegMXJxkR0I/CXObHalYeYcAMPrL19eroNZHtJ8DQmu1E+ZNOYu/IXMXw==}
     peerDependencies:
       devtools-protocol: '*'
+
+  cjs-module-lexer@2.2.1:
+    resolution: {integrity: sha512-Ca8swihM+/4yKecYHY52kgJd300hi2lADU/a1RxNTRe+RJ9jvqQlESpbz9DnG9mowez8qwXHB8qYdIUw9e+F5Q==}
 
   client-only@0.0.1:
     resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
@@ -9259,6 +9266,8 @@ snapshots:
       devtools-protocol: 0.0.1608973
       mitt: 3.0.1
       zod: 3.25.76
+
+  cjs-module-lexer@2.2.1: {}
 
   client-only@0.0.1: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -19,6 +19,10 @@ overrides:
   browserslist: 4.28.8
   # fast-uri 3.1.5 has four URI parsing advisories. Pin the patched v3 release until every transitive consumer resolves it naturally.
   fast-uri: 3.1.7
+  # Patched transitive parsers and image processing for the website and build tools.
+  "@xmldom/xmldom": 0.9.12
+  sharp: 0.35.4
+  "js-yaml@^4": 4.3.2
 catalogs:
   typescript:
     typescript: ^7.0.2

--- a/scripts/ci/dependency-audit.cjs
+++ b/scripts/ci/dependency-audit.cjs
@@ -42,6 +42,10 @@ const WAIVED = new Map([
     "GHSA-jmr9-qjv8-65gv",
     "extract-zip permits a malicious archive symlink to escape its destination, but no patched release exists. It reaches this workspace only through Puppeteer's browser downloader inside the website-only @marp-team/marp-cli build dependency. ttsc's slide build emits HTML from repository Markdown and does not download or extract an attacker-supplied browser archive.",
   ],
+  [
+    "GHSA-7pqw-9j4j-h8q3",
+    "extract-zip can write through a symlink followed by a same-name archive entry; no patched release exists. It has the same website-only Puppeteer browser-downloader path as GHSA-jmr9-qjv8-65gv. The slide build emits HTML from repository Markdown and does not extract an attacker-supplied archive.",
+  ],
 ]);
 
 function parseSummary(stdout) {

--- a/scripts/ci/dependency-audit.test.cjs
+++ b/scripts/ci/dependency-audit.test.cjs
@@ -129,6 +129,35 @@ test("the unpatched website browser-downloader advisory is explicit", () => {
   assert.match(outcome.message, /GHSA-jmr9-qjv8-65gv/);
 });
 
+test("both browser-downloader waivers expire independently when a fix appears", () => {
+  const ids = ["GHSA-jmr9-qjv8-65gv", "GHSA-7pqw-9j4j-h8q3"];
+  for (const fixed of [undefined, ...ids]) {
+    const advisories = Object.fromEntries(
+      ids.map((id, index) => [
+        index,
+        {
+          ...unfixable(id),
+          ...(id === fixed ? { patched_versions: ">=2.0.2" } : {}),
+        },
+      ]),
+    );
+    const outcome = evaluateAudit({
+      status: 1,
+      stdout: payload({ high: 2, advisories }),
+      stderr: "",
+    });
+    assert.equal(outcome.ok, fixed === undefined);
+    if (fixed === undefined) {
+      assert.match(outcome.message, /waived=2/);
+      for (const id of ids) assert.ok(outcome.message.includes(id));
+    } else {
+      assert.ok(outcome.message.includes(`blocking advisories: ${fixed}`));
+      assert.match(outcome.message, /waived=1/);
+      assert.match(outcome.message, /does not hold/);
+    }
+  }
+});
+
 test("a waiver stops applying the moment upstream publishes a fix", () => {
   const outcome = evaluateAudit({
     status: 1,
@@ -330,18 +359,22 @@ test("the lockfile excludes every campaign high or critical resolution", () => {
     "fast-uri@3.1.5:",
     "form-data@4.0.5:",
     "js-yaml@4.1.1:",
+    "js-yaml@4.3.1:",
     "linkify-it@5.0.0:",
     "nanoid@3.3.16:",
     "next@15.5.18:",
+    "next@16.3.0:",
     "postcss@8.4.31:",
     "postcss@8.5.15:",
     "sharp@0.34.5:",
+    "sharp@0.35.3:",
     "shell-quote@1.8.4:",
     "tmp@0.2.5:",
     "tmp@0.2.6:",
     "undici@7.25.0:",
     "vite@7.3.3:",
     "websocket-driver@0.7.4:",
+    "'@xmldom/xmldom@0.9.10':",
   ])
     assert.doesNotMatch(
       lockfile,

--- a/tests/test-ttsc/package.json
+++ b/tests/test-ttsc/package.json
@@ -15,6 +15,7 @@
     "@ttsc/testing": "workspace:*",
     "@types/node": "catalog:utils",
     "mocha": "^11",
+    "tslib": "2.8.1",
     "ttsc": "workspace:*",
     "typescript": "catalog:typescript"
   }

--- a/tests/test-ttsc/src/features/ttsx-runtime/test_ttsx_decorated_barrels_keep_nested_exports_with_emit_options.ts
+++ b/tests/test-ttsc/src/features/ttsx-runtime/test_ttsx_decorated_barrels_keep_nested_exports_with_emit_options.ts
@@ -1,0 +1,92 @@
+import { TestProject } from "@ttsc/testing";
+import assert from "node:assert/strict";
+import { createRequire } from "node:module";
+import path from "node:path";
+
+import {
+  STANDARD_DECORATOR_OUTPUT,
+  STANDARD_DECORATOR_SOURCE,
+} from "../../internal/ttsx-decorators";
+
+/**
+ * Verifies decorated barrels retain nested exports across compiler emit
+ * options.
+ *
+ * Owned output may rewrite .ts specifiers or qualify export helpers through
+ * tslib. Name discovery must understand that output without changing its
+ * values.
+ *
+ * 1. Re-export an owned barrel with rewriting/importHelpers independently enabled.
+ * 2. Exercise both an orphan and a project-owned decorated outer barrel.
+ * 3. Assert nested named exports and the original live CommonJS getter survive.
+ */
+export const test_ttsx_decorated_barrels_keep_nested_exports_with_emit_options =
+  () => {
+    const tslibRoot = path.dirname(
+      createRequire(import.meta.url).resolve("tslib/package.json"),
+    );
+    for (const owned of [false, true]) {
+      for (const rewrite of [false, true]) {
+        for (const helpers of [false, true]) {
+          const root = TestProject.createProject({
+            "package.json": '{"type":"module"}',
+            "tsconfig.json": TestProject.tsconfig({
+              target: "ES2022",
+              module: "esnext",
+              rootDir: "src",
+              outDir: "dist",
+            }),
+            "src/main.ts":
+              'const name: string = "dep"; const dep = await import(name); console.log(dep.actual, dep.nested, dep.default.nested); dep.change(); console.log(dep.default.nested); export {};',
+            "node_modules/dep/package.json":
+              '{"name":"dep","type":"commonjs","exports":"./index.ts"}',
+            ...(owned
+              ? {
+                  "node_modules/dep/tsconfig.json": TestProject.tsconfig(
+                    {
+                      target: "ESNext",
+                      module: "commonjs",
+                      rootDir: ".",
+                      outDir: "lib",
+                      importHelpers: helpers,
+                      rewriteRelativeImportExtensions: rewrite,
+                    },
+                    { include: ["index.ts"] },
+                  ),
+                }
+              : {}),
+            "node_modules/dep/index.ts":
+              STANDARD_DECORATOR_SOURCE + '\nexport * from "./values/entry";',
+            "node_modules/dep/values/tsconfig.json": TestProject.tsconfig(
+              {
+                target: "ES2022",
+                module: "commonjs",
+                rootDir: ".",
+                outDir: "lib",
+                importHelpers: helpers,
+                rewriteRelativeImportExtensions: rewrite,
+              },
+              { include: ["*.ts"] },
+            ),
+            "node_modules/dep/values/entry.ts": `export const actual = 17; export * from "./nested${rewrite ? ".ts" : ""}";`,
+            "node_modules/dep/values/nested.ts":
+              "export let nested = 42; export function change() { nested = 43; }",
+          });
+          TestProject.copyDirectory(
+            tslibRoot,
+            path.join(root, "node_modules/tslib"),
+          );
+          const result = TestProject.spawn(
+            TestProject.TTSX_BIN,
+            ["src/main.ts"],
+            { cwd: root },
+          );
+          assert.equal(result.status, 0, result.stderr);
+          assert.equal(
+            result.stdout.trim(),
+            STANDARD_DECORATOR_OUTPUT + "\n17 42 42\n43",
+          );
+        }
+      }
+    }
+  };

--- a/tests/test-ttsc/src/features/ttsx-runtime/test_ttsx_decorated_reexport_helpers_keep_nested_scope_names.ts
+++ b/tests/test-ttsc/src/features/ttsx-runtime/test_ttsx_decorated_reexport_helpers_keep_nested_scope_names.ts
@@ -1,0 +1,87 @@
+import { TestProject } from "@ttsc/testing";
+import assert from "node:assert/strict";
+import { createRequire } from "node:module";
+import path from "node:path";
+
+import {
+  STANDARD_DECORATOR_OUTPUT,
+  STANDARD_DECORATOR_SOURCE,
+} from "../../internal/ttsx-decorators";
+
+/**
+ * Verifies decorated modules retain helper re-export names in nested scopes.
+ *
+ * Node's lexer only lists top-level re-export helpers. The runtime previously
+ * recognized block/function helper calls too, and normalizing metadata must
+ * preserve those names while leaving conditional execution unchanged.
+ *
+ * 1. Put a tslib star helper at top level, in a block, an IIFE, or a static block.
+ * 2. Exercise both a decorated orphan and an owned middle module.
+ * 3. Assert ESM and CommonJS retain the same real re-export value.
+ */
+export const test_ttsx_decorated_reexport_helpers_keep_nested_scope_names =
+  () => {
+    const tslibRoot = path.dirname(
+      createRequire(import.meta.url).resolve("tslib/package.json"),
+    );
+    for (const shape of ["top", "block", "iife", "class"]) {
+      for (const middle of [false, true]) {
+        const statement = `tslib.__exportStar(require("${middle ? "./nested" : "./values/entry"}"), exports);`;
+        const wrapped =
+          shape === "block"
+            ? `if (true) {\n${statement}\n}`
+            : shape === "iife"
+              ? `(function () {\n${statement}\n})();`
+              : shape === "class"
+                ? `class ExportScope { static {\n${statement}\n} }`
+                : statement;
+        const helper =
+          'import * as tslib from "tslib";\ndeclare function require(name: string): unknown;\ndeclare const exports: any;\n' +
+          wrapped;
+        const root = TestProject.createProject({
+          "package.json": '{"type":"module"}',
+          "tsconfig.json": TestProject.tsconfig({
+            target: "ES2022",
+            module: "esnext",
+            rootDir: "src",
+            outDir: "dist",
+          }),
+          "src/main.ts":
+            'const name: string = "dep"; const dep = await import(name); console.log(dep.actual, dep.default.actual); export {};',
+          "node_modules/dep/package.json":
+            '{"name":"dep","type":"commonjs","exports":"./index.ts"}',
+          "node_modules/dep/index.ts":
+            STANDARD_DECORATOR_SOURCE +
+            (middle ? '\nexport * from "./values/entry";' : helper),
+          "node_modules/dep/values/tsconfig.json": TestProject.tsconfig(
+            {
+              target: "ES2022",
+              module: "commonjs",
+              rootDir: ".",
+              outDir: "lib",
+            },
+            { include: ["*.ts"] },
+          ),
+          "node_modules/dep/values/entry.ts": middle
+            ? helper
+            : 'export * from "./nested";',
+          "node_modules/dep/values/nested.ts": "export const actual = 17;",
+        });
+        TestProject.copyDirectory(
+          tslibRoot,
+          path.join(root, "node_modules/tslib"),
+        );
+        const result = TestProject.spawn(
+          TestProject.TTSX_BIN,
+          ["src/main.ts"],
+          { cwd: root },
+        );
+        assert.equal(result.status, 0, result.stderr);
+        assert.equal(
+          result.stdout.trim(),
+          STANDARD_DECORATOR_OUTPUT + "\n17 17",
+          `${shape}/${middle}`,
+        );
+      }
+    }
+  };

--- a/tests/test-ttsc/src/features/ttsx-runtime/test_ttsx_decorator_export_discovery_never_removes_runtime_values.ts
+++ b/tests/test-ttsc/src/features/ttsx-runtime/test_ttsx_decorator_export_discovery_never_removes_runtime_values.ts
@@ -1,0 +1,50 @@
+import { TestProject } from "@ttsc/testing";
+import assert from "node:assert/strict";
+
+import {
+  STANDARD_DECORATOR_OUTPUT,
+  STANDARD_DECORATOR_SOURCE,
+} from "../../internal/ttsx-decorators";
+
+/**
+ * Verifies decorator export-name hints never remove real CommonJS values.
+ *
+ * Static discovery can be incomplete for computed JavaScript exports. It may
+ * advertise known names to Node, but it cannot replace the runtime star helper
+ * with a smaller list and delete values the helper would have exported.
+ *
+ * 1. Re-export a known name and a computed CommonJS property from an owned barrel.
+ * 2. Load that barrel through a decorated orphan and an ESM consumer.
+ * 3. Assert the known named export and the computed default-object value survive.
+ */
+export const test_ttsx_decorator_export_discovery_never_removes_runtime_values =
+  () => {
+    const root = TestProject.createProject({
+      "package.json": '{"type":"module"}',
+      "tsconfig.json": TestProject.tsconfig({
+        target: "ES2022",
+        module: "esnext",
+        rootDir: "src",
+        outDir: "dist",
+      }),
+      "src/main.ts":
+        'const name: string = "dep"; const dep = await import(name); console.log(dep.actual, dep.default.dynamic); export {};',
+      "node_modules/dep/package.json":
+        '{"name":"dep","type":"commonjs","exports":"./index.ts"}',
+      "node_modules/dep/index.ts":
+        STANDARD_DECORATOR_SOURCE + '\nexport * from "./values/entry";',
+      "node_modules/dep/values/tsconfig.json": TestProject.tsconfig(
+        { target: "ES2022", module: "commonjs", rootDir: ".", outDir: "lib" },
+        { include: ["entry.ts"] },
+      ),
+      "node_modules/dep/values/entry.ts":
+        'export const actual = 17; export * from "./dynamic.cjs";',
+      "node_modules/dep/values/dynamic.cjs":
+        'module.exports["dyn" + "amic"] = 42;',
+    });
+    const result = TestProject.spawn(TestProject.TTSX_BIN, ["src/main.ts"], {
+      cwd: root,
+    });
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(result.stdout.trim(), STANDARD_DECORATOR_OUTPUT + "\n17 42");
+  };

--- a/tests/test-ttsc/src/features/ttsx-runtime/test_ttsx_decorator_export_discovery_preserves_helper_lookalikes.ts
+++ b/tests/test-ttsc/src/features/ttsx-runtime/test_ttsx_decorator_export_discovery_preserves_helper_lookalikes.ts
@@ -1,0 +1,53 @@
+import { TestProject } from "@ttsc/testing";
+import assert from "node:assert/strict";
+
+import {
+  STANDARD_DECORATOR_OUTPUT,
+  STANDARD_DECORATOR_SOURCE,
+} from "../../internal/ttsx-decorators";
+
+/**
+ * Verifies decorator export discovery ignores helper text inside templates.
+ *
+ * Both inline and imported helper spellings can occur as data. Scanning them as
+ * executable re-exports invents names and rewriting them corrupts the string.
+ *
+ * 1. Put an export-helper lookalike in a multiline exported template literal.
+ * 2. Re-export the owned module through a decorated orphan barrel.
+ * 3. Assert the string is unchanged and the lookalike's target contributes no
+ *    name.
+ */
+export const test_ttsx_decorator_export_discovery_preserves_helper_lookalikes =
+  () => {
+    for (const helper of ["__exportStar", "tslib_1.__exportStar"]) {
+      const text = `\n${helper}(require("./ghost"), exports);\n`;
+      const root = TestProject.createProject({
+        "package.json": '{"type":"module"}',
+        "tsconfig.json": TestProject.tsconfig({
+          target: "ES2022",
+          module: "esnext",
+          rootDir: "src",
+          outDir: "dist",
+        }),
+        "src/main.ts": `const name: string = "dep"; const dep = await import(name); console.log(dep.text === ${JSON.stringify(text)}, Object.hasOwn(dep, "ghost"), Object.hasOwn(dep.default, "ghost")); export {};`,
+        "node_modules/dep/package.json":
+          '{"name":"dep","type":"commonjs","exports":"./index.ts"}',
+        "node_modules/dep/index.ts":
+          STANDARD_DECORATOR_SOURCE + '\nexport * from "./values/entry";',
+        "node_modules/dep/values/tsconfig.json": TestProject.tsconfig(
+          { target: "ES2022", module: "commonjs", rootDir: ".", outDir: "lib" },
+          { include: ["entry.ts"] },
+        ),
+        "node_modules/dep/values/entry.ts": `export const text = \`${text}\`;`,
+        "node_modules/dep/values/ghost.ts": "export const ghost = 42;",
+      });
+      const result = TestProject.spawn(TestProject.TTSX_BIN, ["src/main.ts"], {
+        cwd: root,
+      });
+      assert.equal(result.status, 0, result.stderr);
+      assert.equal(
+        result.stdout.trim(),
+        STANDARD_DECORATOR_OUTPUT + "\ntrue false false",
+      );
+    }
+  };

--- a/tests/test-ttsc/src/features/ttsx-runtime/test_ttsx_decorator_export_hints_preserve_conditional_execution.ts
+++ b/tests/test-ttsc/src/features/ttsx-runtime/test_ttsx_decorator_export_hints_preserve_conditional_execution.ts
@@ -1,0 +1,48 @@
+import { TestProject } from "@ttsc/testing";
+import assert from "node:assert/strict";
+
+import {
+  STANDARD_DECORATOR_OUTPUT,
+  STANDARD_DECORATOR_SOURCE,
+} from "../../internal/ttsx-decorators";
+
+/**
+ * Verifies decorator export hints preserve a conditional helper call.
+ *
+ * A helper-shaped statement can be the unbraced body of an if. Adding metadata
+ * must keep it one statement so neither its require nor its helper escapes that
+ * if.
+ *
+ * 1. Put an export-star helper call behind an unbraced false condition.
+ * 2. Make its dependency throw if evaluated and load the decorated source.
+ * 3. Assert normal decoration, no dependency execution and no runtime export.
+ */
+export const test_ttsx_decorator_export_hints_preserve_conditional_execution =
+  () => {
+    const root = TestProject.createProject({
+      "package.json": '{"type":"module"}',
+      "tsconfig.json": TestProject.tsconfig({
+        target: "ES2022",
+        module: "esnext",
+        rootDir: "src",
+        outDir: "dist",
+      }),
+      "src/main.ts":
+        'const name: string = "dep"; const dep = await import(name); console.log(dep.actual, Object.hasOwn(dep.default, "hidden")); export {};',
+      "node_modules/dep/package.json":
+        '{"name":"dep","type":"commonjs","exports":"./index.ts"}',
+      "node_modules/dep/index.ts":
+        STANDARD_DECORATOR_SOURCE +
+        '\nexport const actual = 17;\ndeclare function __exportStar(value: unknown, target: unknown): void;\ndeclare function require(name: string): unknown;\ndeclare const exports: unknown;\nif (false)\n  __exportStar(require("./hidden"), exports);',
+      "node_modules/dep/hidden.ts":
+        'throw new Error("must-not-execute"); export const hidden = 42;',
+    });
+    const result = TestProject.spawn(TestProject.TTSX_BIN, ["src/main.ts"], {
+      cwd: root,
+    });
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(
+      result.stdout.trim(),
+      STANDARD_DECORATOR_OUTPUT + "\n17 false",
+    );
+  };

--- a/tests/test-ttsc/src/features/ttsx-runtime/test_ttsx_decorator_orphan_reexports_honor_the_owning_project.ts
+++ b/tests/test-ttsc/src/features/ttsx-runtime/test_ttsx_decorator_orphan_reexports_honor_the_owning_project.ts
@@ -1,0 +1,81 @@
+import { TestProject } from "@ttsc/testing";
+import assert from "node:assert/strict";
+
+import {
+  STANDARD_DECORATOR_OUTPUT,
+  STANDARD_DECORATOR_SOURCE,
+} from "../../internal/ttsx-decorators";
+
+/**
+ * Verifies decorated orphan barrels respect re-exported sources' project emit.
+ *
+ * Export discovery reaches both isolated and project-owned sources. Applying
+ * orphan options to an owned source can invent a const-enum export its compiler
+ * erased, or miss a value the project preserved.
+ *
+ * 1. Re-export a project-owned const enum from a decorated CommonJS orphan.
+ * 2. Run with preserveConstEnums disabled and enabled through cold/warm caches.
+ * 3. Assert names match real values and name discovery executes no source effects.
+ */
+export const test_ttsx_decorator_orphan_reexports_honor_the_owning_project =
+  () => {
+    // Node 22's ESM-to-CJS bridge cannot require a hook-loaded ESM dependency.
+    // CI uses Node 24; CommonJS-owned sources remain covered on the runtime floor.
+    const modules =
+      Number(process.versions.node.split(".")[0]) >= 24
+        ? ["commonjs", "esnext"]
+        : ["commonjs"];
+    for (const module of modules) {
+      for (const preserve of [false, true]) {
+        const root = TestProject.createProject({
+          "package.json": '{"type":"module"}',
+          "tsconfig.json": TestProject.tsconfig({
+            target: "ES2022",
+            module: "esnext",
+            rootDir: "src",
+            outDir: "dist",
+          }),
+          "src/main.ts":
+            'const name: string = "dep"; const dep = await import(name); console.log(Object.hasOwn(dep, "Value"), Object.hasOwn(dep.default, "Value"), dep.Value?.Entry ?? "missing", dep.actual); export {};',
+          "node_modules/dep/package.json":
+            '{"name":"dep","type":"commonjs","exports":"./index.ts"}',
+          "node_modules/dep/index.ts":
+            STANDARD_DECORATOR_SOURCE + '\nexport * from "./values/entry";',
+          "node_modules/dep/values/package.json": JSON.stringify({
+            type: module === "esnext" ? "module" : "commonjs",
+          }),
+          "node_modules/dep/values/tsconfig.json": TestProject.tsconfig(
+            {
+              target: "ES2022",
+              module,
+              rootDir: ".",
+              outDir: "lib",
+              preserveConstEnums: preserve,
+            },
+            { include: ["entry.ts"] },
+          ),
+          "node_modules/dep/values/entry.ts":
+            'console.log("values-loaded"); export const enum Value { Entry = 42 } export const actual = 17;',
+        });
+        const cacheDir = TestProject.tmpdir("ttsx-owned-reexport-");
+        for (let i = 0; i < 2; i++) {
+          const result = TestProject.spawn(
+            TestProject.TTSX_BIN,
+            ["src/main.ts"],
+            { cwd: root, env: { TTSC_CACHE_DIR: cacheDir } },
+          );
+          assert.equal(result.status, 0, result.stderr);
+          const lines = result.stdout.trim().split(/\r?\n/);
+          assert.ok(result.stdout.includes(STANDARD_DECORATOR_OUTPUT));
+          assert.equal(
+            lines.filter((line) => line === "values-loaded").length,
+            1,
+          );
+          assert.equal(
+            lines.at(-1),
+            `${preserve} ${preserve} ${preserve ? 42 : "missing"} 17`,
+          );
+        }
+      }
+    }
+  };

--- a/tests/test-ttsc/src/features/ttsx-runtime/test_ttsx_decorator_reexports_survive_regex_literals.ts
+++ b/tests/test-ttsc/src/features/ttsx-runtime/test_ttsx_decorator_reexports_survive_regex_literals.ts
@@ -1,0 +1,57 @@
+import { TestProject } from "@ttsc/testing";
+import assert from "node:assert/strict";
+
+import {
+  STANDARD_DECORATOR_OUTPUT,
+  STANDARD_DECORATOR_SOURCE,
+} from "../../internal/ttsx-decorators";
+
+/**
+ * Verifies regex literals cannot hide decorated modules' real re-exports.
+ *
+ * A backtick in a regex is data, not a template opener. The same lexical rule
+ * applies to the decorated orphan and to each project-owned recursive barrel.
+ *
+ * 1. Put a backtick regex, division, or no extra syntax before a re-export.
+ * 2. Exercise both outer and middle barrel positions.
+ * 3. Assert ESM names and the original CommonJS values both remain available.
+ */
+export const test_ttsx_decorator_reexports_survive_regex_literals = () => {
+  for (const snippet of [
+    "",
+    "const marker = /`/;",
+    "const ratio = 8 / 2 / 2;",
+  ]) {
+    for (const middle of [false, true]) {
+      const root = TestProject.createProject({
+        "package.json": '{"type":"module"}',
+        "tsconfig.json": TestProject.tsconfig({
+          target: "ES2022",
+          module: "esnext",
+          rootDir: "src",
+          outDir: "dist",
+        }),
+        "src/main.ts":
+          'const name: string = "dep"; const dep = await import(name); console.log(dep.actual, dep.default.actual); export {};',
+        "node_modules/dep/package.json":
+          '{"name":"dep","type":"commonjs","exports":"./index.ts"}',
+        "node_modules/dep/index.ts":
+          STANDARD_DECORATOR_SOURCE +
+          (middle ? "" : snippet) +
+          '\nexport * from "./values/entry";',
+        "node_modules/dep/values/tsconfig.json": TestProject.tsconfig(
+          { target: "ES2022", module: "commonjs", rootDir: ".", outDir: "lib" },
+          { include: ["*.ts"] },
+        ),
+        "node_modules/dep/values/entry.ts":
+          (middle ? snippet : "") + '\nexport * from "./nested";',
+        "node_modules/dep/values/nested.ts": "export const actual = 17;",
+      });
+      const result = TestProject.spawn(TestProject.TTSX_BIN, ["src/main.ts"], {
+        cwd: root,
+      });
+      assert.equal(result.status, 0, result.stderr);
+      assert.equal(result.stdout.trim(), STANDARD_DECORATOR_OUTPUT + "\n17 17");
+    }
+  }
+};

--- a/tests/test-ttsc/src/features/ttsx-runtime/test_ttsx_executes_standard_decorators_at_esnext.ts
+++ b/tests/test-ttsc/src/features/ttsx-runtime/test_ttsx_executes_standard_decorators_at_esnext.ts
@@ -1,0 +1,70 @@
+import { TestProject } from "@ttsc/testing";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+
+import {
+  STANDARD_DECORATOR_OUTPUT,
+  STANDARD_DECORATOR_SOURCE,
+} from "../../internal/ttsx-decorators";
+
+/**
+ * Verifies ttsx executes standard decorators at ESNext in both module formats.
+ *
+ * #1359 compiles successfully but gives Node preserved decorator syntax. The
+ * runtime must lower it while ordinary builds retain their configured target.
+ *
+ * 1. Build the reported class/method example with ordinary ttsc.
+ * 2. Run ttsx for ESNext, CommonJS, and NodeNext extension overrides.
+ * 3. Assert decorator effects and unchanged source, config, and published emit.
+ */
+export const test_ttsx_executes_standard_decorators_at_esnext = () => {
+  for (const [module, extension] of [
+    ["esnext", "ts"],
+    ["commonjs", "ts"],
+    ["nodenext", "mts"],
+    ["nodenext", "cts"],
+  ]) {
+    const entry = `src/main.${extension}`;
+    const root = TestProject.createProject({
+      "package.json": JSON.stringify({
+        type: module === "commonjs" ? "commonjs" : "module",
+      }),
+      "tsconfig.json": TestProject.tsconfig({
+        target: "ESNext",
+        module,
+        strict: true,
+        rootDir: "src",
+        outDir: "dist",
+        declaration: true,
+      }),
+      [entry]: STANDARD_DECORATOR_SOURCE,
+    });
+    const config = fs.readFileSync(path.join(root, "tsconfig.json"), "utf8");
+    const built = TestProject.spawn(TestProject.TTSC_BIN, ["--emit"], {
+      cwd: root,
+    });
+    assert.equal(built.status, 0, built.stderr);
+    const output = path.join(
+      root,
+      "dist",
+      `main.${extension === "mts" ? "mjs" : extension === "cts" ? "cjs" : "js"}`,
+    );
+    const emitted = fs.readFileSync(output, "utf8");
+    assert.match(emitted, /@sayHelloClass/);
+    const result = TestProject.spawn(TestProject.TTSX_BIN, [entry], {
+      cwd: root,
+    });
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(result.stdout.trim(), STANDARD_DECORATOR_OUTPUT);
+    assert.equal(fs.readFileSync(output, "utf8"), emitted);
+    assert.equal(
+      fs.readFileSync(path.join(root, "tsconfig.json"), "utf8"),
+      config,
+    );
+    assert.equal(
+      fs.readFileSync(path.join(root, entry), "utf8"),
+      STANDARD_DECORATOR_SOURCE,
+    );
+  }
+};

--- a/tests/test-ttsc/src/features/ttsx-runtime/test_ttsx_executes_standard_decorators_in_source_dependencies.ts
+++ b/tests/test-ttsc/src/features/ttsx-runtime/test_ttsx_executes_standard_decorators_in_source_dependencies.ts
@@ -1,0 +1,72 @@
+import { TestProject } from "@ttsc/testing";
+import assert from "node:assert/strict";
+
+import {
+  STANDARD_DECORATOR_OUTPUT,
+  STANDARD_DECORATOR_SOURCE,
+} from "../../internal/ttsx-decorators";
+
+/**
+ * Verifies decorated source dependencies execute with and without a tsconfig.
+ *
+ * Dependency builds used to preserve ESNext decorators, while orphan ESM
+ * stripping could not transform them. Both paths need compiler lowering.
+ *
+ * 1. Install a decorated raw source package in each module format.
+ * 2. Run a dynamic import with and without the dependency's own tsconfig.
+ * 3. Assert decoration and the dependency's named export survive cold and warm
+ *    runs.
+ */
+export const test_ttsx_executes_standard_decorators_in_source_dependencies =
+  () => {
+    const cacheDir = TestProject.tmpdir("ttsx-decorators-cache-");
+    for (const module of ["esnext", "commonjs"]) {
+      for (const configured of [false, true]) {
+        const root = TestProject.createProject({
+          "package.json": JSON.stringify({ type: "module" }),
+          "tsconfig.json": TestProject.tsconfig({
+            target: "ES2022",
+            module: "esnext",
+            rootDir: "src",
+            outDir: "dist",
+            strict: true,
+          }),
+          "src/main.ts": `const name: string = "decorated-dep"; const dep = await import(name); console.log(dep.answer); export {};`,
+          "node_modules/decorated-dep/package.json": JSON.stringify({
+            name: "decorated-dep",
+            type: module === "commonjs" ? "commonjs" : "module",
+            exports: "./src/index.ts",
+          }),
+          ...(configured
+            ? {
+                "node_modules/decorated-dep/tsconfig.json":
+                  TestProject.tsconfig({
+                    target: "ESNext",
+                    module,
+                    rootDir: "src",
+                    outDir: "lib",
+                  }),
+              }
+            : {}),
+          "node_modules/decorated-dep/src/index.ts":
+            'import { answer } from "./helper";\n' +
+            STANDARD_DECORATOR_SOURCE +
+            "\nexport { answer };\n",
+          "node_modules/decorated-dep/src/helper.ts":
+            "export const answer = 42;",
+        });
+        for (let i = 0; i < 2; i++) {
+          const result = TestProject.spawn(
+            TestProject.TTSX_BIN,
+            ["src/main.ts"],
+            { cwd: root, env: { TTSC_CACHE_DIR: cacheDir } },
+          );
+          assert.equal(result.status, 0, result.stderr);
+          assert.equal(
+            result.stdout.trim(),
+            STANDARD_DECORATOR_OUTPUT + "\n42",
+          );
+        }
+      }
+    }
+  };

--- a/tests/test-ttsc/src/features/ttsx-runtime/test_ttsx_register_executes_excluded_standard_decorators.ts
+++ b/tests/test-ttsc/src/features/ttsx-runtime/test_ttsx_register_executes_excluded_standard_decorators.ts
@@ -1,0 +1,47 @@
+import { TestProject } from "@ttsc/testing";
+import assert from "node:assert/strict";
+
+import {
+  STANDARD_DECORATOR_OUTPUT,
+  STANDARD_DECORATOR_SOURCE,
+} from "../../internal/ttsx-decorators";
+import { TTSX_REGISTER, linkTtscPackage } from "../../internal/ttsx-register";
+
+/**
+ * Verifies registered and direct excluded entries lower inherited decorators.
+ *
+ * The entry-only fallback builds a second project, and the public preload
+ * shares that preparation. Both must retain runtime lowering through extends.
+ *
+ * 1. Exclude a decorated script from a project's included source tree.
+ * 2. Execute it with ttsx and the public Node preload in both module formats.
+ * 3. Assert the same class and method effects in all runs.
+ */
+export const test_ttsx_register_executes_excluded_standard_decorators = () => {
+  for (const module of ["esnext", "commonjs"]) {
+    const root = TestProject.createProject({
+      "package.json": JSON.stringify({
+        type: module === "commonjs" ? "commonjs" : "module",
+      }),
+      "base.json": JSON.stringify({
+        compilerOptions: { target: "ESNext", module, strict: true },
+      }),
+      "tsconfig.json": JSON.stringify({
+        extends: "./base.json",
+        compilerOptions: { rootDir: "src", outDir: "dist" },
+        include: ["src"],
+      }),
+      "src/included.ts": "export const included = true;",
+      "scripts/main.ts": STANDARD_DECORATOR_SOURCE,
+    });
+    linkTtscPackage(root);
+    for (const [command, args] of [
+      [TestProject.TTSX_BIN, ["scripts/main.ts"]],
+      [process.execPath, ["--require", TTSX_REGISTER, "scripts/main.ts"]],
+    ] as const) {
+      const result = TestProject.spawn(command, [...args], { cwd: root });
+      assert.equal(result.status, 0, result.stderr);
+      assert.equal(result.stdout.trim(), STANDARD_DECORATOR_OUTPUT);
+    }
+  }
+};

--- a/tests/test-ttsc/src/features/ttsx-runtime/test_ttsx_standard_decorator_orphan_maps_survive_cached_runs.ts
+++ b/tests/test-ttsc/src/features/ttsx-runtime/test_ttsx_standard_decorator_orphan_maps_survive_cached_runs.ts
@@ -32,6 +32,7 @@ export const test_ttsx_standard_decorator_orphan_maps_survive_cached_runs =
           exports: "./index.ts",
         }),
         "node_modules/dep/index.ts": [
+          'export * from "./values";',
           "function decorated(value: Function, context: ClassDecoratorContext) {}",
           "@decorated",
           "class Foo {",
@@ -41,6 +42,7 @@ export const test_ttsx_standard_decorator_orphan_maps_survive_cached_runs =
           "}",
           "export const run = () => new Foo().run();",
         ].join("\n"),
+        "node_modules/dep/values.ts": "export const value = 1;",
       });
       for (let i = 0; i < 2; i++) {
         const result = TestProject.spawn(
@@ -56,7 +58,7 @@ export const test_ttsx_standard_decorator_orphan_maps_survive_cached_runs =
             .includes(
               path
                 .join(root, "node_modules/dep/index.ts")
-                .replaceAll("\\", "/") + ":5:",
+                .replaceAll("\\", "/") + ":6:",
             ),
           result.stderr,
         );

--- a/tests/test-ttsc/src/features/ttsx-runtime/test_ttsx_standard_decorator_orphan_maps_survive_cached_runs.ts
+++ b/tests/test-ttsc/src/features/ttsx-runtime/test_ttsx_standard_decorator_orphan_maps_survive_cached_runs.ts
@@ -1,0 +1,65 @@
+import { TestProject } from "@ttsc/testing";
+import assert from "node:assert/strict";
+import path from "node:path";
+
+/**
+ * Verifies orphan decorator stack traces retain source positions after caching.
+ *
+ * Decorator helpers move emitted lines. The isolated emit and its persistent
+ * cache must retain an inline map whose path belongs to this exact source.
+ *
+ * 1. Load equivalent throwing decorated dependencies from two project paths.
+ * 2. Execute each twice through one cache root.
+ * 3. Assert every stack points to the original method line in its own project.
+ */
+export const test_ttsx_standard_decorator_orphan_maps_survive_cached_runs =
+  () => {
+    const cacheDir = TestProject.tmpdir("ttsx-decorator-maps-");
+    for (const type of ["module", "module", "commonjs", "commonjs"]) {
+      const root = TestProject.createProject({
+        "package.json": '{"type":"module"}',
+        "tsconfig.json": TestProject.tsconfig({
+          target: "ES2022",
+          module: "esnext",
+          rootDir: "src",
+          outDir: "dist",
+        }),
+        "src/main.ts":
+          'const name: string = "dep"; const dep = await import(name); dep.run(); export {};',
+        "node_modules/dep/package.json": JSON.stringify({
+          name: "dep",
+          type,
+          exports: "./index.ts",
+        }),
+        "node_modules/dep/index.ts": [
+          "function decorated(value: Function, context: ClassDecoratorContext) {}",
+          "@decorated",
+          "class Foo {",
+          "  run() {",
+          '    throw new Error("decorator-map");',
+          "  }",
+          "}",
+          "export const run = () => new Foo().run();",
+        ].join("\n"),
+      });
+      for (let i = 0; i < 2; i++) {
+        const result = TestProject.spawn(
+          TestProject.TTSX_BIN,
+          ["src/main.ts"],
+          { cwd: root, env: { TTSC_CACHE_DIR: cacheDir } },
+        );
+        assert.notEqual(result.status, 0);
+        assert.match(result.stderr, /Error: decorator-map/);
+        assert.ok(
+          result.stderr
+            .replaceAll("\\", "/")
+            .includes(
+              path
+                .join(root, "node_modules/dep/index.ts")
+                .replaceAll("\\", "/") + ":5:",
+            ),
+          result.stderr,
+        );
+      }
+    }
+  };

--- a/tests/test-ttsc/src/features/ttsx-runtime/test_ttsx_standard_decorator_orphans_expose_reexported_const_enums.ts
+++ b/tests/test-ttsc/src/features/ttsx-runtime/test_ttsx_standard_decorator_orphans_expose_reexported_const_enums.ts
@@ -1,0 +1,55 @@
+import { TestProject } from "@ttsc/testing";
+import assert from "node:assert/strict";
+
+import {
+  STANDARD_DECORATOR_OUTPUT,
+  STANDARD_DECORATOR_SOURCE,
+} from "../../internal/ttsx-decorators";
+
+/**
+ * Verifies decorated CommonJS orphans expose const enums through export-star.
+ *
+ * Isolated runtime emission preserves const enums, so CommonJS name discovery
+ * must use the same policy instead of erasing exports that exist at runtime.
+ *
+ * 1. Export a const enum and an interface directly or through a barrel.
+ * 2. Import the decorated CommonJS package into ESM with cold and warm caches.
+ * 3. Assert the enum is the actual CommonJS value and the interface stays absent.
+ */
+export const test_ttsx_standard_decorator_orphans_expose_reexported_const_enums =
+  () => {
+    const values =
+      "export const enum Value { Entry = 42 }\nexport interface OnlyType { value: number }";
+    for (const barrel of [false, true]) {
+      const root = TestProject.createProject({
+        "package.json": '{"type":"module"}',
+        "tsconfig.json": TestProject.tsconfig({
+          target: "ES2022",
+          module: "esnext",
+          rootDir: "src",
+          outDir: "dist",
+        }),
+        "src/main.ts":
+          'const name: string = "dep"; const dep = await import(name); console.log(dep.Value.Entry, dep.Value === dep.default.Value, Object.hasOwn(dep, "OnlyType")); export {};',
+        "node_modules/dep/package.json":
+          '{"name":"dep","type":"commonjs","exports":"./index.ts"}',
+        "node_modules/dep/index.ts":
+          STANDARD_DECORATOR_SOURCE +
+          (barrel ? '\nexport * from "./values";' : values),
+        "node_modules/dep/values.ts": values,
+      });
+      const cacheDir = TestProject.tmpdir("ttsx-decorator-reexports-");
+      for (let i = 0; i < 2; i++) {
+        const result = TestProject.spawn(
+          TestProject.TTSX_BIN,
+          ["src/main.ts"],
+          { cwd: root, env: { TTSC_CACHE_DIR: cacheDir } },
+        );
+        assert.equal(result.status, 0, result.stderr);
+        assert.equal(
+          result.stdout.trim(),
+          STANDARD_DECORATOR_OUTPUT + "\n42 true false",
+        );
+      }
+    }
+  };

--- a/tests/test-ttsc/src/features/ttsx-runtime/test_ttsx_standard_decorators_honor_response_file_options.ts
+++ b/tests/test-ttsc/src/features/ttsx-runtime/test_ttsx_standard_decorators_honor_response_file_options.ts
@@ -1,0 +1,54 @@
+import { TestProject } from "@ttsc/testing";
+import assert from "node:assert/strict";
+
+import {
+  STANDARD_DECORATOR_OUTPUT,
+  STANDARD_DECORATOR_SOURCE,
+} from "../../internal/ttsx-decorators";
+
+/**
+ * Verifies decorator runtime targets follow compiler response-file precedence.
+ *
+ * A scan of visible CLI flags misses targets inside response files, leaving
+ * decorators intact or replacing an explicitly requested lower target.
+ *
+ * 1. Select ESNext or ES2019 using nested response files and direct CLI flags.
+ * 2. Run decorated code which exposes whether optional chaining was lowered.
+ * 3. Assert the compiler's last effective target controls both behaviors.
+ */
+export const test_ttsx_standard_decorators_honor_response_file_options = () => {
+  for (const [target, response, args, nativeOptionalChain] of [
+    ["ES2022", "--target esnext\n", ["@args.txt"], true],
+    ["ESNext", "--target es2019\n", ["@args.txt"], false],
+    ["ESNext", "@inner.txt\n", ["--target", "es2019", "@args.txt"], true],
+    ["ESNext", "@inner.txt\n", ["@args.txt", "--target", "es2019"], false],
+    ["ESNext", "--target invalid\n", ["@args.txt"], null],
+  ] as const) {
+    const root = TestProject.commonJsProject(
+      {
+        "args.txt": response,
+        "inner.txt": "--target esnext\n",
+        "src/main.ts":
+          STANDARD_DECORATOR_SOURCE +
+          '\nfunction optional(value?: { answer: number }) { return value?.answer; }\nconsole.log(optional.toString().includes("?."));',
+      },
+      { compilerOptions: { target } },
+    );
+    const result = TestProject.spawn(
+      TestProject.TTSX_BIN,
+      [...args, "src/main.ts"],
+      { cwd: root },
+    );
+    if (nativeOptionalChain === null) {
+      assert.notEqual(result.status, 0);
+      assert.match(result.stderr, /TS6046/);
+      assert.equal(result.stdout, "");
+    } else {
+      assert.equal(result.status, 0, result.stderr);
+      assert.equal(
+        result.stdout.trim(),
+        STANDARD_DECORATOR_OUTPUT + "\n" + nativeOptionalChain,
+      );
+    }
+  }
+};

--- a/tests/test-ttsc/src/features/ttsx-runtime/test_ttsx_standard_decorators_in_orphans_do_not_cache_imported_values.ts
+++ b/tests/test-ttsc/src/features/ttsx-runtime/test_ttsx_standard_decorators_in_orphans_do_not_cache_imported_values.ts
@@ -1,0 +1,62 @@
+import { TestProject } from "@ttsc/testing";
+import assert from "node:assert/strict";
+
+import {
+  STANDARD_DECORATOR_OUTPUT,
+  STANDARD_DECORATOR_SOURCE,
+} from "../../internal/ttsx-decorators";
+
+/**
+ * Verifies orphan decorator caches never freeze imported const enum values.
+ *
+ * The cache owns the decorated file's bytes. Inlining an imported value binds
+ * that output to another file which can change without invalidating this
+ * cache.
+ *
+ * 1. Run a decorated orphan importing a const enum through a shared cache.
+ * 2. Change only the enum source, then change the package from ESM to CommonJS.
+ * 3. Assert each new value is observed while the decorated file stays unchanged.
+ */
+export const test_ttsx_standard_decorators_in_orphans_do_not_cache_imported_values =
+  () => {
+    const root = TestProject.createProject({
+      "package.json": '{"type":"module"}',
+      "tsconfig.json": TestProject.tsconfig({
+        target: "ES2022",
+        module: "esnext",
+        rootDir: "src",
+        outDir: "dist",
+      }),
+      "src/main.ts":
+        'const name: string = "dep"; const dep = await import(name); console.log(dep.answer); export {};',
+      "node_modules/dep/src/index.ts":
+        'import { Value } from "./enum";\n' +
+        STANDARD_DECORATOR_SOURCE +
+        "\nexport const answer = Value.Entry;",
+    });
+    const cacheDir = TestProject.tmpdir("ttsx-isolated-decorators-");
+    for (const [type, answer] of [
+      ["module", 1],
+      ["module", 2],
+      ["commonjs", 3],
+      ["commonjs", 4],
+    ] as const) {
+      TestProject.writeFiles(root, {
+        "node_modules/dep/package.json": JSON.stringify({
+          name: "dep",
+          type,
+          exports: "./src/index.ts",
+        }),
+        "node_modules/dep/src/enum.ts": `export const enum Value { Entry = ${answer} }`,
+      });
+      const result = TestProject.spawn(TestProject.TTSX_BIN, ["src/main.ts"], {
+        cwd: root,
+        env: { TTSC_CACHE_DIR: cacheDir },
+      });
+      assert.equal(result.status, 0, result.stderr);
+      assert.equal(
+        result.stdout.trim(),
+        STANDARD_DECORATOR_OUTPUT + "\n" + answer,
+      );
+    }
+  };

--- a/tests/test-ttsc/src/features/ttsx-runtime/test_ttsx_standard_decorators_in_orphans_keep_the_requested_source.ts
+++ b/tests/test-ttsc/src/features/ttsx-runtime/test_ttsx_standard_decorators_in_orphans_keep_the_requested_source.ts
@@ -1,0 +1,42 @@
+import { TestProject } from "@ttsc/testing";
+import assert from "node:assert/strict";
+
+import {
+  STANDARD_DECORATOR_OUTPUT,
+  STANDARD_DECORATOR_SOURCE,
+} from "../../internal/ttsx-decorators";
+
+/**
+ * Verifies orphan decorator lowering executes the requested source.
+ *
+ * A full compilation also emits imports outside node_modules. Two index.ts
+ * files can make a basename lookup silently skip the decorated entry.
+ *
+ * 1. Dynamically import an excluded script that imports another index.ts.
+ * 2. Decorate a class only in the requested script.
+ * 3. Assert its decorator effects and exports both execute.
+ */
+export const test_ttsx_standard_decorators_in_orphans_keep_the_requested_source =
+  () => {
+    const root = TestProject.createProject({
+      "package.json": '{"type":"module"}',
+      "tsconfig.json": TestProject.tsconfig({
+        target: "ES2022",
+        module: "esnext",
+        rootDir: "src",
+        outDir: "dist",
+      }),
+      "src/main.ts":
+        'const name: string = "../scripts/index.ts"; const dep = await import(name); console.log(dep.answer, dep.own); export {};',
+      "scripts/index.ts":
+        'import { answer } from "./internal/index";\n' +
+        STANDARD_DECORATOR_SOURCE +
+        "\nexport { answer }; export const own = 1;",
+      "scripts/internal/index.ts": "export const answer = 42;",
+    });
+    const result = TestProject.spawn(TestProject.TTSX_BIN, ["src/main.ts"], {
+      cwd: root,
+    });
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(result.stdout.trim(), STANDARD_DECORATOR_OUTPUT + "\n42 1");
+  };

--- a/tests/test-ttsc/src/features/ttsx-runtime/test_ttsx_standard_decorators_keep_lower_targets_and_legacy_semantics.ts
+++ b/tests/test-ttsc/src/features/ttsx-runtime/test_ttsx_standard_decorators_keep_lower_targets_and_legacy_semantics.ts
@@ -1,0 +1,60 @@
+import { TestProject } from "@ttsc/testing";
+import assert from "node:assert/strict";
+
+import {
+  STANDARD_DECORATOR_OUTPUT,
+  STANDARD_DECORATOR_SOURCE,
+} from "../../internal/ttsx-decorators";
+
+/**
+ * Verifies decorator support retains lower targets and legacy semantics.
+ *
+ * The runtime override applies only to ESNext. Raising a configured lower
+ * target changes emitted syntax, and experimentalDecorators selects another
+ * API.
+ *
+ * 1. Run the standard example at default, ES2025, and ES2019 targets.
+ * 2. Assert optional chaining follows the effective config or CLI target.
+ * 3. Run a legacy class decorator with experimentalDecorators at ESNext.
+ */
+export const test_ttsx_standard_decorators_keep_lower_targets_and_legacy_semantics =
+  () => {
+    for (const [target, args, nativeOptionalChain] of [
+      [undefined, [], true],
+      ["ES2025", [], true],
+      ["ES2019", [], false],
+      ["ESNext", ["-t", "es2019"], false],
+      ["ESNext", ["--target", "null"], true],
+    ] as const) {
+      const root = TestProject.commonJsProject(
+        {
+          "src/main.ts":
+            STANDARD_DECORATOR_SOURCE +
+            '\nfunction optional(value?: { answer: number }) { return value?.answer; }\nconsole.log(optional.toString().includes("?."));',
+        },
+        { compilerOptions: { target } },
+      );
+      const result = TestProject.spawn(
+        TestProject.TTSX_BIN,
+        [...args, "src/main.ts"],
+        { cwd: root },
+      );
+      assert.equal(result.status, 0, result.stderr);
+      assert.equal(
+        result.stdout.trim(),
+        STANDARD_DECORATOR_OUTPUT + "\n" + nativeOptionalChain,
+      );
+    }
+    const root = TestProject.commonJsProject(
+      {
+        "src/main.ts":
+          "function legacy(target: Function) { console.log(target.name); }\n@legacy\nclass Foo {}\nnew Foo();",
+      },
+      { compilerOptions: { target: "ESNext", experimentalDecorators: true } },
+    );
+    const result = TestProject.spawn(TestProject.TTSX_BIN, ["src/main.ts"], {
+      cwd: root,
+    });
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(result.stdout.trim(), "Foo");
+  };

--- a/tests/test-ttsc/src/features/ttsx-runtime/test_ttsx_standard_decorators_preserve_cli_and_library_options.ts
+++ b/tests/test-ttsc/src/features/ttsx-runtime/test_ttsx_standard_decorators_preserve_cli_and_library_options.ts
@@ -1,0 +1,73 @@
+import { TestProject } from "@ttsc/testing";
+import assert from "node:assert/strict";
+
+import {
+  STANDARD_DECORATOR_OUTPUT,
+  STANDARD_DECORATOR_SOURCE,
+} from "../../internal/ttsx-decorators";
+
+/**
+ * Verifies decorator lowering preserves ESNext libraries and implicit modules.
+ *
+ * Replacing the target alone drops proposal types and changes the implicit
+ * module kind. CLI aliases, casing, and repeated targets must still win.
+ *
+ * 1. Select ESNext through the config and through several CLI spellings.
+ * 2. Use Disposable and import attributes without explicit lib or module.
+ * 3. Assert successful checking and execution, then retain an explicit ESNext lib.
+ */
+export const test_ttsx_standard_decorators_preserve_cli_and_library_options =
+  () => {
+    for (const args of [
+      [],
+      ["-t", "esnext"],
+      ["--TARGET", "ESNEXT"],
+      ["--target", "es2019", "-target", "esnext"],
+    ]) {
+      const root = TestProject.createProject({
+        "package.json": JSON.stringify({ type: "module" }),
+        "tsconfig.json": TestProject.tsconfig({
+          target: args.length ? "ES2019" : "ESNext",
+          strict: true,
+          rootDir: "src",
+          outDir: "dist",
+          resolveJsonModule: true,
+        }),
+        "src/data.json": '{"value":42}',
+        "src/main.ts":
+          `import data from "./data.json" with { type: "json" };\nlet disposal: Disposable | undefined; void disposal;\n` +
+          STANDARD_DECORATOR_SOURCE +
+          "\nconsole.log(data.value);",
+      });
+      const result = TestProject.spawn(
+        TestProject.TTSX_BIN,
+        [...args, "src/main.ts"],
+        { cwd: root },
+      );
+      assert.equal(result.status, 0, result.stderr);
+      assert.equal(result.stdout.trim(), STANDARD_DECORATOR_OUTPUT + "\n42");
+    }
+    for (const cliLib of [false, true]) {
+      const root = TestProject.createProject({
+        "package.json": '{"type":"module"}',
+        "tsconfig.json": TestProject.tsconfig({
+          target: "ESNext",
+          module: "esnext",
+          strict: true,
+          rootDir: "src",
+          outDir: "dist",
+          ...(cliLib ? {} : { lib: ["esnext"] }),
+        }),
+        "src/main.ts":
+          'declare const console: { log(...args: unknown[]): void };\nif (false) {\n// @ts-expect-error DOM must remain absent.\ndocument.title = "forbidden";\n}\n' +
+          STANDARD_DECORATOR_SOURCE,
+      });
+      const result = TestProject.spawn(
+        TestProject.TTSX_BIN,
+        [...(cliLib ? ["--lib", "esnext"] : []), "src/main.ts"],
+        { cwd: root },
+      );
+      assert.equal(result.status, 0, result.stderr);
+      assert.equal(result.stdout.trim(), STANDARD_DECORATOR_OUTPUT);
+    }
+  };

--- a/tests/test-ttsc/src/features/ttsx-runtime/test_ttsx_standard_decorators_preserve_member_initialization.ts
+++ b/tests/test-ttsc/src/features/ttsx-runtime/test_ttsx_standard_decorators_preserve_member_initialization.ts
@@ -1,0 +1,65 @@
+import { TestProject } from "@ttsc/testing";
+import assert from "node:assert/strict";
+
+/**
+ * Verifies standard decorator fields and accessors preserve initialization.
+ *
+ * Decorator lowering shares the class-field transform. Private fields,
+ * auto-accessors and addInitializer must retain TC39 value and ordering rules.
+ *
+ * 1. Decorate a private field, an auto-accessor, and a static method.
+ * 2. Instantiate the class after its class initializer has run.
+ * 3. Assert transformed values and static/class/instance initializer order.
+ */
+export const test_ttsx_standard_decorators_preserve_member_initialization =
+  () => {
+    for (const module of ["commonjs", "esnext"]) {
+      const root = TestProject.createProject({
+        "package.json": JSON.stringify({
+          type: module === "commonjs" ? "commonjs" : "module",
+        }),
+        "tsconfig.json": TestProject.tsconfig({
+          target: "ESNext",
+          module,
+          strict: true,
+          rootDir: "src",
+          outDir: "dist",
+        }),
+        "src/main.ts": `
+const events: string[] = [];
+function tagged(value: Function, context: ClassDecoratorContext) {
+  context.addInitializer(function() { events.push("class:" + this.name); });
+}
+function field(value: undefined, context: ClassFieldDecoratorContext) {
+  context.addInitializer(function() { events.push("field:" + String(context.name)); });
+  return function(initial: number) { return initial + 1; };
+}
+function accessor(value: ClassAccessorDecoratorTarget<Foo, number>, context: ClassAccessorDecoratorContext<Foo, number>) {
+  context.addInitializer(function() { events.push("accessor:" + String(context.name)); });
+  return { init(initial: number) { return initial * 2; } };
+}
+function method(value: Function, context: ClassMethodDecoratorContext) {
+  context.addInitializer(function() { events.push("static:" + String(context.name)); });
+}
+@tagged
+class Foo {
+  @field #value = 2;
+  @accessor accessor count = 4;
+  @method static run() { return "method"; }
+  read() { return this.#value + this.count; }
+}
+const foo = new Foo();
+console.log(foo.read(), Foo.run());
+console.log(events.join(","));
+`,
+      });
+      const result = TestProject.spawn(TestProject.TTSX_BIN, ["src/main.ts"], {
+        cwd: root,
+      });
+      assert.equal(result.status, 0, result.stderr);
+      assert.equal(
+        result.stdout.trim(),
+        "11 method\nstatic:run,class:Foo,field:#value,accessor:count",
+      );
+    }
+  };

--- a/tests/test-ttsc/src/features/ttsx-runtime/test_ttsx_standard_decorators_reject_invalid_programs_before_effects.ts
+++ b/tests/test-ttsc/src/features/ttsx-runtime/test_ttsx_standard_decorators_reject_invalid_programs_before_effects.ts
@@ -1,0 +1,65 @@
+import { TestProject } from "@ttsc/testing";
+import assert from "node:assert/strict";
+
+import { STANDARD_DECORATOR_SOURCE } from "../../internal/ttsx-decorators";
+
+/**
+ * Verifies decorator lowering preserves diagnostics before execution.
+ *
+ * Runtime target selection must not hide invalid decorator signatures or add
+ * libraries to a project that explicitly disables them.
+ *
+ * 1. Run an invalid decorator and decorated programs with lib [] or noLib.
+ * 2. Exercise both config and CLI noLib settings plus an invalid target.
+ * 3. Assert compiler diagnostics and no decorator or entry side effects.
+ */
+export const test_ttsx_standard_decorators_reject_invalid_programs_before_effects =
+  () => {
+    const cases = [
+      {
+        options: {},
+        args: [],
+        source:
+          'function invalid() { return 42; }\n@invalid\nclass Foo {}\nconsole.log("executed");',
+        diagnostic: /TS1329/,
+      },
+      {
+        options: { lib: [] },
+        args: [],
+        source: STANDARD_DECORATOR_SOURCE,
+        diagnostic: /TS2318/,
+      },
+      {
+        options: { noLib: true },
+        args: [],
+        source: STANDARD_DECORATOR_SOURCE,
+        diagnostic: /TS2318/,
+      },
+      {
+        options: {},
+        args: ["--noLib"],
+        source: STANDARD_DECORATOR_SOURCE,
+        diagnostic: /TS2318/,
+      },
+      {
+        options: {},
+        args: ["--target", "invalid"],
+        source: STANDARD_DECORATOR_SOURCE,
+        diagnostic: /TS6046/,
+      },
+    ];
+    for (const scenario of cases) {
+      const root = TestProject.commonJsProject(
+        { "src/main.ts": scenario.source },
+        { compilerOptions: { target: "ESNext", ...scenario.options } },
+      );
+      const result = TestProject.spawn(
+        TestProject.TTSX_BIN,
+        [...scenario.args, "src/main.ts"],
+        { cwd: root },
+      );
+      assert.notEqual(result.status, 0);
+      assert.match(result.stderr + result.stdout, scenario.diagnostic);
+      assert.doesNotMatch(result.stdout, /Hello Class|Hello Function|executed/);
+    }
+  };

--- a/tests/test-ttsc/src/internal/ttsx-decorators.ts
+++ b/tests/test-ttsc/src/internal/ttsx-decorators.ts
@@ -1,0 +1,27 @@
+/** Standard decorator witness from #1359, with observable replacement behavior. */
+export const STANDARD_DECORATOR_SOURCE = `
+function sayHelloClass<T extends { new (...args: any[]): {} }>(ClassType: T, context: ClassDecoratorContext) {
+  return class extends ClassType {
+    constructor(...args: any[]) {
+      super(...args);
+      console.log("Hello Class " + context.name);
+    }
+  };
+}
+function sayHelloMethod<T>(target: (this: T, ...args: any[]) => any, context: ClassMethodDecoratorContext) {
+  return function(this: T, ...args: any[]): any {
+    console.log("Hello Function " + context.name.toString());
+    return target.apply(this, args);
+  };
+}
+@sayHelloClass
+class Foo {
+  constructor(public bar: string) {}
+  @sayHelloMethod
+  getBar() { return this.bar; }
+}
+console.log(new Foo("abc").getBar());
+`;
+
+export const STANDARD_DECORATOR_OUTPUT =
+  "Hello Class Foo\nHello Function getBar\nabc";

--- a/tests/test-ttsc/src/native-plugins/corpus-misc/test_ttsx_standard_decorators_compose_with_source_plugins.ts
+++ b/tests/test-ttsc/src/native-plugins/corpus-misc/test_ttsx_standard_decorators_compose_with_source_plugins.ts
@@ -1,0 +1,42 @@
+import { TestProject } from "@ttsc/testing";
+import assert from "node:assert/strict";
+
+import { TestUtilityPlugins } from "../../internal/TestUtilityPlugins";
+import {
+  STANDARD_DECORATOR_OUTPUT,
+  STANDARD_DECORATOR_SOURCE,
+} from "../../internal/ttsx-decorators";
+
+/**
+ * Verifies standard decorators execute alongside native source transforms.
+ *
+ * The native host receives compiler overrides through TTSC_TSGO_ARGS rather
+ * than its command-line parser. Both transforms must reach the executed emit.
+ *
+ * 1. Configure the source-backed strip plugin at ESNext.
+ * 2. Add a console.warn for the plugin to remove beside the decorator example.
+ * 3. Assert class and method effects, with the warning removed.
+ */
+export const test_ttsx_standard_decorators_compose_with_source_plugins = () => {
+  const root = TestProject.commonJsProject(
+    {
+      "strip.config.json": JSON.stringify({ calls: ["console.warn"] }),
+      "src/main.ts":
+        'console.warn("must-be-stripped");\n' + STANDARD_DECORATOR_SOURCE,
+    },
+    {
+      compilerOptions: {
+        target: "ESNext",
+        plugins: [{ transform: "@ttsc/strip" }],
+      },
+    },
+  );
+  TestUtilityPlugins.seedPackages(root, ["strip"]);
+  const result = TestProject.spawn(TestProject.TTSX_BIN, ["src/main.ts"], {
+    cwd: root,
+    env: { PATH: TestUtilityPlugins.goPath() },
+  });
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(result.stdout.trim(), STANDARD_DECORATOR_OUTPUT);
+  assert.doesNotMatch(result.stderr, /must-be-stripped/);
+};

--- a/website/package.json
+++ b/website/package.json
@@ -45,7 +45,7 @@
     "katex": "^0.16.22",
     "lz-string": "^1.5.0",
     "monaco-editor": "^0.52.0",
-    "next": "^16.3.0",
+    "next": "^16.3.3",
     "nextra": "4.6.0",
     "nextra-theme-docs": "4.6.0",
     "path": "^0.12.7",

--- a/website/src/content/docs/ttsc/execute.mdx
+++ b/website/src/content/docs/ttsc/execute.mdx
@@ -57,7 +57,7 @@ Projects that enable `allowImportingTsExtensions` are supported. During the runt
 
 For runtime users, standard TC39 class and member decorators work in both ESM and CommonJS, including `ttsc/register`, entries outside `include`, and dependencies that ship TypeScript source. Keep `experimentalDecorators` unset for standard decorators; enable it only for TypeScript's legacy decorator API.
 
-TypeScript-Go preserves proposal syntax when `target` is `ESNext`. For execution, `ttsx` lowers that target to `ES2025` in its private runtime build, retaining the original library selection and module kind. Lower targets keep their configured value. The same rule applies when `--target` selects `ESNext` on the command line. The project's `tsconfig.json`, source files, and ordinary `ttsc` build output are unchanged.
+TypeScript-Go preserves proposal syntax when `target` is `ESNext`. For execution, `ttsx` lowers that target to `ES2025` in its private runtime build, retaining the original library selection and module kind. Lower targets keep their configured value. The same rule applies when `--target` selects `ESNext` on the command line or in a compiler response file. The project's `tsconfig.json`, source files, and ordinary `ttsc` build output are unchanged.
 
 ## Raw-TypeScript dependencies
 

--- a/website/src/content/docs/ttsc/execute.mdx
+++ b/website/src/content/docs/ttsc/execute.mdx
@@ -53,6 +53,12 @@ The module format follows the same rule everywhere, because it is the rule the c
 
 Projects that enable `allowImportingTsExtensions` are supported. During the runtime emit, `ttsx` rewrites relative `.ts`, `.tsx`, `.mts`, and `.cts` import specifiers to the matching JavaScript extensions so Node can execute the output. The emitted JavaScript lives in a per-run cache directory and is removed after the script exits.
 
+## Decorators
+
+For runtime users, standard TC39 class and member decorators work in both ESM and CommonJS, including `ttsc/register`, entries outside `include`, and dependencies that ship TypeScript source. Keep `experimentalDecorators` unset for standard decorators; enable it only for TypeScript's legacy decorator API.
+
+TypeScript-Go preserves proposal syntax when `target` is `ESNext`. For execution, `ttsx` lowers that target to `ES2025` in its private runtime build, retaining the original library selection and module kind. Lower targets keep their configured value. The same rule applies when `--target` selects `ESNext` on the command line. The project's `tsconfig.json`, source files, and ordinary `ttsc` build output are unchanged.
+
 ## Raw-TypeScript dependencies
 
 The type-check covers your whole program, but at runtime your dependencies are loaded by Node directly. When part of the graph is ESM, Node trips over dependencies that ship raw TypeScript:


### PR DESCRIPTION
This pull request owns the single-issue campaign for #1359: execute standard decorators through ttsx, including registered entries and raw TypeScript dependencies.

The reproduced failure is ESNext output retaining decorators that Node cannot execute. The runtime compilation will lower that syntax while retaining the project's library and module semantics. Investigation is limited to this decorator execution defect and its consequences.

Verification is pending. Baseline reproduction fails in ESM and CommonJS; an ES2025 runtime emit executes the expected class/method behavior. Ordinary CI, Individual Self-Review, and Overall Self-Review are required before merge.
