### PR TITLE
fix(driver): preserve native plugin emit integrity

### DIFF
--- a/packages/ttsc/cmd/ttsc/build.go
+++ b/packages/ttsc/cmd/ttsc/build.go
@@ -114,10 +114,9 @@ func runBuild(args []string) int {
       fmt.Fprintf(stderr, "ttsc: emit failed: %v\n", err)
       return 3
     }
-    for _, d := range eDiags {
-      fmt.Fprintln(stderr, "  -", d.String())
-    }
+    driver.WritePrettyDiagnostics(stderr, eDiags, cwd)
     if driver.CountErrors(eDiags) > 0 {
+      fmt.Fprintln(stderr, "ttsc: emit failed; build output is incomplete")
       return 2
     }
     if !*quiet {

--- a/packages/ttsc/driver/emit_plugin.go
+++ b/packages/ttsc/driver/emit_plugin.go
@@ -1,7 +1,9 @@
 package driver
 
 import (
+  "context"
   "errors"
+  "fmt"
   "strings"
   "sync"
 
@@ -37,25 +39,34 @@ func (h *pluginEmitHost) GetEmitModuleFormatOfFile(file shimast.HasFileName) shi
   return h.program.GetEmitModuleFormatOfFile(file)
 }
 func (h *pluginEmitHost) GetEmitResolver() shimprinter.EmitResolver {
-  return guardedEmitResolver{h.emitResolver}
+  return h.emitResolver
 }
 
-// guardedEmitResolver makes tsgo's const-enum inliner safe against plugin-built
-// nodes. The inliner calls GetConstantValue on every property/element access it
-// visits — including synthetic ones a plugin injects — and tsgo's checker can
-// nil-panic while computing a contextual type for such a node. A failure there
-// only means "not a const enum", so recover to nil and leave the node as-is.
+// guardedEmitResolver only resolves member accesses from the program's input
+// trees. ParseNode follows original links but trusts the synthesized flag:
+// standalone factories leave it clear, even on generated nodes with copied
+// source positions. Recovering a checker panic is too late to prevent that
+// lookup from recording diagnostics on a parameter the binder never saw.
 type guardedEmitResolver struct {
   shimprinter.EmitResolver
+  originalMembers map[*shimast.Node]struct{}
 }
 
-func (g guardedEmitResolver) GetConstantValue(node *shimast.Node) (result any) {
-  defer func() {
-    if recover() != nil {
-      result = nil
-    }
-  }()
+func (g guardedEmitResolver) GetConstantValue(node *shimast.Node) any {
+  if _, original := g.originalMembers[node]; !original {
+    return nil
+  }
   return g.EmitResolver.GetConstantValue(node)
+}
+
+func collectOriginalMembers(node *shimast.Node, members map[*shimast.Node]struct{}) {
+  if node.Kind == shimast.KindPropertyAccessExpression || node.Kind == shimast.KindElementAccessExpression {
+    members[node] = struct{}{}
+  }
+  node.ForEachChild(func(child *shimast.Node) bool {
+    collectOriginalMembers(child, members)
+    return false
+  })
 }
 func (h *pluginEmitHost) GetProjectReferenceFromSource(path shimtspath.Path) *shimtsoptions.SourceOutputAndProjectReference {
   return h.program.GetProjectReferenceFromSource(path)
@@ -180,8 +191,31 @@ func (p *Program) EmitWithPluginTransformers(transforms []PluginTransform, write
   if len(linked) != 0 {
     transforms = append(append([]PluginTransform{}, transforms...), linked...)
   }
-  host := &pluginEmitHost{program: p.TSProgram, emitResolver: p.Checker.GetEmitResolver()}
   options := p.TSProgram.Options()
+  if options.NoEmit.IsTrue() {
+    // Analysis-only incremental projects may still write build information.
+    // Delegate that policy to the ordinary emitter without running JS hooks.
+    result, diagnostics, err := p.EmitAllRaw(writeFile)
+    if err != nil {
+      return diagnostics, err
+    }
+    return p.pluginEmitDiagnostics("analysis-only emit", result.Diagnostics)
+  }
+  if result := shimcompiler.HandleNoEmitOnError(context.Background(), p.TSProgram, nil); result != nil {
+    return p.pluginEmitDiagnostics("pre-emit checking", result.Diagnostics)
+  }
+  // Snapshot ownership before any transformer runs, including transforms that
+  // mutate their input in place or reuse a member from another source file.
+  members := make(map[*shimast.Node]struct{})
+  for _, sf := range p.TSProgram.SourceFiles() {
+    collectOriginalMembers(sf.AsNode(), members)
+  }
+  host := &pluginEmitHost{program: p.TSProgram, emitResolver: guardedEmitResolver{p.Checker.GetEmitResolver(), members}}
+
+  // noEmitOnError applies to the whole build. The JS lane runs before the
+  // declaration lane, so defer callbacks until both have succeeded. Outside
+  // that option keep upstream's emit-despite-errors behavior.
+  output := newPluginEmitOutput(writeFile, options.NoEmitOnError.IsTrue())
   for _, sf := range shimcompiler.GetSourceFilesToEmit(host, nil, false) {
     paths := shimcompiler.GetOutputPathsFor(sf, options, host, false)
     if paths.JsFilePath() != "" && !p.outputEscapesOutDir(paths.JsFilePath()) {
@@ -262,11 +296,11 @@ func (p *Program) EmitWithPluginTransformers(transforms []PluginTransform, write
       // why the remaining fields stay zero.
       if err := p.writePluginEmitOutput(paths.JsFilePath(), printed.JS, &shimcompiler.WriteFileData{
         SourceMapUrlPos: printed.SourceMapUrlPos,
-      }, writeFile); err != nil {
-        return nil, err
+      }, output.write); err != nil {
+        return nil, fmt.Errorf("driver: native plugin JavaScript emit failed: %w", err)
       }
-      if err := p.writePluginEmitOutput(printed.MapPath, printed.MapText, nil, writeFile); err != nil {
-        return nil, err
+      if err := p.writePluginEmitOutput(printed.MapPath, printed.MapText, nil, output.write); err != nil {
+        return nil, fmt.Errorf("driver: native plugin source map emit failed: %w", err)
       }
     }
   }
@@ -274,7 +308,10 @@ func (p *Program) EmitWithPluginTransformers(transforms []PluginTransform, write
   // so it also runs for a JavaScript-only `incremental` / `composite` project
   // that has no declarations to write at all.
   if !options.GetEmitDeclarations() && !p.emitsBuildInfo() {
-    return nil, nil
+    if result := shimcompiler.HandleNoEmitOnError(context.Background(), p.TSProgram, nil); result != nil {
+      return p.pluginEmitDiagnostics("JavaScript emit", result.Diagnostics)
+    }
+    return nil, output.flush()
   }
 
   // What the build information this pass writes does and does not claim.
@@ -304,16 +341,18 @@ func (p *Program) EmitWithPluginTransformers(transforms []PluginTransform, write
         }
         return nil
       }
-      if writeFile != nil {
-        return writeFile(fileName, text, data)
-      }
-      return DefaultWriteFile(fileName, text)
+      return output.write(fileName, text, data)
     },
   })
+  var diagnostics []Diagnostic
   if result != nil && len(result.Diagnostics) != 0 {
-    return p.convertProgramDiagnostics(result.Diagnostics), nil
+    var err error
+    diagnostics, err = p.pluginEmitDiagnostics("declaration emit", result.Diagnostics)
+    if err != nil {
+      return diagnostics, err
+    }
   }
-  return nil, nil
+  return diagnostics, output.flush()
 }
 
 // writePluginEmitOutput writes one artifact of the hand-assembled emit, passing

--- a/packages/ttsc/driver/emit_plugin_output.go
+++ b/packages/ttsc/driver/emit_plugin_output.go
@@ -1,0 +1,83 @@
+package driver
+
+import (
+  "fmt"
+  "strings"
+
+  shimast "github.com/microsoft/typescript-go/shim/ast"
+  shimcompiler "github.com/microsoft/typescript-go/shim/compiler"
+)
+
+// PluginEmitError reports compiler errors from a native plugin emit. The same
+// diagnostics remain in the returned slice for structured consumers. Hosts
+// that only check the Go error still reject an incomplete build and display
+// the compiler's code, severity and available source context.
+type PluginEmitError struct {
+  Diagnostics []Diagnostic
+  Phase string
+  Declarations bool
+  cwd string
+}
+
+func (e *PluginEmitError) Error() string {
+  var out strings.Builder
+  fmt.Fprintf(&out, "driver: native plugin %s failed; build output is incomplete", e.Phase)
+  if e.Declarations {
+    out.WriteString("; declaration output is incomplete or skipped")
+  }
+  out.WriteByte('\n')
+  WritePrettyDiagnostics(&out, e.Diagnostics, e.cwd)
+  return strings.TrimSpace(out.String())
+}
+
+func (p *Program) pluginEmitDiagnostics(phase string, raw []*shimast.Diagnostic) ([]Diagnostic, error) {
+  diagnostics := p.convertProgramDiagnostics(raw)
+  if CountErrors(diagnostics) == 0 {
+    return diagnostics, nil
+  }
+  return diagnostics, &PluginEmitError{
+    Diagnostics: diagnostics,
+    Phase: phase,
+    Declarations: p.TSProgram.Options().GetEmitDeclarations(),
+    cwd: p.TSProgram.GetCurrentDirectory(),
+  }
+}
+
+type pluginEmitOutput struct {
+  writeFile shimcompiler.WriteFile
+  buffered bool
+  pending []pluginEmitFile
+}
+
+type pluginEmitFile struct {
+  name string
+  text string
+  data *shimcompiler.WriteFileData
+}
+
+func newPluginEmitOutput(writeFile shimcompiler.WriteFile, buffered bool) *pluginEmitOutput {
+  if writeFile == nil {
+    writeFile = func(name, text string, _ *shimcompiler.WriteFileData) error {
+      return DefaultWriteFile(name, text)
+    }
+  }
+  return &pluginEmitOutput{writeFile: writeFile, buffered: buffered}
+}
+
+// The caller serializes declaration writes; JavaScript and flush are serial.
+func (o *pluginEmitOutput) write(name, text string, data *shimcompiler.WriteFileData) error {
+  if !o.buffered {
+    return o.writeFile(name, text, data)
+  }
+  o.pending = append(o.pending, pluginEmitFile{name, text, data})
+  return nil
+}
+
+func (o *pluginEmitOutput) flush() error {
+  for _, file := range o.pending {
+    if err := o.writeFile(file.name, file.text, file.data); err != nil {
+      return fmt.Errorf("driver: native plugin output write failed for %s; build output is incomplete: %w", file.name, err)
+    }
+  }
+  return nil
+}

--- a/packages/ttsc/driver/emit_plugin_output.go
+++ b/packages/ttsc/driver/emit_plugin_output.go
@@ -13,10 +13,10 @@ import (
 // that only check the Go error still reject an incomplete build and display
 // the compiler's code, severity and available source context.
 type PluginEmitError struct {
-  Diagnostics []Diagnostic
-  Phase string
+  Diagnostics  []Diagnostic
+  Phase        string
   Declarations bool
-  cwd string
+  cwd          string
 }
 
 func (e *PluginEmitError) Error() string {
@@ -36,17 +36,17 @@ func (p *Program) pluginEmitDiagnostics(phase string, raw []*shimast.Diagnostic)
     return diagnostics, nil
   }
   return diagnostics, &PluginEmitError{
-    Diagnostics: diagnostics,
-    Phase: phase,
+    Diagnostics:  diagnostics,
+    Phase:        phase,
     Declarations: p.TSProgram.Options().GetEmitDeclarations(),
-    cwd: p.TSProgram.GetCurrentDirectory(),
+    cwd:          p.TSProgram.GetCurrentDirectory(),
   }
 }
 
 type pluginEmitOutput struct {
   writeFile shimcompiler.WriteFile
-  buffered bool
-  pending []pluginEmitFile
+  buffered  bool
+  pending   []pluginEmitFile
 }
 
 type pluginEmitFile struct {

--- a/packages/ttsc/driver/program.go
+++ b/packages/ttsc/driver/program.go
@@ -142,7 +142,9 @@ func WritePrettyDiagnostics(w io.Writer, diagnostics []Diagnostic, cwd string) {
   rich := make([]Diagnostic, 0, len(diagnostics))
   plain := make([]Diagnostic, 0)
   for _, d := range diagnostics {
-    if d.raw != nil || d.lint != nil {
+    if d.raw != nil && d.raw.File() != nil && d.raw.Pos() < 0 {
+      plain = append(plain, d)
+    } else if d.raw != nil || d.lint != nil {
       rich = append(rich, d)
     } else {
       plain = append(plain, d)
@@ -162,7 +164,18 @@ func WritePrettyDiagnostics(w io.Writer, diagnostics []Diagnostic, cwd string) {
     shimdiagnosticwriter.FormatMixedDiagnostics(w, astDiags, lintDiags, cwd)
   }
   for _, d := range plain {
-    fmt.Fprintln(w, "  -", d.String())
+    severity := "error"
+    if d.Severity == SeverityWarning {
+      severity = "warning"
+    }
+    code := ""
+    if d.Code != 0 {
+      code = fmt.Sprintf(" TS%d", d.Code)
+    }
+    fmt.Fprintf(w, "  - %s%s: %s\n", severity, code, d.String())
+    if d.raw != nil && d.raw.File() != nil && d.raw.Pos() < 0 {
+      fmt.Fprintln(w, "    Diagnostic refers to generated code; no authored source location is available.")
+    }
   }
 }
 
@@ -187,9 +200,10 @@ func CountErrors(diagnostics []Diagnostic) int {
       }
       continue
     }
-    // Plain text diagnostics (manually assembled): treat as errors so
-    // "ttsc: tsconfig not found"-style failures still flip the exit code.
-    n++
+    // Plain diagnostics default to error but may explicitly declare warning.
+    if d.Severity != SeverityWarning {
+      n++
+    }
   }
   return n
 }

--- a/packages/ttsc/test/cli/project_build_emit_error_rejects_manifest_test.go
+++ b/packages/ttsc/test/cli/project_build_emit_error_rejects_manifest_test.go
@@ -1,0 +1,35 @@
+package ttsc_test
+
+import (
+  "os"
+  "path/filepath"
+  "strings"
+  "testing"
+)
+
+// Verifies the native CLI rejects a diagnostic-only declaration failure.
+//
+// Ordinary source checking does not report TS4094 in an emitting project.
+// The host must inspect emit diagnostics before publishing its manifest.
+//
+// 1. Export an anonymous class with a private field and enable declarations.
+// 2. Run the real build command with a manifest path.
+// 3. Assert nonzero status, TS4094, failure context and no success manifest.
+func TestCLIProjectBuildEmitErrorRejectsManifest(t *testing.T) {
+  root := t.TempDir()
+  writeProjectFile(t, root, "tsconfig.json", `{"compilerOptions":{"target":"es2020","module":"commonjs","outDir":"lib","declaration":true},"files":["index.ts"]}`)
+  writeProjectFile(t, root, "index.ts", `export const value = class { private hidden = 1; };`)
+  manifest := filepath.Join(root, "manifest.json")
+  code, out, errOut := runNativeCommand(t, "build", "--cwd", root, "--emit", "--manifest", manifest)
+  if code == 0 {
+    t.Fatalf("build succeeded: %s %s", out, errOut)
+  }
+  for _, text := range []string{"error", "TS4094", "ttsc: emit failed", "build output is incomplete"} {
+    if !strings.Contains(errOut, text) {
+      t.Fatalf("missing %q: %s", text, errOut)
+    }
+  }
+  if _, err := os.Stat(manifest); !os.IsNotExist(err) {
+    t.Fatalf("incomplete build published a manifest: %v", err)
+  }
+}

--- a/packages/ttsc/test/driver/diagnostic_plain_warnings_preserve_severity_test.go
+++ b/packages/ttsc/test/driver/diagnostic_plain_warnings_preserve_severity_test.go
@@ -1,0 +1,32 @@
+package driver_test
+
+import (
+  "bytes"
+  "strings"
+  "testing"
+
+  "github.com/samchon/ttsc/packages/ttsc/driver"
+)
+
+// Verifies plain warning diagnostics preserve severity in counting and output.
+//
+// Native hosts may receive diagnostic DTOs without a raw compiler or lint
+// object. That representation must not turn a warning into a build error.
+//
+// 1. Construct an explicit warning and a default error without source anchors.
+// 2. Count empty, warning-only and mixed diagnostic batches.
+// 3. Render both and assert their severity and codes remain visible.
+func TestDiagnosticPlainWarningsPreserveSeverity(t *testing.T) {
+  warning := driver.Diagnostic{Severity: driver.SeverityWarning, Code: 1001, Message: "advice"}
+  failure := driver.Diagnostic{Code: 1002, Message: "failure"}
+  if driver.CountErrors(nil) != 0 || driver.CountErrors([]driver.Diagnostic{warning}) != 0 || driver.CountErrors([]driver.Diagnostic{warning, failure}) != 1 {
+    t.Fatal("plain diagnostic severity changed the error count")
+  }
+  var out bytes.Buffer
+  driver.WritePrettyDiagnostics(&out, []driver.Diagnostic{warning, failure}, "")
+  for _, text := range []string{"warning TS1001: advice", "error TS1002: failure"} {
+    if !strings.Contains(out.String(), text) {
+      t.Fatalf("missing %q: %s", text, out.String())
+    }
+  }
+}

--- a/packages/ttsc/test/driver/emit_plugin_declaration_errors_return_go_error_test.go
+++ b/packages/ttsc/test/driver/emit_plugin_declaration_errors_return_go_error_test.go
@@ -1,0 +1,50 @@
+package driver_test
+
+import (
+  "errors"
+  "fmt"
+  "strings"
+  "testing"
+
+  shimcompiler "github.com/microsoft/typescript-go/shim/compiler"
+
+  "github.com/samchon/ttsc/packages/ttsc/driver"
+)
+
+// Verifies declaration diagnostics also return a failing Go error.
+//
+// Legacy native hosts check err but only print the diagnostic slice. TS4094
+// must fail those hosts while noEmitOnError still controls output publication.
+//
+// 1. Export an anonymous class whose private member prevents valid declarations.
+// 2. Emit with noEmitOnError enabled and disabled.
+// 3. Assert structured TS4094, declaration failure context and the write policy.
+func TestEmitPluginDeclarationErrorsReturnGoError(t *testing.T) {
+  for _, noEmitOnError := range []bool{false, true} {
+    t.Run(fmt.Sprint(noEmitOnError), func(t *testing.T) {
+      root := t.TempDir()
+      writeProjectFile(t, root, "tsconfig.json", fmt.Sprintf(`{"compilerOptions":{"target":"es2020","module":"commonjs","outDir":"lib","declaration":true,"noEmitOnError":%v},"files":["index.ts"]}`, noEmitOnError))
+      writeProjectFile(t, root, "index.ts", `export const value = class { private hidden = 1; };`)
+      p, diagnostics, err := driver.LoadProgram(root, "tsconfig.json", driver.LoadProgramOptions{})
+      if err != nil || len(diagnostics) != 0 {
+        t.Fatalf("load: %v %v", err, diagnostics)
+      }
+      defer p.Close()
+      writes := 0
+      diagnostics, err = p.EmitWithPluginTransformers(nil, func(_, _ string, _ *shimcompiler.WriteFileData) error {
+        writes++
+        return nil
+      })
+      var failure *driver.PluginEmitError
+      if !errors.As(err, &failure) || len(diagnostics) != 1 || diagnostics[0].Code != 4094 {
+        t.Fatalf("diagnostics=%v error=%v", diagnostics, err)
+      }
+      if (writes == 0) != noEmitOnError {
+        t.Fatalf("noEmitOnError=%v writes=%d", noEmitOnError, writes)
+      }
+      if !strings.Contains(err.Error(), "declaration output is incomplete or skipped") || !strings.Contains(err.Error(), "TS4094") {
+        t.Fatalf("missing declaration failure details: %v", err)
+      }
+    })
+  }
+}

--- a/packages/ttsc/test/driver/emit_plugin_default_writer_respects_failure_policy_test.go
+++ b/packages/ttsc/test/driver/emit_plugin_default_writer_respects_failure_policy_test.go
@@ -1,0 +1,53 @@
+package driver_test
+
+import (
+  "fmt"
+  "os"
+  "path/filepath"
+  "testing"
+
+  "github.com/samchon/ttsc/packages/ttsc/driver"
+)
+
+// Verifies a nil plugin writer publishes complete output or returns a write error.
+//
+// Buffering must retain the default filesystem writer when no callback is
+// supplied, and a failed final flush must never report successful compilation.
+//
+// 1. Load declaration projects with and without noEmitOnError buffering.
+// 2. Emit normally, then repeat with a file obstructing the output directory.
+// 3. Assert both complete disk output and failing filesystem writes.
+func TestEmitPluginDefaultWriterRespectsFailurePolicy(t *testing.T) {
+  for _, buffered := range []bool{false, true} {
+    for _, obstructed := range []bool{false, true} {
+      t.Run(fmt.Sprintf("buffered=%v/obstructed=%v", buffered, obstructed), func(t *testing.T) {
+        root := t.TempDir()
+        writeProjectFile(t, root, "tsconfig.json", fmt.Sprintf(`{"compilerOptions":{"target":"es2020","module":"commonjs","outDir":"lib","declaration":true,"noEmitOnError":%v},"files":["index.ts"]}`, buffered))
+        writeProjectFile(t, root, "index.ts", `export const value: number = 1;`)
+        if obstructed {
+          writeProjectFile(t, root, "lib", "occupied")
+        }
+        p, diagnostics, err := driver.LoadProgram(root, "tsconfig.json", driver.LoadProgramOptions{})
+        if err != nil || len(diagnostics) != 0 {
+          t.Fatalf("load: %v %v", err, diagnostics)
+        }
+        defer p.Close()
+        diagnostics, err = p.EmitWithPluginTransformers(nil, nil)
+        if obstructed {
+          if err == nil {
+            t.Fatal("obstructed output directory reported success")
+          }
+          return
+        }
+        if err != nil || len(diagnostics) != 0 {
+          t.Fatalf("emit: %v %v", err, diagnostics)
+        }
+        for _, file := range []string{"index.js", "index.d.ts"} {
+          if data, err := os.ReadFile(filepath.Join(root, "lib", file)); err != nil || len(data) == 0 {
+            t.Fatalf("missing %s: %v", file, err)
+          }
+        }
+      })
+    }
+  }
+}

--- a/packages/ttsc/test/driver/emit_plugin_generated_members_keep_declarations_test.go
+++ b/packages/ttsc/test/driver/emit_plugin_generated_members_keep_declarations_test.go
@@ -1,0 +1,107 @@
+package driver_test
+
+import (
+  "fmt"
+  "path/filepath"
+  "strings"
+  "testing"
+
+  shimast "github.com/microsoft/typescript-go/shim/ast"
+  shimcompiler "github.com/microsoft/typescript-go/shim/compiler"
+  shimprinter "github.com/microsoft/typescript-go/shim/printer"
+
+  "github.com/samchon/ttsc/packages/ttsc/driver"
+)
+
+// Verifies generated member accesses preserve declarations and checker state.
+//
+// Independent factories do not mark generated nodes as synthesized. Neither
+// those nodes nor generated nodes with copied source ranges belong to the
+// original checker. Genuine original mappings must still inline const enums.
+//
+// 1. Load valid sources with declarations, maps and noEmitOnError.
+// 2. Inject a bound arrow with property or element access using each factory.
+// 3. Emit twice and check complete output, clean diagnostics and enum inlining.
+func TestEmitPluginGeneratedMembersKeepDeclarations(t *testing.T) {
+  for _, factory := range []string{"emit", "standalone", "copied-range"} {
+    for _, element := range []bool{false, true} {
+      t.Run(fmt.Sprintf("%s/element=%v", factory, element), func(t *testing.T) {
+        root := t.TempDir()
+        writeProjectFile(t, root, "tsconfig.json", `{"compilerOptions":{"module":"commonjs","target":"es2020","outDir":"lib","strict":true,"declaration":true,"declarationMap":true,"sourceMap":true,"noEmitOnError":true},"files":["index.ts","other.ts"]}`)
+        writeProjectFile(t, root, "index.ts", "const enum E { A = 7, B = 11 }\nexport const answer: number = 0;\nexport const constant = E.A + E[\"B\"];\n")
+        writeProjectFile(t, root, "other.ts", "export interface Other { value: string; }\n")
+        program, diagnostics, err := driver.LoadProgram(root, "tsconfig.json", driver.LoadProgramOptions{})
+        if err != nil || len(diagnostics) != 0 {
+          t.Fatalf("load: %v %v", err, diagnostics)
+        }
+        defer program.Close()
+        if diagnostics := program.Diagnostics(); len(diagnostics) != 0 {
+          t.Fatalf("source diagnostics: %v", diagnostics)
+        }
+        transform := func(ec *shimprinter.EmitContext, source *shimast.SourceFile) *shimast.SourceFile {
+          var visitor *shimast.NodeVisitor
+          visitor = ec.NewNodeVisitor(func(node *shimast.Node) *shimast.Node {
+            if node.Kind == shimast.KindPropertyAccessExpression && node.Expression().Text() == "E" {
+              // A rebuilt original is a valid checker input through ParseNode.
+              rebuilt := ec.Factory.NewPropertyAccessExpression(node.Expression(), nil, node.Name(), shimast.NodeFlagsNone)
+              ec.SetOriginal(rebuilt, node)
+              return rebuilt
+            }
+            if node.Kind != shimast.KindNumericLiteral || node.Text() != "0" {
+              return visitor.VisitEachChild(node)
+            }
+            f := ec.Factory
+            memberFactory := &f.NodeFactory
+            if factory != "emit" {
+              memberFactory = shimast.NewNodeFactory(shimast.NodeFactoryHooks{})
+            }
+            var access *shimast.Node
+            if element {
+              access = memberFactory.NewElementAccessExpression(f.NewIdentifier("input"), nil, memberFactory.NewStringLiteral("value", 0), shimast.NodeFlagsNone)
+            } else {
+              access = memberFactory.NewPropertyAccessExpression(f.NewIdentifier("input"), nil, memberFactory.NewIdentifier("value"), shimast.NodeFlagsNone)
+            }
+            if factory == "copied-range" {
+              access.Loc = node.Loc
+            }
+            parameter := f.NewParameterDeclaration(nil, nil, f.NewIdentifier("input"), nil, nil, nil)
+            arrow := f.NewArrowFunction(nil, nil, f.NewNodeList([]*shimast.Node{parameter}), nil, nil, f.NewToken(shimast.KindEqualsGreaterThanToken), access)
+            argument := f.NewObjectLiteralExpression(f.NewNodeList([]*shimast.Node{
+              f.NewPropertyAssignment(nil, f.NewIdentifier("value"), nil, nil, f.NewNumericLiteral("123", 0)),
+            }), false)
+            return f.NewCallExpression(f.NewParenthesizedExpression(arrow), nil, nil, f.NewNodeList([]*shimast.Node{argument}), shimast.NodeFlagsNone)
+          })
+          return visitor.VisitSourceFile(source)
+        }
+        for iteration := 0; iteration < 2; iteration++ {
+          outputs := map[string]string{}
+          diagnostics, err := program.EmitWithPluginTransformer(transform, func(name, source string, _ *shimcompiler.WriteFileData) error {
+            outputs[filepath.Base(name)] = source
+            return nil
+          })
+          if err != nil || len(diagnostics) != 0 {
+            t.Fatalf("emit %d: %v %v", iteration, err, diagnostics)
+          }
+          for _, file := range []string{"index.js", "index.js.map", "index.d.ts", "index.d.ts.map", "other.d.ts", "other.d.ts.map"} {
+            if outputs[file] == "" {
+              t.Fatalf("missing %s: %v", file, outputs)
+            }
+          }
+          if !strings.Contains(outputs["index.d.ts"], "answer: number") || !strings.Contains(outputs["index.js"], "7 /* E.A */ + 11 /* E[\"B\"] */") {
+            t.Fatalf("declarations or original enum resolution changed: %v", outputs)
+          }
+          member := "input.value"
+          if element {
+            member = "input[\"value\"]"
+          }
+          if !strings.Contains(outputs["index.js"], "input => "+member) {
+            t.Fatalf("generated member lost: %s", outputs["index.js"])
+          }
+          if diagnostics := program.Diagnostics(); len(diagnostics) != 0 {
+            t.Fatalf("checker contaminated after emit: %v", diagnostics)
+          }
+        }
+      })
+    }
+  }
+}

--- a/packages/ttsc/test/driver/emit_plugin_late_errors_withhold_outputs_test.go
+++ b/packages/ttsc/test/driver/emit_plugin_late_errors_withhold_outputs_test.go
@@ -1,0 +1,66 @@
+package driver_test
+
+import (
+  "fmt"
+  "strings"
+  "testing"
+
+  shimast "github.com/microsoft/typescript-go/shim/ast"
+  shimcompiler "github.com/microsoft/typescript-go/shim/compiler"
+  shimprinter "github.com/microsoft/typescript-go/shim/printer"
+
+  "github.com/samchon/ttsc/packages/ttsc/driver"
+)
+
+// Verifies a plugin's direct checker error cannot publish buffered outputs.
+//
+// A plugin can query the checker itself after the pre-emit gate. An error from
+// that query must fail both JS-only and declaration builds without writing a
+// successful prefix or attempting to render a negative source position.
+//
+// 1. Load two clean source files under noEmitOnError.
+// 2. Let the second transform query a generated unresolved member expression.
+// 3. Assert TS2304, generated-code context and zero output callbacks.
+func TestEmitPluginLateErrorsWithholdOutputs(t *testing.T) {
+  for _, declarations := range []bool{false, true} {
+    t.Run(fmt.Sprint(declarations), func(t *testing.T) {
+      root := t.TempDir()
+      writeProjectFile(t, root, "tsconfig.json", fmt.Sprintf(`{"compilerOptions":{"target":"es2020","module":"commonjs","outDir":"lib","sourceMap":true,"noEmitOnError":true,"declaration":%v},"files":["first.ts","second.ts"]}`, declarations))
+      writeProjectFile(t, root, "first.ts", `export const first = 1;`)
+      writeProjectFile(t, root, "second.ts", `export const second = 2;`)
+      p, diagnostics, err := driver.LoadProgram(root, "tsconfig.json", driver.LoadProgramOptions{})
+      if err != nil || len(diagnostics) != 0 {
+        t.Fatalf("load: %v %v", err, diagnostics)
+      }
+      defer p.Close()
+      calls, writes := 0, 0
+      transform := func(_ *shimprinter.EmitContext, sf *shimast.SourceFile) *shimast.SourceFile {
+        calls++
+        if calls == 2 {
+          f := shimast.NewNodeFactory(shimast.NodeFactoryHooks{})
+          member := f.NewPropertyAccessExpression(f.NewIdentifier("generatedInput"), nil, f.NewIdentifier("value"), shimast.NodeFlagsNone)
+          member.Parent = sf.AsNode()
+          shimast.SetParentInChildrenUnset(member)
+          p.Checker.GetConstantValue(member)
+        }
+        return sf
+      }
+      diagnostics, err = p.EmitWithPluginTransformer(transform, func(_, _ string, _ *shimcompiler.WriteFileData) error {
+        writes++
+        return nil
+      })
+      if err == nil || writes != 0 || calls != 2 || len(diagnostics) != 1 || diagnostics[0].Code != 2304 {
+        t.Fatalf("calls=%d writes=%d diags=%v err=%v", calls, writes, diagnostics, err)
+      }
+      d := diagnostics[0]
+      if d.Line != 0 || d.Column != 0 || d.Start != nil || d.Length != nil {
+        t.Fatalf("invented authored location: %+v", d)
+      }
+      for _, text := range []string{"error TS2304", "generatedInput", "generated code", "no authored source location", "native plugin"} {
+        if !strings.Contains(err.Error(), text) {
+          t.Fatalf("missing %q: %v", text, err)
+        }
+      }
+    })
+  }
+}

--- a/packages/ttsc/test/driver/emit_plugin_noemit_preserves_build_information_test.go
+++ b/packages/ttsc/test/driver/emit_plugin_noemit_preserves_build_information_test.go
@@ -1,0 +1,46 @@
+package driver_test
+
+import (
+  "strings"
+  "testing"
+
+  shimast "github.com/microsoft/typescript-go/shim/ast"
+  shimcompiler "github.com/microsoft/typescript-go/shim/compiler"
+  shimprinter "github.com/microsoft/typescript-go/shim/printer"
+
+  "github.com/samchon/ttsc/packages/ttsc/driver"
+)
+
+// Verifies noEmit skips JavaScript while preserving upstream build information.
+//
+// The manual JS emitter must respect analysis-only configuration just as the
+// upstream declaration emitter does, including a configured incremental build.
+//
+// 1. Load a valid project with noEmit, declaration and incremental enabled.
+// 2. Call the plugin emitter with observable transform and write callbacks.
+// 3. Assert no transform runs and only the build-information artifact is written.
+func TestEmitPluginNoEmitPreservesBuildInformation(t *testing.T) {
+  root := t.TempDir()
+  writeProjectFile(t, root, "tsconfig.json", `{"compilerOptions":{"target":"es2020","noEmit":true,"declaration":true,"incremental":true},"files":["index.ts"]}`)
+  writeProjectFile(t, root, "index.ts", `export const value = 1;`)
+  p, diagnostics, err := driver.LoadProgram(root, "tsconfig.json", driver.LoadProgramOptions{})
+  if err != nil || len(diagnostics) != 0 {
+    t.Fatalf("load: %v %v", err, diagnostics)
+  }
+  defer p.Close()
+  called := false
+  writes := []string{}
+  diagnostics, err = p.EmitWithPluginTransformer(func(_ *shimprinter.EmitContext, sf *shimast.SourceFile) *shimast.SourceFile {
+    called = true
+    return sf
+  }, func(name, _ string, _ *shimcompiler.WriteFileData) error {
+    writes = append(writes, name)
+    return nil
+  })
+  if called || err != nil || len(diagnostics) != 0 {
+    t.Fatalf("called=%v diagnostics=%v error=%v", called, diagnostics, err)
+  }
+  if len(writes) != 1 || !strings.HasSuffix(writes[0], ".tsbuildinfo") {
+    t.Fatalf("noEmit incremental artifacts: %v", writes)
+  }
+}

--- a/packages/ttsc/test/driver/emit_plugin_source_errors_withhold_outputs_test.go
+++ b/packages/ttsc/test/driver/emit_plugin_source_errors_withhold_outputs_test.go
@@ -1,0 +1,49 @@
+package driver_test
+
+import (
+  "errors"
+  "fmt"
+  "strings"
+  "testing"
+
+  shimcompiler "github.com/microsoft/typescript-go/shim/compiler"
+
+  "github.com/samchon/ttsc/packages/ttsc/driver"
+)
+
+// Verifies noEmitOnError blocks every plugin output on source errors.
+//
+// The handwritten JavaScript lane must obey the same pre-emit gate as the
+// declaration lane, even when no declaration pass is configured.
+//
+// 1. Load an invalid source with JS-only, declaration and declaration-only output.
+// 2. Emit without a prior host diagnostic call and capture writes.
+// 3. Assert TS2322, a Go error, truthful context and zero writes.
+func TestEmitPluginSourceErrorsWithholdOutputs(t *testing.T) {
+  for _, options := range []string{"", `,"declaration":true`, `,"declaration":true,"emitDeclarationOnly":true`, `,"incremental":true`} {
+    t.Run(options, func(t *testing.T) {
+      root := t.TempDir()
+      writeProjectFile(t, root, "tsconfig.json", fmt.Sprintf(`{"compilerOptions":{"target":"es2020","module":"commonjs","outDir":"lib","noEmitOnError":true%s},"files":["index.ts"]}`, options))
+      writeProjectFile(t, root, "index.ts", `export const value: number = "bad";`)
+      p, diagnostics, err := driver.LoadProgram(root, "tsconfig.json", driver.LoadProgramOptions{})
+      if err != nil || len(diagnostics) != 0 {
+        t.Fatalf("load: %v %v", err, diagnostics)
+      }
+      defer p.Close()
+      writes := 0
+      diagnostics, err = p.EmitWithPluginTransformers(nil, func(_, _ string, _ *shimcompiler.WriteFileData) error {
+        writes++
+        return nil
+      })
+      var failure *driver.PluginEmitError
+      if !errors.As(err, &failure) || writes != 0 || len(diagnostics) != 1 || diagnostics[0].Code != 2322 {
+        t.Fatalf("writes=%d diagnostics=%v error=%v", writes, diagnostics, err)
+      }
+      for _, text := range []string{"native plugin pre-emit checking failed", "error", "TS2322", "index.ts", "build output is incomplete"} {
+        if !strings.Contains(err.Error(), text) {
+          t.Fatalf("missing %q: %v", text, err)
+        }
+      }
+    })
+  }
+}

--- a/packages/ttsc/test/driver/emit_plugin_synthetic_member_access_const_enum_no_panic_test.go
+++ b/packages/ttsc/test/driver/emit_plugin_synthetic_member_access_const_enum_no_panic_test.go
@@ -1,23 +1,5 @@
 package driver_test
 
-// R4: the const-enum inliner must survive plugin-built member accesses.
-//
-// tsgo's ConstEnumInliningTransformer calls EmitResolver.GetConstantValue on
-// every property/element access it visits during emit, including the synthetic
-// nodes a plugin injects. The checker can nil-panic computing a type for such a
-// node, so the driver wraps the resolver in an unexported guardedEmitResolver
-// whose GetConstantValue recovers any panic to nil ("not a const-enum member").
-//
-// This test drives the full emit pipeline with a const enum present (so the
-// inliner runs and visits every property/element access) and a plugin that
-// injects a synthetic property access AND a synthetic element access. Emit must
-// complete without panic, the real const-enum references must be inlined
-// (proving the inliner is active over the transformed tree), and the synthetic
-// accesses must survive verbatim. This locks the integration-level contract
-// that a plugin may freely inject member-access AST into a const-enum project
-// without crashing emit, which is exactly the path the guardedEmitResolver
-// recover backstops.
-
 import (
   "path/filepath"
   "strings"
@@ -30,6 +12,15 @@ import (
   "github.com/samchon/ttsc/packages/ttsc/driver"
 )
 
+// Verifies emit-context member accesses remain generated during enum inlining.
+//
+// The inliner follows original mappings before consulting the resolver. An
+// emit-factory access has no parse original and must never enter the checker,
+// while genuine enum members still resolve to their constants.
+//
+// 1. Load a const-enum project and inject nested synthetic member accesses.
+// 2. Emit through the real plugin pipeline.
+// 3. Assert both real enum inlining and unchanged generated accesses.
 func TestEmitWithSyntheticMemberAccessDoesNotPanicWithConstEnum(t *testing.T) {
   root := t.TempDir()
   writeProjectFile(t, root, "tsconfig.json", `{"compilerOptions":{"module":"commonjs","target":"es2020","outDir":"bin","strict":true},"files":["index.ts"]}`)
@@ -47,7 +38,7 @@ func TestEmitWithSyntheticMemberAccessDoesNotPanicWithConstEnum(t *testing.T) {
   // The plugin replaces the `0` initializer with a synthetic element access
   // built on top of a synthetic property access: `synthObj.X[3]`. Both are
   // property/element accesses, so the const-enum inliner's visitor descends
-  // into them and calls GetConstantValue on each.
+  // into them while ParseNode excludes them from constant resolution.
   transform := func(ec *shimprinter.EmitContext, sf *shimast.SourceFile) *shimast.SourceFile {
     var visitor *shimast.NodeVisitor
     visit := func(node *shimast.Node) *shimast.Node {
@@ -69,11 +60,11 @@ func TestEmitWithSyntheticMemberAccessDoesNotPanicWithConstEnum(t *testing.T) {
   emitted := map[string]string{}
   // EmitWithPluginTransformer would panic here (and fail the test) if the
   // const-enum inliner hit GetConstantValue on the synthetic access unguarded.
-  if _, err := prog.EmitWithPluginTransformer(transform, func(fileName, text string, _ *shimcompiler.WriteFileData) error {
+  if diagnostics, err := prog.EmitWithPluginTransformer(transform, func(fileName, text string, _ *shimcompiler.WriteFileData) error {
     emitted[filepath.Base(fileName)] = text
     return nil
-  }); err != nil {
-    t.Fatal(err)
+  }); err != nil || len(diagnostics) != 0 {
+    t.Fatalf("emit: %v %v", err, diagnostics)
   }
 
   js := emitted["index.js"]

--- a/packages/ttsc/test/driver/emit_plugin_write_errors_fail_build_test.go
+++ b/packages/ttsc/test/driver/emit_plugin_write_errors_fail_build_test.go
@@ -1,0 +1,49 @@
+package driver_test
+
+import (
+  "errors"
+  "fmt"
+  "path/filepath"
+  "strings"
+  "testing"
+
+  shimcompiler "github.com/microsoft/typescript-go/shim/compiler"
+
+  "github.com/samchon/ttsc/packages/ttsc/driver"
+)
+
+// Verifies write failures remain failures on every plugin output lane.
+//
+// The declaration emitter converts callback errors into diagnostics, whereas
+// JS and buffered flushes return Go errors directly. All must reject success.
+//
+// 1. Configure JavaScript, declarations and both source maps.
+// 2. Fail each artifact's callback with and without noEmitOnError buffering.
+// 3. Assert a non-nil error preserving the write failure message.
+func TestEmitPluginWriteErrorsFailBuild(t *testing.T) {
+  for _, buffered := range []bool{false, true} {
+    for _, file := range []string{"index.js", "index.js.map", "index.d.ts", "index.d.ts.map"} {
+      t.Run(fmt.Sprintf("%v/%s", buffered, file), func(t *testing.T) {
+        root := t.TempDir()
+        writeProjectFile(t, root, "tsconfig.json", fmt.Sprintf(`{"compilerOptions":{"target":"es2020","module":"commonjs","outDir":"lib","declaration":true,"sourceMap":true,"declarationMap":true,"noEmitOnError":%v},"files":["index.ts"]}`, buffered))
+        writeProjectFile(t, root, "index.ts", `export const value: number = 1;`)
+        p, diagnostics, err := driver.LoadProgram(root, "tsconfig.json", driver.LoadProgramOptions{})
+        if err != nil || len(diagnostics) != 0 {
+          t.Fatalf("load: %v %v", err, diagnostics)
+        }
+        defer p.Close()
+        failed := false
+        _, err = p.EmitWithPluginTransformers(nil, func(name, _ string, _ *shimcompiler.WriteFileData) error {
+          if filepath.Base(name) == file {
+            failed = true
+            return errors.New("output device unavailable")
+          }
+          return nil
+        })
+        if !failed || err == nil || !strings.Contains(err.Error(), "output device unavailable") {
+          t.Fatalf("failed=%v error=%v", failed, err)
+        }
+      })
+    }
+  }
+}

--- a/packages/ttsc/test/utility/build_emit_error_reports_compiler_context_test.go
+++ b/packages/ttsc/test/utility/build_emit_error_reports_compiler_context_test.go
@@ -1,0 +1,33 @@
+package ttsc_test
+
+import (
+  "strings"
+  "testing"
+
+  "github.com/samchon/ttsc/packages/ttsc/utility"
+)
+
+// Verifies the utility host fails and identifies an emit diagnostic.
+//
+// Emit diagnostics may accompany a nil Go error. The utility host must keep
+// TS4094 and the error severity visible and report an incomplete build.
+//
+// 1. Load a source whose exported anonymous class cannot have declarations.
+// 2. Run the utility build entrypoint with declarations enabled.
+// 3. Assert a failing status and compiler plus host/phase context.
+func TestUtilityBuildEmitErrorReportsCompilerContext(t *testing.T) {
+  root := t.TempDir()
+  writeProjectFile(t, root, "tsconfig.json", `{"compilerOptions":{"target":"es2020","module":"commonjs","outDir":"lib","declaration":true},"files":["index.ts"]}`)
+  writeProjectFile(t, root, "index.ts", `export const value = class { private hidden = 1; };`)
+  code, out, errOut := captureUtilityOutput(t, func() int {
+    return utility.RunBuild([]string{"--cwd", root, "--emit"})
+  })
+  if code == 0 {
+    t.Fatalf("build succeeded: %s %s", out, errOut)
+  }
+  for _, text := range []string{"error", "TS4094", "ttsc utility: emit failed", "build output is incomplete"} {
+    if !strings.Contains(errOut, text) {
+      t.Fatalf("missing %q: %s", text, errOut)
+    }
+  }
+}

--- a/packages/ttsc/utility/host.go
+++ b/packages/ttsc/utility/host.go
@@ -115,10 +115,9 @@ func RunBuildWithIO(args []string, stdout, stderr io.Writer) int {
     fmt.Fprintf(opts.stderr, "ttsc utility: emit failed: %v\n", err)
     return 3
   }
-  for _, d := range eDiags {
-    fmt.Fprintln(opts.stderr, "  -", d.String())
-  }
+  driver.WritePrettyDiagnostics(opts.stderr, eDiags, opts.cwd)
   if driver.CountErrors(eDiags) > 0 {
+    fmt.Fprintln(opts.stderr, "ttsc utility: emit failed; build output is incomplete")
     return 2
   }
   if res != nil && !opts.quiet {

--- a/tests/projects/go-driver-emit-plugin/go-plugin/main.go
+++ b/tests/projects/go-driver-emit-plugin/go-plugin/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+  "encoding/json"
   "flag"
   "fmt"
   "os"
@@ -40,6 +41,7 @@ func runBuild(args []string) int {
   fs.SetOutput(os.Stderr)
   cwd := fs.String("cwd", "", "")
   tsconfig := fs.String("tsconfig", "", "")
+  manifest := fs.String("manifest", "manifest.json", "")
   _ = fs.String("plugins-json", "", "")
   _ = fs.Bool("emit", false, "")
   _ = fs.Bool("noEmit", false, "")
@@ -74,14 +76,40 @@ func runBuild(args []string) int {
   }
   defer prog.Close()
 
-  emitDiags, err := prog.EmitWithPluginTransformers([]driver.PluginTransform{replaceBeforeLiteral}, writeFile)
+  // Match existing native hosts that buffer outputs and check only the Go
+  // error before publication. Compiler diagnostics must also fail this host.
+  pending := map[string]string{}
+  emitDiags, err := prog.EmitWithPluginTransformers([]driver.PluginTransform{replaceBeforeLiteral}, func(name, text string, _ *shimcompiler.WriteFileData) error {
+    pending[name] = text
+    return nil
+  })
   if err != nil {
-    fmt.Fprintln(os.Stderr, err)
+    fmt.Fprintln(os.Stderr, "go-driver-emit-plugin: emit failed:", err)
     return 2
   }
-  if len(emitDiags) != 0 {
-    driver.WritePrettyDiagnostics(os.Stderr, emitDiags, root)
-    return 2
+  driver.WritePrettyDiagnostics(os.Stderr, emitDiags, root)
+  emitted := []string{}
+  for name, text := range pending {
+    if err := writeFile(name, text, nil); err != nil {
+      fmt.Fprintln(os.Stderr, err)
+      return 2
+    }
+    emitted = append(emitted, name)
+  }
+  if *manifest != "" {
+    manifestPath := *manifest
+    if !filepath.IsAbs(manifestPath) {
+      manifestPath = filepath.Join(root, manifestPath)
+    }
+    data, err := json.Marshal(emitted)
+    if err != nil {
+      fmt.Fprintln(os.Stderr, err)
+      return 2
+    }
+    if err := writeFile(manifestPath, string(data), nil); err != nil {
+      fmt.Fprintln(os.Stderr, err)
+      return 2
+    }
   }
   return 0
 }
@@ -93,7 +121,15 @@ func replaceBeforeLiteral(ec *shimprinter.EmitContext, sf *shimast.SourceFile) *
       return node
     }
     if node.Kind == shimast.KindStringLiteral && node.Text() == "before" {
-      return ec.Factory.NewStringLiteral("GO DRIVER EMIT PLUGIN", 0)
+      f := ec.Factory
+      standalone := shimast.NewNodeFactory(shimast.NodeFactoryHooks{})
+      access := standalone.NewPropertyAccessExpression(f.NewIdentifier("input"), nil, standalone.NewIdentifier("value"), shimast.NodeFlagsNone)
+      parameter := f.NewParameterDeclaration(nil, nil, f.NewIdentifier("input"), nil, nil, nil)
+      arrow := f.NewArrowFunction(nil, nil, f.NewNodeList([]*shimast.Node{parameter}), nil, nil, f.NewToken(shimast.KindEqualsGreaterThanToken), access)
+      argument := f.NewObjectLiteralExpression(f.NewNodeList([]*shimast.Node{
+        f.NewPropertyAssignment(nil, f.NewIdentifier("value"), nil, nil, f.NewStringLiteral("GO DRIVER EMIT PLUGIN", 0)),
+      }), false)
+      return f.NewCallExpression(f.NewParenthesizedExpression(arrow), nil, nil, f.NewNodeList([]*shimast.Node{argument}), shimast.NodeFlagsNone)
     }
     return visitor.VisitEachChild(node)
   }

--- a/tests/projects/go-driver-emit-plugin/tsconfig.json
+++ b/tests/projects/go-driver-emit-plugin/tsconfig.json
@@ -6,6 +6,7 @@
     "outDir": "dist",
     "rootDir": "src",
     "declaration": true,
+    "noEmitOnError": true,
     "declarationMap": true,
     "sourceMap": true,
     "plugins": [

--- a/tests/test-ttsc/src/native-plugins/corpus-misc/test_plugin_corpus_driver_emit_error_rejects_publication.ts
+++ b/tests/test-ttsc/src/native-plugins/corpus-misc/test_plugin_corpus_driver_emit_error_rejects_publication.ts
@@ -1,0 +1,52 @@
+import { TestProject } from "@ttsc/testing";
+
+import {
+  assert,
+  copyProject,
+  fs,
+  goPath,
+  path,
+  spawn,
+  ttscBin,
+} from "../../internal/plugin-corpus";
+
+/**
+ * Verifies a native host checking only Go errors rejects declaration failure.
+ *
+ * Legacy native hosts print emit diagnostics and publish pending outputs after
+ * a nil Go error. TS4094 must now stop that path, including manifest
+ * publication, with the host name, phase, severity and compiler code in the
+ * error.
+ *
+ * 1. Copy the driver emit fixture and introduce a declaration-only error.
+ * 2. Run the real ttsc source-plugin build with noEmitOnError on and off.
+ * 3. Assert failure status, useful diagnostics and no output directory or
+ *    manifest.
+ */
+export const test_plugin_corpus_driver_emit_error_rejects_publication = () => {
+  const cacheDir = TestProject.tmpdir("ttsc-driver-emit-error-cache-");
+  for (const noEmitOnError of [false, true]) {
+    const root = copyProject("go-driver-emit-plugin");
+    const configPath = path.join(root, "tsconfig.json");
+    const config = JSON.parse(fs.readFileSync(configPath, "utf8"));
+    config.compilerOptions.noEmitOnError = noEmitOnError;
+    fs.writeFileSync(configPath, JSON.stringify(config));
+    fs.writeFileSync(
+      path.join(root, "src", "main.ts"),
+      "export const value = class { private hidden = 1; };\n",
+    );
+    const manifest = path.join(root, "manifest.json");
+    const result = spawn(ttscBin, ["--cwd", root, "--emit"], {
+      cwd: root,
+      env: { PATH: goPath(), TTSC_CACHE_DIR: cacheDir },
+    });
+    assert.notEqual(result.status, 0, result.stdout + result.stderr);
+    assert.match(result.stderr, /go-driver-emit-plugin: emit failed/);
+    assert.match(result.stderr, /native plugin .* failed/);
+    assert.match(result.stderr, /error/);
+    assert.match(result.stderr, /TS4094/);
+    assert.match(result.stderr, /declaration output is incomplete or skipped/);
+    assert.equal(fs.existsSync(path.join(root, "dist")), false);
+    assert.equal(fs.existsSync(manifest), false);
+  }
+};

--- a/tests/test-ttsc/src/native-plugins/corpus-misc/test_plugin_corpus_driver_emit_transform_preserves_declaration_outputs.ts
+++ b/tests/test-ttsc/src/native-plugins/corpus-misc/test_plugin_corpus_driver_emit_transform_preserves_declaration_outputs.ts
@@ -20,7 +20,8 @@ import {
  * the cost of dropping declaration artifacts.
  *
  * 1. Copy the `go-driver-emit-plugin` fixture, which enables declaration,
- *    declarationMap, and sourceMap.
+ *    declarationMap, sourceMap, and noEmitOnError. Its transform creates a
+ *    standalone-factory member access inside a generated arrow.
  * 2. Run `ttsc --emit` so the source plugin is built and executes its own
  *    driver.EmitWithPluginTransformers build.
  * 3. Assert `.js`, `.js.map`, `.d.ts`, and `.d.ts.map` all exist, the JS is
@@ -52,9 +53,25 @@ export const test_plugin_corpus_driver_emit_transform_preserves_declaration_outp
       assert.ok(fs.existsSync(path.join(root, rel)), `${rel} was not emitted`);
     }
 
+    const manifest: string[] = JSON.parse(
+      fs.readFileSync(path.join(root, "manifest.json"), "utf8"),
+    );
+    assert.ok(manifest.some((file) => file.endsWith("main.d.ts")));
+
     const js = fs.readFileSync(path.join(root, "dist", "main.js"), "utf8");
     assert.match(js, /GO DRIVER EMIT PLUGIN/);
+    assert.match(js, /input => input\.value/);
     assert.match(js, /\/\/# sourceMappingURL=main\.js\.map/);
+
+    const executed = spawn(
+      process.execPath,
+      [path.join(root, "dist", "main.js")],
+      {
+        cwd: root,
+      },
+    );
+    assert.equal(executed.status, 0, executed.stderr);
+    assert.equal(executed.stdout.trim(), "GO DRIVER EMIT PLUGIN");
 
     const dts = fs.readFileSync(path.join(root, "dist", "main.d.ts"), "utf8");
     assert.match(dts, /export interface Payload/);

--- a/website/src/content/docs/development/reference/driver-api.mdx
+++ b/website/src/content/docs/development/reference/driver-api.mdx
@@ -51,6 +51,16 @@ text := shimprinter.EmitSourceFile(printer, file)
 | `EmitFile(...)` | You only need one file's emit (rarely used outside the utility host). |
 | `DefaultWriteFile` | The default `WriteFileFunc`. Writes through the program's FS. Pass to `EmitAll` when you don't need interception. |
 
+### Native plugin emission
+
+Use `EmitWithPluginTransformer`, `EmitWithPluginTransformers`, or `EmitLinkedTransforms` when your native host transforms ASTs in the compiler's emit context. Build generated nodes with `ec.Factory` and use `ec.SetOriginal` when rebuilding an authored node. The constant resolver only accepts member accesses present in the program before the emit transforms run. Standalone-factory accesses remain generated expressions even if they lack synthesized flags or copy a source range; genuine original links still allow const-enum inlining.
+
+Compiler errors from these methods return both the diagnostic slice and a `*driver.PluginEmitError`. Check the Go error before publishing pending files, a manifest, or a successful build result. Its message includes the native plugin emit phase, compiler codes and severity, available source context, and an incomplete-output summary. Hosts may use `errors.As` to read its `Diagnostics`, `Phase`, and `Declarations` fields. When printing the error, do not print the same diagnostic slice again.
+
+With `noEmitOnError`, the driver checks before JavaScript emission and holds JavaScript, maps, declarations and build information until compilation succeeds. A compiler error invokes no output callbacks. Without that option, TypeScript's emit-despite-errors policy remains, but an emit error still returns a failing Go error. A filesystem or callback failure can leave files already written; report failure and withhold the success manifest. `noEmit` delegates to the upstream emitter, including its incremental build-information policy, without running JavaScript transforms.
+
+`WritePrettyDiagnostics` retains codes and severity when an emit diagnostic has no authored location. A diagnostic from a generated node uses a location-free message instead of a fabricated source line or snippet. Explicit warning diagnostics do not count as errors, including plain diagnostic values without compiler or lint objects.
+
 For the `transform` subcommand, the host treats `typescript[fileName]` as opaque text. See [Plugin protocol → Transform](/docs/development/concepts/protocol#transform). Run a printer before placing AST-mutated source in the map.
 
 ### Emit-concurrency contract


### PR DESCRIPTION
Native plugin emission can send standalone-factory member accesses to the original checker, produce TS2304 after valid source checking, and withhold declarations while returning a nil Go error. Existing hosts can consequently publish JavaScript and report a successful incomplete build.

This draft owns the complete accepted scope of #1364 in one solo campaign: original-node ownership, complete declaration output, emit error propagation and output withholding, diagnostic code/severity/context, and positive/negative/boundary regressions. No accepted work is deferred. Implementation and verification are pending; ordinary CI remains enabled.

Pre-implementation evidence: the issue's independent Go reproduction fails with TS2304, nil error and no declarations; source/declaration probes confirm premature JS publication under noEmitOnError; the rich diagnostic writer panics on the generated node's negative location. Two complete scope-limited discovery rounds finished, with the second adding no meaningful candidate. Exact implementation validation and Individual/Overall Self-Review rounds will be recorded as formal COMMENT reviews.
